### PR TITLE
fix(dependency issue):  Add an implicit dependency between the metric…

### DIFF
--- a/src/services/data/serverless.yml
+++ b/src/services/data/serverless.yml
@@ -348,7 +348,7 @@ resources:
     SeatoolLogMessageMetricFilter:
       Type: "AWS::Logs::MetricFilter"
       Properties:
-        LogGroupName: /aws/lambda/${self:service}-${sls:stage}-sinkSeatool
+        LogGroupName: !Ref SinkSeatoolLogGroup
         FilterPattern: '"SEATOOL Validation Error"'
         MetricTransformations:
           - MetricName: SeatoolValidationErrors
@@ -373,7 +373,7 @@ resources:
     OnemacLogMessageMetricFilter:
       Type: "AWS::Logs::MetricFilter"
       Properties:
-        LogGroupName: /aws/lambda/${self:service}-${sls:stage}-sinkOnemac
+        LogGroupName: !Ref SinkOnemacLogGroup
         FilterPattern: '"ONEMAC Validation Error"'
         MetricTransformations:
           - MetricName: ONEMACValidationErrors


### PR DESCRIPTION
## Purpose

This changeset adds an implicit dependency between the new metric stream filters and their underlying log groups.  Without this change, we would have new environments fail to deploy if the log group didn't get built before the stream filter.

#### Linked Issues to Close

Minor fix against https://qmacbis.atlassian.net/browse/OY2-24758

## Approach

Lookup the log group name with a !Ref... this sets the dependency and order correctly.

## Assorted Notes/Considerations/Learning

None