### PR TITLE
fix(webforms): Spacing, font size, and border

### DIFF
--- a/src/services/ui/src/components/RHF/Document.tsx
+++ b/src/services/ui/src/components/RHF/Document.tsx
@@ -11,7 +11,7 @@ export const RHFDocument = <TFieldValues extends FieldValues>(props: {
   return (
     <div className="py-4">
       <div className="mb-5">
-        <FormLabel className="font-bold text-3xl px-6 font-serif">
+        <FormLabel className="font-bold text-4xl px-8 font-serif">
           {props.document.header}
         </FormLabel>
       </div>

--- a/src/services/ui/src/components/RHF/Document.tsx
+++ b/src/services/ui/src/components/RHF/Document.tsx
@@ -9,19 +9,22 @@ export const RHFDocument = <TFieldValues extends FieldValues>(props: {
   control: Control<TFieldValues>;
 }) => {
   return (
-    <div className="py-4">
-      <div className="mb-5">
-        <FormLabel className="font-bold text-4xl px-8 font-serif">
-          {props.document.header}
-        </FormLabel>
+    <div>
+      <div className="h-[5px] bg-gradient-to-r from-primary from-50% to-[#02bfe7] to-[66%] rounded-t"></div>
+      <div className="py-4 px-8 border-2 border-t-0 mt-0">
+        <div className="my-5">
+          <FormLabel className="font-bold text-4xl px-8 font-serif">
+            {props.document.header}
+          </FormLabel>
+        </div>
+        {props.document.sections.map((SEC, index) => (
+          <RHFSection
+            key={`rhf-section-${index}-${SEC.title}`}
+            control={props.control}
+            section={SEC}
+          />
+        ))}
       </div>
-      {props.document.sections.map((SEC, index) => (
-        <RHFSection
-          key={`rhf-section-${index}-${SEC.title}`}
-          control={props.control}
-          section={SEC}
-        />
-      ))}
     </div>
   );
 };

--- a/src/services/ui/src/components/RHF/FormGroup.tsx
+++ b/src/services/ui/src/components/RHF/FormGroup.tsx
@@ -11,7 +11,7 @@ export const RHFFormGroup = <TFieldValues extends FieldValues>(props: {
 }) => {
   return (
     <DependencyWrapper {...props.form}>
-      <div className="py-4 px-6">
+      <div className="py-4">
         {props.form.description && (
           <div className="mb-2">
             <FormLabel className="font-bold">

--- a/src/services/ui/src/components/RHF/Section.tsx
+++ b/src/services/ui/src/components/RHF/Section.tsx
@@ -13,17 +13,21 @@ export const RHFSection = <TFieldValues extends FieldValues>(props: {
     <DependencyWrapper {...props.section}>
       <div className="py-4">
         {props.section.title && (
-          <div className="bg-primary py-4 px-6 w-full text-white">
-            <FormLabel className="text-2xl">{props.section.title}</FormLabel>
+          <div className="bg-primary py-4 px-8 w-full text-white">
+            <FormLabel className="text-2xl font-semibold">
+              {props.section.title}
+            </FormLabel>
           </div>
         )}
-        {props.section.form.map((FORM, index) => (
-          <RHFFormGroup
-            key={`rhf-form-${index}-${FORM.description}`}
-            control={props.control}
-            form={FORM}
-          />
-        ))}
+        <div className="px-8">
+          {props.section.form.map((FORM, index) => (
+            <RHFFormGroup
+              key={`rhf-form-${index}-${FORM.description}`}
+              control={props.control}
+              form={FORM}
+            />
+          ))}
+        </div>
       </div>
     </DependencyWrapper>
   );

--- a/src/services/ui/src/pages/form/index.tsx
+++ b/src/services/ui/src/pages/form/index.tsx
@@ -48,7 +48,7 @@ export function ExampleForm() {
   });
 
   return (
-    <div className="max-w-screen-xl mx-auto p-4 lg:px-8">
+    <div className="max-w-screen-xl mx-auto p-4 py-8 lg:px-8">
       <Form {...form}>
         <form onSubmit={onSubmit} className="space-y-6">
           <RHFDocument document={ABP1} {...form} />


### PR DESCRIPTION
## Purpose

This ticket:
- adjusts the font size of the topmost header
- adjusts the spacing of child elements within checkbox lists and radio groups
- adds a border around the form with a gradient at the top
- adjusts overall spacing to better match the Figma designs.

Here is an example of the incorrect spacing with multiple layers of child elements:

![Screenshot 2023-10-20 at 11 55 12 AM](https://github.com/Enterprise-CMCS/macpro-mako/assets/2159852/c91817a9-dc94-487c-acb9-c92ba2c9a31e)

and how it looks after the adjustment:

![Screenshot 2023-10-23 at 2 32 34 PM](https://github.com/Enterprise-CMCS/macpro-mako/assets/2159852/d0be17ce-6e23-4c28-9432-df0360c094d1)

The branch can be viewed and tested here: https://d8nenw68wip9a.cloudfront.net/form