### PR TITLE
fix(idm deploy bug):  Fix issue when deploying non-IDM backed environemnts

### DIFF
--- a/src/services/auth/serverless.yml
+++ b/src/services/auth/serverless.yml
@@ -191,9 +191,9 @@ resources:
         IdpIdentifiers:
           - IdpIdentifier
         ProviderDetails:
-          client_id: ${self:custom.idmInfo.oidc_client_id}
-          client_secret: ${self:custom.idmInfo.oidc_client_secret}
-          oidc_issuer: ${self:custom.idmInfo.oidc_issuer}
+          client_id: ${self:custom.idmInfo.oidc_client_id, ""}
+          client_secret: ${self:custom.idmInfo.oidc_client_secret, ""}
+          oidc_issuer: ${self:custom.idmInfo.oidc_issuer, ""}
           attributes_request_method: GET
           authorize_scopes: "email openid profile phone"
         ProviderName: IDM


### PR DESCRIPTION
## Purpose

This fixes a bug whereby ephemeral branches would not deploy.

#### Linked Issues to Close

Bug against https://qmacbis.atlassian.net/browse/OY2-24473

## Approach

In the case of an ephemeral branch where IDM is not in play, there are a few variables for which we don't have values but we need defaults to accomodate serverless' resolution.  For these, blank string defaults were added.
Also, the cognito lambda config trigger was wrapped in a conditional; the conditional's absence wouldn't block deployment, but it would cause silent failures within the lambda.

## Assorted Notes/Considerations/Learning

None