### PR TITLE
fix(dependency issue):  Add implicit dependency in api service between metric filters and log groups

### DIFF
--- a/src/services/api/serverless.yml
+++ b/src/services/api/serverless.yml
@@ -127,7 +127,7 @@ resources:
     ApiGateway400ErrorCount:
       Type: AWS::Logs::MetricFilter
       Properties:
-        LogGroupName: !Sub /aws/api-gateway/${self:service}-${sls:stage}
+        LogGroupName: !Ref ApiGatewayLogGroup
         FilterName: ApiGateway400ErrorCount
         FilterPattern: '[ip, user, timestamp, request, status = 4*]'
         MetricTransformations:
@@ -154,7 +154,7 @@ resources:
     ApiGateway500ErrorCount:
       Type: AWS::Logs::MetricFilter
       Properties:
-        LogGroupName: !Sub /aws/api-gateway/${self:service}-${sls:stage}
+        LogGroupName: !Ref ApiGatewayLogGroup
         FilterName: ApiGateway500ErrorCount
         FilterPattern: '[ip, user, timestamp, request, status = 5*]'
         MetricTransformations:
@@ -199,7 +199,7 @@ resources:
     LambdaLogMessageMetricFilter:
       Type: "AWS::Logs::MetricFilter"
       Properties:
-        LogGroupName: /aws/lambda/${self:service}-${sls:stage}-search
+        LogGroupName: !Ref SearchLogGroup
         FilterPattern: "ERROR"
         MetricTransformations:
           - MetricName: LambdaErrorCount


### PR DESCRIPTION
## Purpose

Exact same type of issue and fix as https://github.com/Enterprise-CMCS/macpro-mako/pull/109 but in the api service.

