### PR TITLE
fix(dev costs):  Run 1 node OS clusters in dev environments

### DIFF
--- a/src/services/data/serverless.yml
+++ b/src/services/data/serverless.yml
@@ -587,7 +587,7 @@ resources:
           SubnetIds:
             Fn::If:
               - isDev
-              - - ${self:custom.vpc.privateSubnets[0]}
+              - - ${self:custom.vpc.privateSubnets.0}
               - >-
                 ${self:custom.vpc.privateSubnets}
 


### PR DESCRIPTION
## Purpose

This changeset makes it so ephemeral/dev branches deploy opensearch clusters that are 67% cheaper.

#### Linked Issues to Close

None

## Approach

When not master, val, or production, opensearch is deployed as a single node domain.  We aren't concerned with performance impacts, and think the reduction in dev cost is worth the additional conditions in our serverless yaml file.

## Assorted Notes/Considerations/Learning

This will cause a security hub finding, as keeping data replicated across multiple nodes is a good practice.  However, the issue is not a concern in development, and findings will not exist in val or production.  The production env is what must have no findings to pass audit.  