### PR TITLE
Finsoup

### DIFF
--- a/src/services/ui/src/components/RHF/FieldArray.tsx
+++ b/src/services/ui/src/components/RHF/FieldArray.tsx
@@ -42,10 +42,12 @@ export const RHFFieldArray = <TFields extends FieldValues>(
                 />
               );
             })}
-            <Trash2
-              className="self-end mb-4 cursor-pointer stroke-primary"
-              onClick={() => fieldArr.remove(index)}
-            />
+            {index >= 1 && (
+              <Trash2
+                className="self-end mb-4 cursor-pointer stroke-primary"
+                onClick={() => fieldArr.remove(index)}
+              />
+            )}
           </div>
         );
       })}

--- a/src/services/ui/src/components/RHF/FieldArray.tsx
+++ b/src/services/ui/src/components/RHF/FieldArray.tsx
@@ -4,6 +4,8 @@ import { Trash2 } from "lucide-react";
 import { RHFSlot } from "./Slot";
 import { Button, FormField } from "../Inputs";
 import { FieldArrayProps } from "./types";
+import { slotReducer } from "./utils";
+import { useEffect } from "react";
 
 export const RHFFieldArray = <TFields extends FieldValues>(
   props: FieldArrayProps<TFields>
@@ -11,16 +13,17 @@ export const RHFFieldArray = <TFields extends FieldValues>(
   const fieldArr = useFieldArray({
     control: props.control,
     name: props.name,
+    shouldUnregister: true,
   });
 
   const onAppend = () => {
-    fieldArr.append(
-      props.fields.reduce((ACC, S) => {
-        ACC[S.name] = "";
-        return ACC;
-      }, {} as any)
-    );
+    fieldArr.append(props.fields.reduce(slotReducer, {}) as any);
   };
+
+  useEffect(() => {
+    if (fieldArr.fields.length) return;
+    fieldArr.append(props.fields.reduce(slotReducer, {}) as any);
+  }, []);
 
   return (
     <div className="flex flex-col gap-4 w-max">
@@ -30,10 +33,10 @@ export const RHFFieldArray = <TFields extends FieldValues>(
             {props.fields.map((SLOT) => {
               return (
                 <FormField
-                  //   shouldUnregister
                   key={`${SLOT.name}-${index}`}
                   control={props.control}
                   name={`${props.name}.${index}.${SLOT.name}` as any}
+                  {...(SLOT.rules && { rules: SLOT.rules })}
                   render={RHFSlot({
                     ...SLOT,
                     control: props.control,

--- a/src/services/ui/src/components/RHF/FieldGroup.tsx
+++ b/src/services/ui/src/components/RHF/FieldGroup.tsx
@@ -4,6 +4,8 @@ import { Plus } from "lucide-react";
 import { RHFSlot } from "./Slot";
 import { Button, FormField } from "../Inputs";
 import { FieldGroupProps } from "./types";
+import { slotReducer } from "./utils";
+import { useEffect } from "react";
 
 export const FieldGroup = <TFields extends FieldValues>(
   props: FieldGroupProps<TFields>
@@ -14,13 +16,13 @@ export const FieldGroup = <TFields extends FieldValues>(
   });
 
   const onAppend = () => {
-    fieldArr.append(
-      props.fields.reduce((ACC, S) => {
-        ACC[S.name] = "";
-        return ACC;
-      }, {} as any)
-    );
+    fieldArr.append(props.fields.reduce(slotReducer, {}) as any);
   };
+
+  useEffect(() => {
+    if (fieldArr.fields.length) return;
+    fieldArr.append(props.fields.reduce(slotReducer, {}) as any);
+  }, []);
 
   return (
     <div className="flex flex-col gap-4 w-max">
@@ -30,10 +32,10 @@ export const FieldGroup = <TFields extends FieldValues>(
             {props.fields.map((SLOT) => {
               return (
                 <FormField
-                  //   shouldUnregister
                   key={`${SLOT.name}-${index}`}
                   control={props.control}
                   name={`${props.name}.${index}.${SLOT.name}` as any}
+                  {...(SLOT.rules && { rules: SLOT.rules })}
                   render={RHFSlot({
                     ...SLOT,
                     control: props.control,

--- a/src/services/ui/src/components/RHF/FieldGroup.tsx
+++ b/src/services/ui/src/components/RHF/FieldGroup.tsx
@@ -13,6 +13,7 @@ export const FieldGroup = <TFields extends FieldValues>(
   const fieldArr = useFieldArray({
     control: props.control,
     name: props.name,
+    shouldUnregister: true,
   });
 
   const onAppend = () => {

--- a/src/services/ui/src/components/RHF/FormGroup.tsx
+++ b/src/services/ui/src/components/RHF/FormGroup.tsx
@@ -20,17 +20,16 @@ export const RHFFormGroup = <TFieldValues extends FieldValues>(props: {
           </div>
         )}
         <div className={props.form.wrapperStyling}>
-          {props.form.slots.map((SLOT) => {
-            return (
-              <DependencyWrapper key={SLOT.name} {...SLOT}>
-                <FormField
-                  control={props.control}
-                  name={SLOT.name as any}
-                  render={RHFSlot({ ...SLOT, control: props.control })}
-                />
-              </DependencyWrapper>
-            );
-          })}
+          {props.form.slots.map((SLOT) => (
+            <DependencyWrapper key={SLOT.name} {...SLOT}>
+              <FormField
+                control={props.control}
+                name={SLOT.name as any}
+                {...(SLOT.rules && { rules: SLOT.rules })}
+                render={RHFSlot({ ...SLOT, control: props.control })}
+              />
+            </DependencyWrapper>
+          ))}
         </div>
       </div>
     </DependencyWrapper>

--- a/src/services/ui/src/components/RHF/Slot.tsx
+++ b/src/services/ui/src/components/RHF/Slot.tsx
@@ -118,14 +118,16 @@ export const RHFSlot = <
                           </div>
                           {field.value === OPT.value &&
                             OPT.form &&
-                            OPT.form.map((FORM: any, index: any) => (
-                              <div
-                                className="ml-[0.6rem] px-4 border-l-4 border-l-primary"
-                                key={`rhf-form-${index}-${FORM.description}`}
-                              >
-                                <RHFFormGroup form={FORM} control={control} />
-                              </div>
-                            ))}
+                            OPT.form.map((FORM: any, index: any) => {
+                              return (
+                                <div
+                                  className="ml-[0.6rem] px-4 border-l-4 border-l-primary"
+                                  key={`rhf-form-${index}-${FORM.description}`}
+                                >
+                                  <RHFFormGroup form={FORM} control={control} />
+                                </div>
+                              );
+                            })}
                           {field.value === OPT.value &&
                             OPT.slots &&
                             OPT.slots.map((SLOT: any, index: any) => (
@@ -136,7 +138,8 @@ export const RHFSlot = <
                                 <FormField
                                   control={control}
                                   name={SLOT.name}
-                                  render={RHFSlot(SLOT)}
+                                  {...(SLOT.rules && { rules: SLOT.rules })}
+                                  render={RHFSlot({ ...SLOT, control })}
                                 />
                               </div>
                             ))}
@@ -178,7 +181,8 @@ export const RHFSlot = <
                               <FormField
                                 control={control}
                                 name={SLOT.name}
-                                render={RHFSlot(SLOT)}
+                                {...(SLOT.rules && { rules: SLOT.rules })}
+                                render={RHFSlot({ ...SLOT, control })}
                               />
                             </div>
                           ))}

--- a/src/services/ui/src/components/RHF/index.ts
+++ b/src/services/ui/src/components/RHF/index.ts
@@ -2,3 +2,4 @@ export * from "./Document";
 export * from "./FormGroup";
 export * from "./Section";
 export * from "./Slot";
+export * from "./utils";

--- a/src/services/ui/src/components/RHF/types.ts
+++ b/src/services/ui/src/components/RHF/types.ts
@@ -33,6 +33,13 @@ export type RHFSlotProps = {
   };
 }[keyof RHFComponentMap];
 
+export type RHFOption = {
+  label: string;
+  value: any;
+  form?: FormGroup[];
+  slots?: RHFSlotProps[];
+};
+
 export type RHFComponentMap = {
   Input: InputProps & {
     label?: ReactElement | string;
@@ -42,21 +49,11 @@ export type RHFComponentMap = {
   Switch: SwitchProps;
   Select: SelectProps;
   Radio: RadioProps & {
-    options: {
-      label: string;
-      value: any;
-      form?: FormGroup[];
-      slots?: RHFSlotProps[];
-    }[];
+    options: RHFOption[];
   };
   DatePicker: CalendarProps;
   Checkbox: {
-    options: {
-      label: string;
-      value: any;
-      form?: FormGroup[];
-      slots?: RHFSlotProps[];
-    }[];
+    options: RHFOption[];
   };
   FieldArray: any;
   FieldGroup: {

--- a/src/services/ui/src/components/RHF/types.ts
+++ b/src/services/ui/src/components/RHF/types.ts
@@ -20,11 +20,11 @@ export type RHFSlotProps = {
   labelStyling?: string;
   description?: ReactElement | string;
   dependency?: DependencyRule;
+  rules?: RegisterOptions;
 } & {
   [K in keyof RHFComponentMap]: {
     rhf: K;
     props?: RHFComponentMap[K];
-    rules?: RegisterOptions;
     fields?: K extends "FieldArray"
       ? RHFSlotProps[]
       : K extends "FieldGroup"

--- a/src/services/ui/src/components/RHF/utils.ts
+++ b/src/services/ui/src/components/RHF/utils.ts
@@ -47,8 +47,7 @@ export const slotReducer = (ACC: GL, SLOT: T.RHFSlotProps): GL => {
   if (SLOT.rhf === "Checkbox") {
     if (SLOT.props?.options) {
       SLOT.props.options.forEach(optionReducer);
-      const [first] = SLOT.props.options;
-      ACC[SLOT.name] = first.value;
+      ACC[SLOT.name] = [];
     }
   }
 

--- a/src/services/ui/src/components/RHF/utils.ts
+++ b/src/services/ui/src/components/RHF/utils.ts
@@ -1,0 +1,68 @@
+import * as T from "@/components/RHF/types";
+
+type GL = Record<string, any>;
+
+export const formGroupReducer = (ACC: GL, FORM: T.FormGroup) => {
+  FORM.slots.reduce(slotReducer, ACC);
+  return ACC;
+};
+
+export const slotReducer = (ACC: GL, SLOT: T.RHFSlotProps): GL => {
+  const optionReducer = (OPT: T.RHFOption) => {
+    if (OPT.form) OPT.form.reduce(formGroupReducer, ACC);
+    if (OPT.slots) OPT.slots.reduce(slotReducer, ACC);
+    return ACC;
+  };
+
+  const fieldReducer = (ACC1: GL, SLOT: T.RHFSlotProps): GL => {
+    if (SLOT.rhf === "FieldArray") {
+      return { ...ACC1, [SLOT.name]: [SLOT.fields?.reduce(fieldReducer, {})] };
+    }
+    if (SLOT.rhf === "FieldGroup") {
+      return { ...ACC1, [SLOT.name]: [SLOT.fields?.reduce(fieldReducer, {})] };
+    }
+
+    return { ...ACC1, ...slotReducer(ACC1, SLOT) };
+  };
+
+  if (SLOT.rhf === "Input") ACC[SLOT.name] = "";
+  if (SLOT.rhf === "Textarea") ACC[SLOT.name] = "";
+  if (SLOT.rhf === "Switch") ACC[SLOT.name] = false;
+  if (SLOT.rhf === "Radio") {
+    if (SLOT.props?.options) {
+      SLOT.props.options.forEach(optionReducer);
+      const [first] = SLOT.props.options;
+      ACC[SLOT.name] = first.value;
+    }
+  }
+
+  if (SLOT.rhf === "Select") {
+    if (SLOT.props?.options) {
+      SLOT.props.options.forEach(optionReducer);
+      const [first] = SLOT.props.options;
+      ACC[SLOT.name] = first.value;
+    }
+  }
+
+  if (SLOT.rhf === "Checkbox") {
+    if (SLOT.props?.options) {
+      SLOT.props.options.forEach(optionReducer);
+      const [first] = SLOT.props.options;
+      ACC[SLOT.name] = first.value;
+    }
+  }
+
+  if (SLOT.rhf === "FieldArray")
+    ACC[SLOT.name] = [SLOT.fields?.reduce(fieldReducer, {})];
+  if (SLOT.rhf === "FieldGroup")
+    ACC[SLOT.name] = [SLOT.fields?.reduce(fieldReducer, {})];
+
+  return ACC;
+};
+
+export const documentInitializer = (document: T.Document) => {
+  return document.sections.reduce((ACC, SEC) => {
+    SEC.form.reduce(formGroupReducer, ACC);
+    return ACC;
+  }, {} as any);
+};

--- a/src/services/ui/src/pages/form/index.tsx
+++ b/src/services/ui/src/pages/form/index.tsx
@@ -4,6 +4,7 @@ import { Button, Form } from "@/components/Inputs";
 
 import { RHFDocument } from "@/components/RHF";
 import { ABP1 } from "./proto";
+import { documentInitializer } from "@/components/RHF";
 
 export const JsonFormSchema = {
   type: "object",
@@ -28,19 +29,7 @@ export function ExampleForm() {
   const form = useForm({
     resolver: ajvResolver(JsonFormSchema as any),
     // shouldUnregister: true,
-    defaultValues: {
-      alt_benefit_plan_population_name: "",
-      eligibility_groups: [{}],
-      is_enrollment_available: "no",
-      target_criteria: [],
-      income_target: "",
-      income_definition: "",
-      income_definition_specific: "",
-      income_definition_specific_statewide: [{}],
-      is_incremental_amount: false,
-      dollar_incremental_amount: "",
-      is_geographic_area: "no",
-    },
+    defaultValues: documentInitializer(ABP1),
   });
 
   const onSubmit = form.handleSubmit((data) => {

--- a/src/services/ui/src/pages/form/index.tsx
+++ b/src/services/ui/src/pages/form/index.tsx
@@ -1,4 +1,3 @@
-import { ajvResolver } from "@hookform/resolvers/ajv";
 import { useForm } from "react-hook-form";
 import { Button, Form } from "@/components/Inputs";
 
@@ -6,35 +5,21 @@ import { RHFDocument } from "@/components/RHF";
 import { ABP1 } from "./proto";
 import { documentInitializer } from "@/components/RHF";
 
-export const JsonFormSchema = {
-  type: "object",
-  properties: {
-    alt_benefit_plan_population_name: {
-      type: "string",
-      minLength: 1,
-      maxLength: 20,
-      errorMessage: {
-        minLength: "This field is required",
-      },
-    },
-    is_enrollment_available: {
-      type: "string",
-    },
-  },
-  required: ["alt_benefit_plan_population_name"],
-  additionalProperties: true,
-};
-
 export function ExampleForm() {
+  const defaultValues = documentInitializer(ABP1);
+
   const form = useForm({
-    resolver: ajvResolver(JsonFormSchema as any),
-    // shouldUnregister: true,
-    defaultValues: documentInitializer(ABP1),
+    defaultValues,
   });
 
-  const onSubmit = form.handleSubmit((data) => {
-    console.log(data);
-  });
+  const onSubmit = form.handleSubmit(
+    (data) => {
+      console.log({ data });
+    },
+    (err) => {
+      console.log({ err });
+    }
+  );
 
   return (
     <div className="max-w-screen-xl mx-auto p-4 py-8 lg:px-8">

--- a/src/services/ui/src/pages/form/proto.tsx
+++ b/src/services/ui/src/pages/form/proto.tsx
@@ -14,9 +14,14 @@ export const ABP1: Document = {
               rhf: "Input",
               name: "alt_benefit_plan_population_name",
               label: "Alternative Benefit Plan population name",
-              props: {
-                placeholder: "enter name",
+              rules: {
+                required: "*Required",
+                maxLength: {
+                  value: 20,
+                  message: "Max 20 Characters",
+                },
               },
+              props: { placeholder: "enter name" },
               dependency: {
                 // example of a value changing field, with multi-conditions
                 conditions: [
@@ -308,7 +313,7 @@ export const ABP1: Document = {
                                                 slots: [
                                                   {
                                                     rhf: "FieldGroup",
-                                                    name: "income_definition_specific_statewide_arr",
+                                                    name: "income_definition_region_statewide_group",
                                                     props: {
                                                       appendText: "Add Region",
                                                       removeText:
@@ -317,7 +322,7 @@ export const ABP1: Document = {
                                                     fields: [
                                                       {
                                                         rhf: "FieldArray",
-                                                        name: "income_definition_specific_statewide",
+                                                        name: "income_definition_region_statewide_arr",
                                                         fields: [
                                                           {
                                                             rhf: "Input",


### PR DESCRIPTION
## Purpose

Webforms needs a way to standardize default form values.  
- Created an initializer function that accepts a `Document` and recursively scans through each slot and sets a default value depending on the rhf type.
- Added useEffects to FieldGroup + FieldArray that re-appends default values when corresponding field is unregistered

#### Linked Issues to Close

## Approach

It addresses the issue by nautical cloud formation templates through kafka buckets running on aws lambda step functions 

## Assorted Notes/Considerations/Learning

We should use the `Document` to drive validation.  Since it provides all the information to generate a form, it can be used to validate the type/schema of incoming and outgoing data.
