### PR TITLE
feat(rightsize os):  Rightsize the clusters to m5 large's for higher envs

### DIFF
--- a/src/services/data/serverless.yml
+++ b/src/services/data/serverless.yml
@@ -129,6 +129,16 @@ stepFunctions:
           SuccessState:
             Type: Succeed
 
+params:
+  master:
+    osInstanceType: m5.large.search
+  val:
+    osInstanceType: m5.large.search
+  production:
+    osInstanceType: m5.large.search
+  default:
+    osInstanceType: t3.small.search
+
 functions:
   sinkSeatool:
     handler: handlers/sink.seatool
@@ -360,7 +370,7 @@ resources:
           VolumeType: gp2
           VolumeSize: 10
         ClusterConfig:
-          InstanceType: t3.small.search
+          InstanceType: ${param:osInstanceType}
           InstanceCount: 3
           DedicatedMasterEnabled: false
           ZoneAwarenessEnabled: true


### PR DESCRIPTION
## Purpose

Rightsize master, val, and production environments to run m5.large.search instances

#### Linked Issues to Close

Closes https://qmacbis.atlassian.net/browse/OY2-24836

## Approach

standard stage param pattern

## Assorted Notes/Considerations/Learning

none