### PR TITLE
feal(subtype): Add subtype labels and qa fixes

### DIFF
--- a/src/packages/shared-types/onemac.ts
+++ b/src/packages/shared-types/onemac.ts
@@ -66,7 +66,7 @@ export const transformOnemac = (id: string) => {
     additionalInformation: data.additionalInformation,
     submitterEmail: data.submitterEmail,
     submitterName: data.submitterName,
-    origin: "OneMAC",
+    origin: "oneMAC",
   }));
 };
 

--- a/src/services/ui/src/components/Opensearch/utils.ts
+++ b/src/services/ui/src/components/Opensearch/utils.ts
@@ -25,6 +25,9 @@ const filterMapQueryReducer = (
   }
 
   if (filter.type === "global_search") {
+    const query = [`(${filter.value})`, `(*${filter.value}*)`]
+      .flatMap((s) => [s, s.toUpperCase(), s.toLocaleLowerCase()])
+      .join(" OR ");
     if (filter.value) {
       state[filter.prefix].push({
         query_string: {
@@ -33,7 +36,7 @@ const filterMapQueryReducer = (
             "submitterName.keyword",
             "leadAnalyst.keyword",
           ],
-          query: `(${filter.value}) OR (*${filter.value}*)`,
+          query,
         },
       });
     }

--- a/src/services/ui/src/components/PackageDetails/ChipSpaPackageDetails.tsx
+++ b/src/services/ui/src/components/PackageDetails/ChipSpaPackageDetails.tsx
@@ -1,6 +1,7 @@
 import { format } from "date-fns";
 import { OsMainSourceItem } from "shared-types";
 import { removeUnderscoresAndCapitalize } from "@/utils";
+import { LABELS } from "@/lib";
 
 export const ChipSpaPackageDetails = (data: OsMainSourceItem) => {
   if (!data) return null;
@@ -18,8 +19,10 @@ export const ChipSpaPackageDetails = (data: OsMainSourceItem) => {
       value: removeUnderscoresAndCapitalize(data.planType),
     },
     {
-      label: "Sub-Type",
-      value: data.actionType || "N/A",
+      label: "Sub Type",
+      value: data.actionType
+        ? LABELS[data.actionType as keyof typeof LABELS]
+        : "N/A",
     },
     {
       label: "Initial Submission Date",

--- a/src/services/ui/src/components/PackageDetails/ChipSpaPackageDetails.tsx
+++ b/src/services/ui/src/components/PackageDetails/ChipSpaPackageDetails.tsx
@@ -21,7 +21,7 @@ export const ChipSpaPackageDetails = (data: OsMainSourceItem) => {
     {
       label: "Sub Type",
       value: data.actionType
-        ? LABELS[data.actionType as keyof typeof LABELS]
+        ? LABELS[data.actionType as keyof typeof LABELS] || data.actionType
         : "N/A",
     },
     {

--- a/src/services/ui/src/components/Pagination/index.tsx
+++ b/src/services/ui/src/components/Pagination/index.tsx
@@ -24,7 +24,7 @@ export const Pagination: FC<Props> = (props) => {
       <div className="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between">
         <div className="flex gap-6">
           <p className="flex gap-2 text-sm text-gray-700">
-            items per page:
+            Records per page:
             <select
               className="font-bold cursor-pointer border-[1px] mt-[-1px]"
               value={props.pageSize}
@@ -40,7 +40,7 @@ export const Pagination: FC<Props> = (props) => {
             <span className="font-bold">{state.upperBoundValue}</span>
             of
             <span className="font-bold">{props.count}</span>
-            items
+            records
           </p>
         </div>
         <div>

--- a/src/services/ui/src/components/SubmissionInfo/index.tsx
+++ b/src/services/ui/src/components/SubmissionInfo/index.tsx
@@ -7,7 +7,7 @@ export const SubmissionInfo = (data: OsMainSourceItem) => {
   }
   const submissionDetails = [
     {
-      label: "Submitter",
+      label: "Submitted By",
       value: <p className="text-lg">{data.submitterName || "None"}</p>,
     },
     {

--- a/src/services/ui/src/index.css
+++ b/src/services/ui/src/index.css
@@ -33,3 +33,20 @@
   .usa-banner__inner {
     max-width: 80rem;
   }
+
+  .usa-footer__primary-section div:first-child {
+    max-width: 80rem;
+    margin:auto
+  }
+
+  .usa-footer__secondary-section div:first-child {
+    max-width: 80rem;
+    margin:auto;
+  }
+
+  @media (min-width: 1350px) {
+    .usa-footer__secondary-section div:first-child {
+      padding-left: 2.5rem;
+      padding-right: 2.5rem;
+    }
+  }

--- a/src/services/ui/src/lib/index.tsx
+++ b/src/services/ui/src/lib/index.tsx
@@ -1,0 +1,3 @@
+export * from "./TestWrapper";
+export * from "./labels";
+export * from "./utils";

--- a/src/services/ui/src/lib/labels.ts
+++ b/src/services/ui/src/lib/labels.ts
@@ -1,0 +1,5 @@
+export const LABELS = {
+  New: "Initial",
+  Amend: "Amendment",
+  Renew: "Renewal",
+} as const;

--- a/src/services/ui/src/pages/dashboard/Lists/spas/consts.tsx
+++ b/src/services/ui/src/pages/dashboard/Lists/spas/consts.tsx
@@ -1,6 +1,5 @@
 import { Link } from "react-router-dom";
 import { format } from "date-fns";
-
 import { removeUnderscoresAndCapitalize } from "@/utils";
 import { getStatus } from "../statusHelper";
 import { OsTableColumn } from "@/components/Opensearch/Table/types";
@@ -31,7 +30,7 @@ export const TABLE_COLUMNS = (props?: { isCms?: boolean }): OsTableColumn[] => [
   },
   {
     field: "planType.keyword",
-    label: "Plan Type",
+    label: "Type",
     cell: (data) => removeUnderscoresAndCapitalize(data.planType),
   },
   {

--- a/src/services/ui/src/pages/dashboard/Lists/spas/consts.tsx
+++ b/src/services/ui/src/pages/dashboard/Lists/spas/consts.tsx
@@ -68,4 +68,9 @@ export const TABLE_COLUMNS = (props?: { isCms?: boolean }): OsTableColumn[] => [
     label: "Submitted By",
     cell: (data) => data.submitterName,
   },
+  {
+    field: "leadAnalystName.keyword",
+    label: "CPOC",
+    cell: (data) => data.leadAnalystName,
+  },
 ];

--- a/src/services/ui/src/pages/dashboard/Lists/waivers/consts.tsx
+++ b/src/services/ui/src/pages/dashboard/Lists/waivers/consts.tsx
@@ -39,7 +39,9 @@ export const TABLE_COLUMNS = (props?: { isCms?: boolean }): OsTableColumn[] => [
     field: "actionType.keyword",
     label: "Sub Type",
     cell: (data) =>
-      data.actionType ? LABELS[data.actionType as keyof typeof LABELS] : "",
+      data.actionType
+        ? LABELS[data.actionType as keyof typeof LABELS] || data.actionType
+        : "",
   },
   {
     field: "status.keyword",

--- a/src/services/ui/src/pages/dashboard/Lists/waivers/consts.tsx
+++ b/src/services/ui/src/pages/dashboard/Lists/waivers/consts.tsx
@@ -4,6 +4,7 @@ import { format } from "date-fns";
 import { removeUnderscoresAndCapitalize } from "@/utils";
 import { getStatus } from "../statusHelper";
 import { OsTableColumn } from "@/components/Opensearch/Table/types";
+import { LABELS } from "@/lib";
 
 export const TABLE_COLUMNS = (props?: { isCms?: boolean }): OsTableColumn[] => [
   {
@@ -31,8 +32,14 @@ export const TABLE_COLUMNS = (props?: { isCms?: boolean }): OsTableColumn[] => [
   },
   {
     field: "planType.keyword",
-    label: "Plan Type",
+    label: "Type",
     cell: (data) => removeUnderscoresAndCapitalize(data.planType),
+  },
+  {
+    field: "actionType.keyword",
+    label: "Sub Type",
+    cell: (data) =>
+      data.actionType ? LABELS[data.actionType as keyof typeof LABELS] : "",
   },
   {
     field: "status.keyword",

--- a/src/services/ui/src/pages/dashboard/Lists/waivers/consts.tsx
+++ b/src/services/ui/src/pages/dashboard/Lists/waivers/consts.tsx
@@ -9,7 +9,7 @@ export const TABLE_COLUMNS = (props?: { isCms?: boolean }): OsTableColumn[] => [
   {
     props: { className: "w-[150px]" },
     field: "id.keyword",
-    label: "Waiver ID",
+    label: "Waiver Number",
     cell: (data) => {
       if (!data.authority) return <></>;
       return (
@@ -67,5 +67,10 @@ export const TABLE_COLUMNS = (props?: { isCms?: boolean }): OsTableColumn[] => [
     field: "submitterName.keyword",
     label: "Submitted By",
     cell: (data) => data.submitterName,
+  },
+  {
+    field: "leadAnalystName.keyword",
+    label: "CPOC",
+    cell: (data) => data.leadAnalystName,
   },
 ];


### PR DESCRIPTION
## Purpose

few things here:

- add LABELS map
- add sub type column on dahsboard and details page
- change items to Records in pagination
- hacked alignment of footer
- include the CPOC name column to the dashboard
- Waiver Number instead of Waiver ID
- origin should be oneMAC not OneMAC
- Submitted By instead of Submitter on package details
