### PR TITLE
fix(ui-s3): update ui-infra s3 bucket permissions

### DIFF
--- a/src/services/ui-infra/serverless.yml
+++ b/src/services/ui-infra/serverless.yml
@@ -121,6 +121,10 @@ resources:
           ServerSideEncryptionConfiguration:
             - ServerSideEncryptionByDefault:
                 SSEAlgorithm: "AES256"
+        AccessControl: LogDeliveryWrite
+        OwnershipControls:
+          Rules:
+            - ObjectOwnership: BucketOwnerPreferred
       DeletionPolicy: Delete
     LoggingBucketPolicy:
       Type: "AWS::S3::BucketPolicy"


### PR DESCRIPTION
## Purpose

Resolved issue with s3 logging bucket permissions in ui-infra service. 

see: 
https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-ownershipcontrolsrule.html

https://qmacbis.atlassian.net/browse/OY2-24109