### PR TITLE
fix(tagging):  Add missing stackTags to ui and ui-infra serverless.ym…

### DIFF
--- a/src/services/ui-infra/serverless.yml
+++ b/src/services/ui-infra/serverless.yml
@@ -23,6 +23,9 @@ custom:
   project: ${env:PROJECT}
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
+  stackTags:
+    PROJECT: ${self:custom.project}
+    SERVICE: ${self:service}
   serverlessTerminationProtection:
     stages:
       - master

--- a/src/services/ui/serverless.yml
+++ b/src/services/ui/serverless.yml
@@ -18,6 +18,9 @@ custom:
   project: ${env:PROJECT}
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
+  stackTags:
+    PROJECT: ${self:custom.project}
+    SERVICE: ${self:service}
   serverlessTerminationProtection:
     stages:
       - master


### PR DESCRIPTION
## Purpose

Add missing Cloudformation stack tags for ui and ui-infra services.

#### Linked Issues to Close

None.

## Approach

I noticed two of the services were not being destroyed.  They weren't failing to destroy, they were simply not getting called to be destroyed.  This led me to find that they were not getting our normal stackTags, which meant our utilities couldn't find the stacks.

## Assorted Notes/Considerations/Learning

We should merge this and then identify and delete any orphaned stacks out there.
