### PR TITLE
fix(workspace setup):  Fix and re-enable our CI around workspace setup

### DIFF
--- a/.github/workflows/workspace-setup.yml
+++ b/.github/workflows/workspace-setup.yml
@@ -19,7 +19,6 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - run: breakkkkkkk
       - name: Checkout
         uses: actions/checkout@v3
 


### PR DESCRIPTION
## Purpose

This changeset fixes our previously faliing workflow for testing workspace setup.  The workflow has been re-enabled.

#### Linked Issues to Close

None

## Approach

Two changes were made:
- the timeout limit was increased due to the time it takes to build a stage
- the e2e tests were commented out as the block that does the running is out of date.  e2e tests will very shortly be re-enabled, and this will be updated and uncommented.

## Assorted Notes/Considerations/Learning

None