### PR TITLE
feat(indexer speed):  Speed up the indexer by using batches

### DIFF
--- a/src/libs/opensearch-lib.ts
+++ b/src/libs/opensearch-lib.ts
@@ -36,6 +36,24 @@ export async function updateData(host:string, indexObject:any) {
   console.log(response.body);
 }
 
+export async function bulkUpdateData(host:string, arrayOfDocuments:any) {
+  client = client || (await getClient(host));
+  var response = await client.helpers.bulk({
+    datasource: arrayOfDocuments,
+    onDocument (doc:any) {
+      // The update operation always requires a tuple to be returned, with the
+      // first element being the action and the second being the update options.
+      return [
+        {
+          update: { _index: 'main', _id: doc.id }
+        },
+        { doc_as_upsert: true }
+      ]
+    }
+  });
+  console.log(response);
+}
+
 export async function deleteIndex(host:string, index:string) {
   client = client || (await getClient(host));
   var response = await client.indices.delete({index});

--- a/src/services/data/handlers/sink.ts
+++ b/src/services/data/handlers/sink.ts
@@ -68,6 +68,7 @@ function getLeadAnalyst(eventData) {
 
 export const seatool: Handler = async (event) => {
   const records: Record<string, unknown>[] = [];
+  const docObject: any = {};
   for (const key in event.records) {
     event.records[key].forEach(
       ({ key, value }: { key: string; value: string }) => {
@@ -82,7 +83,6 @@ export const seatool: Handler = async (event) => {
           const rai_received_date = record?.["RAI"]
             ? sortAndExtractReceivedDate(record?.["RAI"])
             : null;
-          console.log(planTypeId);
           switch (planTypeId) {
           case 124:
           case 125:
@@ -127,28 +127,18 @@ export const seatool: Handler = async (event) => {
             break;
           }
           if (Object.keys(eventData).length) {
-            records.push({
-              key: id,
-              value: eventData,
-            });
+            docObject[id] = eventData;
           }
         }
       }
     );
   }
-  console.log(records);
-  console.log("yepyep");
+  for (const [, b] of Object.entries(docObject)) {
+    const c: Record<any, any> = b; // Idk it wouldn't let me just push b... type thing.
+    records.push(c);
+  }
   try {
-    for (const item of records) {
-      await os.updateData(osDomain, {
-        index,
-        id: item.key,
-        body: {
-          doc: item.value,
-          doc_as_upsert: true,
-        },
-      });
-    }
+    await os.bulkUpdateData(osDomain, records);
   } catch (error) {
     console.error(error);
   }
@@ -156,6 +146,7 @@ export const seatool: Handler = async (event) => {
 
 export const onemac: Handler = async (event) => {
   const records: Record<string, unknown>[] = [];
+  const docObject: any = {};
   for (const key in event.records) {
     event.records[key].forEach(
       ({ key, value }: { key: string; value: string }) => {
@@ -170,6 +161,7 @@ export const onemac: Handler = async (event) => {
             console.log("Not a package type - ignoring");
             return;
           }
+          eventData.id = id;
           eventData.attachments = record.attachments || null;
           if (record.attachments && Array.isArray(record.attachments)) {
             eventData.attachments = record.attachments.map((attachment) => {
@@ -190,26 +182,18 @@ export const onemac: Handler = async (event) => {
           eventData.submitterEmail = record.submitterEmail || null;
           eventData.submissionOrigin = "OneMAC";
           if (Object.keys(eventData).length) {
-            records.push({
-              key: id,
-              value: eventData,
-            });
+            docObject[id] = eventData;
           }
         }
       }
     );
   }
+  for (const [, b] of Object.entries(docObject)) {
+    const c: Record<any, any> = b; // Idk it wouldn't let me just push b... type thing.
+    records.push(c);
+  }
   try {
-    for (const item of records) {
-      await os.updateData(osDomain, {
-        index,
-        id: item.key,
-        body: {
-          doc: item.value,
-          doc_as_upsert: true,
-        },
-      });
-    }
+    await os.bulkUpdateData(osDomain, records);
   } catch (error) {
     console.error(error);
   }

--- a/src/services/data/serverless.yml
+++ b/src/services/data/serverless.yml
@@ -240,7 +240,7 @@ resources:
     SinkSeatoolTrigger:
       Type: AWS::Lambda::EventSourceMapping
       Properties:
-        BatchSize: 100
+        BatchSize: 1000
         Enabled: true
         FunctionName: !GetAtt SinkSeatoolLambdaFunction.Arn
         SelfManagedEventSource:
@@ -264,7 +264,7 @@ resources:
     SinkOnemacTrigger:
       Type: AWS::Lambda::EventSourceMapping
       Properties:
-        BatchSize: 100
+        BatchSize: 1000
         Enabled: true
         FunctionName: !GetAtt SinkOnemacLambdaFunction.Arn
         SelfManagedEventSource:


### PR DESCRIPTION
## Purpose

This changeset speeds up the sink index functions by batching requests to OpenSearch.  Each is completing roughly 10x faster.

#### Linked Issues to Close

None

## Approach

The lambda event batch is now set to 1000, from 100.
An object with the id as key and eventData as value is created from the event.
Stepping through the event and setting object[id]=value ensures that newer events for the same key overwrite older events.
We then transform the object into an array, and call a batchUpdateData helper function.

## Assorted Notes/Considerations/Learning

None