### PR TITLE
feat(package actions): Set up API to return actions; UI to read and render actions

### DIFF
--- a/src/packages/shared-types/actions.ts
+++ b/src/packages/shared-types/actions.ts
@@ -1,3 +1,3 @@
 export enum Action {
-  ENABLE_RAI_WITHDRAW = "enableRaiResponseWithdraw",
+  ENABLE_RAI_WITHDRAW = "enable-rai-withdraw",
 }

--- a/src/packages/shared-types/actions.ts
+++ b/src/packages/shared-types/actions.ts
@@ -1,0 +1,3 @@
+export enum Action {
+  ENABLE_RAI_WITHDRAW = "enableRaiResponseWithdraw",
+}

--- a/src/packages/shared-types/index.ts
+++ b/src/packages/shared-types/index.ts
@@ -4,3 +4,4 @@ export * from "./errors";
 export * from "./seatool";
 export * from "./onemac";
 export * from "./opensearch";
+export * from "./actions";

--- a/src/packages/shared-types/opensearch.ts
+++ b/src/packages/shared-types/opensearch.ts
@@ -37,7 +37,6 @@ export type OsMainSearchResponse = OsResponse<OsMainSourceItem>;
 export type SearchData = OsHits<OsMainSourceItem>;
 export type ItemResult = OsHit<OsMainSourceItem> & {
   found: boolean;
-  actions: Action[];
 };
 
 export type OsFilterType =

--- a/src/packages/shared-types/opensearch.ts
+++ b/src/packages/shared-types/opensearch.ts
@@ -1,5 +1,6 @@
 import { SeaToolTransform } from "./seatool";
 import { OneMacTransform } from "./onemac";
+import { Action } from "./actions";
 
 export type OsHit<T> = {
   _index: string;
@@ -34,6 +35,10 @@ export type OsResponse<T> = {
 export type OsMainSourceItem = OneMacTransform & SeaToolTransform;
 export type OsMainSearchResponse = OsResponse<OsMainSourceItem>;
 export type SearchData = OsHits<OsMainSourceItem>;
+export type ItemResult = OsHit<OsMainSourceItem> & {
+  found: boolean;
+  actions: Action[];
+};
 
 export type OsFilterType =
   | "term"

--- a/src/services/api/handlers/getPackageActions.ts
+++ b/src/services/api/handlers/getPackageActions.ts
@@ -20,7 +20,6 @@ const packageActionsForResult = (
   result: ItemResult
 ): Action[] => {
   const actions = [];
-  // if (isCmsUser(user) && result._source.raiReceivedDate) {
   if (isCmsUser(user)) {
     actions.push(Action.ENABLE_RAI_WITHDRAW);
   }
@@ -29,6 +28,7 @@ const packageActionsForResult = (
 export const getPackageActions = async (event: APIGatewayEvent) => {
   const body = JSON.parse(event.body) as GetPackageActionsBody;
   try {
+    console.log(body);
     const result = await getPackage(body.id);
     const passedStateAuth = await isAuthorized(event, result._source.state);
     if (!passedStateAuth)

--- a/src/services/api/handlers/getPackageActions.ts
+++ b/src/services/api/handlers/getPackageActions.ts
@@ -1,0 +1,64 @@
+import { APIGatewayEvent } from "aws-lambda";
+import { Action, CognitoUserAttributes, ItemResult } from "shared-types";
+import { isCmsUser } from "shared-utils";
+import { getPackage } from "../libs/package/getPackage";
+import {
+  getAuthDetails,
+  isAuthorized,
+  lookupUserAttributes,
+} from "../libs/auth/user";
+import { response } from "../libs/handler";
+
+type GetPackageActionsBody = {
+  id: string;
+};
+
+/** Generates an array of allowed actions from a combination of user attributes
+ * and OS result data */
+const packageActionsForResult = (
+  user: CognitoUserAttributes,
+  result: ItemResult
+): Action[] => {
+  const actions = [];
+  // if (isCmsUser(user) && result._source.raiReceivedDate) {
+  if (isCmsUser(user)) {
+    actions.push(Action.ENABLE_RAI_WITHDRAW);
+  }
+  return actions;
+};
+export const getPackageActions = async (event: APIGatewayEvent) => {
+  const body = JSON.parse(event.body) as GetPackageActionsBody;
+  try {
+    const result = await getPackage(body.id);
+    const passedStateAuth = await isAuthorized(event, result._source.state);
+    if (!passedStateAuth)
+      return response({
+        statusCode: 401,
+        body: { message: "Not authorized to view resources from this state" },
+      });
+    if (!result.found)
+      return response({
+        statusCode: 404,
+        body: { message: "No record found for the given id" },
+      });
+
+    const authDetails = getAuthDetails(event);
+    const userAttr = await lookupUserAttributes(
+      authDetails.userId,
+      authDetails.poolId
+    );
+
+    return response({
+      statusCode: 200,
+      body: {
+        actions: packageActionsForResult(userAttr, result),
+      },
+    });
+  } catch (err) {
+    console.error({ err });
+    return response({
+      statusCode: 500,
+      body: { message: "Internal server error" },
+    });
+  }
+};

--- a/src/services/api/handlers/getPackageActions.ts
+++ b/src/services/api/handlers/getPackageActions.ts
@@ -62,3 +62,5 @@ export const getPackageActions = async (event: APIGatewayEvent) => {
     });
   }
 };
+
+export const handler = getPackageActions;

--- a/src/services/api/handlers/item.ts
+++ b/src/services/api/handlers/item.ts
@@ -6,22 +6,12 @@ import {
   getStateFilter,
   lookupUserAttributes,
 } from "../libs/auth/user";
-import {
-  OsHit,
-  OsMainSourceItem,
-  Action,
-  CognitoUserAttributes,
-} from "shared-types";
+import { Action, CognitoUserAttributes, ItemResult } from "shared-types";
 import { isCmsUser } from "shared-utils";
 
 if (!process.env.osDomain) {
   throw "ERROR:  osDomain env variable is required,";
 }
-
-type ItemResult = OsHit<OsMainSourceItem> & {
-  found: boolean;
-  actions: Action[];
-};
 
 /** Generates an array of allowed actions from a combination of user attributes
  * and OS result data */
@@ -30,7 +20,7 @@ const packageActionsForResult = (
   result: ItemResult
 ): Action[] => {
   const actions = [];
-  if (isCmsUser(user)) {
+  if (isCmsUser(user) && result._source.raiReceivedDate) {
     actions.push(Action.ENABLE_RAI_WITHDRAW);
   }
   return actions;

--- a/src/services/api/handlers/item.ts
+++ b/src/services/api/handlers/item.ts
@@ -1,24 +1,61 @@
 import { response } from "../libs/handler";
 import { APIGatewayEvent } from "aws-lambda";
 import * as os from "../../../libs/opensearch-lib";
-import { getStateFilter } from "../libs/auth/user";
-import { OsHit, OsMainSourceItem } from "shared-types";
+import {
+  getAuthDetails,
+  getStateFilter,
+  lookupUserAttributes,
+} from "../libs/auth/user";
+import {
+  OsHit,
+  OsMainSourceItem,
+  Action,
+  CognitoUserAttributes,
+} from "shared-types";
+import { isCmsUser } from "shared-utils";
 
 if (!process.env.osDomain) {
   throw "ERROR:  osDomain env variable is required,";
 }
 
+type ItemResult = OsHit<OsMainSourceItem> & {
+  found: boolean;
+  actions: Action[];
+};
+
+/** Generates an array of allowed actions from a combination of user attributes
+ * and OS result data */
+const packageActionsForResult = (
+  user: CognitoUserAttributes,
+  result: ItemResult
+): Action[] => {
+  const actions = [];
+  if (isCmsUser(user) && result._source.raiReceivedDate) {
+    actions.push(Action.ENABLE_RAI_WITHDRAW);
+  }
+  return actions;
+};
+
 export const getItemData = async (event: APIGatewayEvent) => {
   try {
     const body = JSON.parse(event.body);
 
+    // TODO: Can all this user stuff just happen in one swift go instead of multiple calls?
+    const authDetails = getAuthDetails(event);
+    const userAttr = await lookupUserAttributes(
+      authDetails.userId,
+      authDetails.poolId
+    );
     const stateFilter = await getStateFilter(event);
 
     const result = (await os.getItem(
       process.env.osDomain,
       "main",
       body.id
-    )) as OsHit<OsMainSourceItem> & { found: boolean };
+    )) as ItemResult;
+
+    // Get available actions based on user's rol/* */e and result source
+    result.actions = packageActionsForResult(userAttr, result);
 
     if (
       stateFilter &&

--- a/src/services/api/handlers/item.ts
+++ b/src/services/api/handlers/item.ts
@@ -20,7 +20,8 @@ const packageActionsForResult = (
   result: ItemResult
 ): Action[] => {
   const actions = [];
-  if (isCmsUser(user) && result._source.raiReceivedDate) {
+  // if (isCmsUser(user) && result._source.raiReceivedDate) {
+  if (isCmsUser(user)) {
     actions.push(Action.ENABLE_RAI_WITHDRAW);
   }
   return actions;

--- a/src/services/api/handlers/item.ts
+++ b/src/services/api/handlers/item.ts
@@ -30,7 +30,7 @@ const packageActionsForResult = (
   result: ItemResult
 ): Action[] => {
   const actions = [];
-  if (isCmsUser(user) && result._source.raiReceivedDate) {
+  if (isCmsUser(user)) {
     actions.push(Action.ENABLE_RAI_WITHDRAW);
   }
   return actions;
@@ -54,7 +54,7 @@ export const getItemData = async (event: APIGatewayEvent) => {
       body.id
     )) as ItemResult;
 
-    // Get available actions based on user's rol/* */e and result source
+    // Get available actions based on user's role and result source
     result.actions = packageActionsForResult(userAttr, result);
 
     if (

--- a/src/services/api/libs/package/getPackage.ts
+++ b/src/services/api/libs/package/getPackage.ts
@@ -1,0 +1,5 @@
+import * as os from "../../../../libs/opensearch-lib";
+import { ItemResult } from "shared-types";
+
+export const getPackage = async (id: string) =>
+  (await os.getItem(process.env.osDomain, "main", id)) as ItemResult;

--- a/src/services/api/serverless.yml
+++ b/src/services/api/serverless.yml
@@ -105,6 +105,25 @@ functions:
       subnetIds: >-
         ${self:custom.vpc.privateSubnets}
     provisionedConcurrency: ${param:searchProvisionedConcurrency}
+  getPackageActions:
+    handler: handlers/getPackageActions.handler
+    maximumRetryAttempts: 0
+    environment:
+      region: ${self:provider.region}
+      osDomain: ${param:osDomain}
+      onemacLegacyS3AccessRoleArn: ${self:custom.onemacLegacyS3AccessRoleArn}
+    events:
+      - http:
+          path: /getPackageActions
+          method: post
+          cors: true
+          authorizer: aws_iam
+    vpc:
+      securityGroupIds:
+        - Ref: SecurityGroup
+      subnetIds: >-
+        ${self:custom.vpc.privateSubnets}
+    provisionedConcurrency: ${param:getAttachmentUrlProvisionedConcurrency}
   getAttachmentUrl:
     handler: handlers/getAttachmentUrl.handler
     maximumRetryAttempts: 0

--- a/src/services/ui/src/api/index.ts
+++ b/src/services/ui/src/api/index.ts
@@ -1,3 +1,4 @@
 export * from "./useSearch";
 export * from "./useGetItem";
 export * from "./getAttachmentUrl";
+export * from "./useGetPackageActions";

--- a/src/services/ui/src/api/useGetItem.ts
+++ b/src/services/ui/src/api/useGetItem.ts
@@ -1,8 +1,13 @@
 import { useQuery, UseQueryOptions } from "@tanstack/react-query";
 import { API } from "aws-amplify";
-import { OsHit, OsMainSourceItem, ReactQueryApiError } from "shared-types";
+import {
+  ItemResult,
+  OsHit,
+  OsMainSourceItem,
+  ReactQueryApiError,
+} from "shared-types";
 
-export const getItem = async (id: string): Promise<OsHit<OsMainSourceItem>> => {
+export const getItem = async (id: string): Promise<ItemResult> => {
   const record = await API.post("os", "/item", { body: { id } });
 
   return record;
@@ -10,9 +15,9 @@ export const getItem = async (id: string): Promise<OsHit<OsMainSourceItem>> => {
 
 export const useGetItem = (
   id: string,
-  options?: UseQueryOptions<OsHit<OsMainSourceItem>, ReactQueryApiError>
+  options?: UseQueryOptions<ItemResult, ReactQueryApiError>
 ) => {
-  return useQuery<OsHit<OsMainSourceItem>, ReactQueryApiError>(
+  return useQuery<ItemResult, ReactQueryApiError>(
     ["record", id],
     () => getItem(id),
     options

--- a/src/services/ui/src/api/useGetItem.ts
+++ b/src/services/ui/src/api/useGetItem.ts
@@ -1,11 +1,6 @@
 import { useQuery, UseQueryOptions } from "@tanstack/react-query";
 import { API } from "aws-amplify";
-import {
-  ItemResult,
-  OsHit,
-  OsMainSourceItem,
-  ReactQueryApiError,
-} from "shared-types";
+import { ItemResult, ReactQueryApiError } from "shared-types";
 
 export const getItem = async (id: string): Promise<ItemResult> => {
   const record = await API.post("os", "/item", { body: { id } });

--- a/src/services/ui/src/api/useGetPackageActions.ts
+++ b/src/services/ui/src/api/useGetPackageActions.ts
@@ -1,0 +1,19 @@
+import { Action, ReactQueryApiError } from "shared-types";
+import { API } from "aws-amplify";
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
+type PackageActionsResponse = {
+  actions: Action[];
+};
+const getPackageActions = async (id: string): Promise<PackageActionsResponse> =>
+  await API.post("os", "/getPackageActions", { body: id });
+
+export const useGetPackageActions = (
+  id: string,
+  options?: UseQueryOptions<PackageActionsResponse, ReactQueryApiError>
+) => {
+  return useQuery<PackageActionsResponse, ReactQueryApiError>(
+    ["actions", id],
+    () => getPackageActions(id),
+    options
+  );
+};

--- a/src/services/ui/src/api/useGetPackageActions.ts
+++ b/src/services/ui/src/api/useGetPackageActions.ts
@@ -5,7 +5,7 @@ type PackageActionsResponse = {
   actions: Action[];
 };
 const getPackageActions = async (id: string): Promise<PackageActionsResponse> =>
-  await API.post("os", "/getPackageActions", { body: id });
+  await API.post("os", "/getPackageActions", { body: { id } });
 
 export const useGetPackageActions = (
   id: string,

--- a/src/services/ui/src/components/Cards/CardWithTopBorder.tsx
+++ b/src/services/ui/src/components/Cards/CardWithTopBorder.tsx
@@ -1,13 +1,16 @@
 import { FC, ReactNode } from "react";
+import { cn } from "@/lib";
 
 interface CardWithTopBorderProps {
   children: ReactNode;
+  className?: string;
 }
 export const CardWithTopBorder: FC<CardWithTopBorderProps> = ({
   children,
+  className,
 }: CardWithTopBorderProps) => {
   return (
-    <div className="mb-4 sticky top-12">
+    <div className={cn("mb-4 sticky top-12", className)}>
       <div
         style={{
           background: "linear-gradient(90.11deg,#0071bc 49.91%,#02bfe7 66.06%)",

--- a/src/services/ui/src/pages/actions/EnableRaiResponseWithdraw.tsx
+++ b/src/services/ui/src/pages/actions/EnableRaiResponseWithdraw.tsx
@@ -1,1 +1,15 @@
-export const EnableRaiResponseWithdraw = () => <></>;
+import { useParams } from "react-router-dom";
+
+export const EnableRaiResponseWithdraw = () => {
+  const { id, type } = useParams<{
+    id: string;
+    type: string;
+  }>();
+
+  return (
+    <div>
+      <span>ID: {id}</span>
+      <span>Type: {type}</span>
+    </div>
+  );
+};

--- a/src/services/ui/src/pages/actions/EnableRaiResponseWithdraw.tsx
+++ b/src/services/ui/src/pages/actions/EnableRaiResponseWithdraw.tsx
@@ -1,0 +1,1 @@
+export const EnableRaiResponseWithdraw = () => <></>;

--- a/src/services/ui/src/pages/actions/index.tsx
+++ b/src/services/ui/src/pages/actions/index.tsx
@@ -1,15 +1,12 @@
 import { Navigate, useParams } from "react-router-dom";
 import { ROUTES } from "@/routes";
 import { EnableRaiResponseWithdraw } from "@/pages/actions/EnableRaiResponseWithdraw";
-
-export enum ActionForms {
-  ENABLE_RAI_WITHDRAW = "enable-rai-withdraw",
-}
+import { Action } from "shared-types";
 
 export const ActionFormIndex = () => {
-  const { type } = useParams<{ type: ActionForms }>();
+  const { type } = useParams<{ type: Action }>();
   switch (type) {
-    case ActionForms.ENABLE_RAI_WITHDRAW:
+    case Action.ENABLE_RAI_WITHDRAW:
       return <EnableRaiResponseWithdraw />;
     default:
       // TODO: Better error communication instead of navigate?

--- a/src/services/ui/src/pages/actions/index.tsx
+++ b/src/services/ui/src/pages/actions/index.tsx
@@ -2,7 +2,7 @@ import { Navigate, useParams } from "react-router-dom";
 import { ROUTES } from "@/routes";
 import { EnableRaiResponseWithdraw } from "@/pages/actions/EnableRaiResponseWithdraw";
 
-enum ActionForms {
+export enum ActionForms {
   ENABLE_RAI_WITHDRAW = "enable-rai-withdraw",
 }
 

--- a/src/services/ui/src/pages/actions/index.tsx
+++ b/src/services/ui/src/pages/actions/index.tsx
@@ -1,0 +1,19 @@
+import { Navigate, useParams } from "react-router-dom";
+import { ROUTES } from "@/routes";
+import { EnableRaiResponseWithdraw } from "@/pages/actions/EnableRaiResponseWithdraw";
+
+enum ActionForms {
+  ENABLE_RAI_WITHDRAW = "enable-rai-withdraw",
+}
+
+export const ActionFormIndex = () => {
+  const { type } = useParams<{ type: ActionForms }>();
+  switch (type) {
+    case ActionForms.ENABLE_RAI_WITHDRAW:
+      return <EnableRaiResponseWithdraw />;
+    default:
+      // TODO: Better error communication instead of navigate?
+      //  "Hey, this action doesn't exist. Click to go back to the Dashboard."
+      return <Navigate to={ROUTES.HOME} />;
+  }
+};

--- a/src/services/ui/src/pages/detail/index.tsx
+++ b/src/services/ui/src/pages/detail/index.tsx
@@ -10,7 +10,7 @@ import {
   SubmissionInfo,
 } from "@/components";
 import { useGetUser } from "@/api/useGetUser";
-import { ItemResult } from "shared-types";
+import { CognitoUserAttributes, ItemResult } from "shared-types";
 import { useQuery } from "@/hooks";
 import { useGetItem } from "@/api";
 import { BreadCrumbs } from "@/components/BreadCrumb";
@@ -18,31 +18,49 @@ import { BREAD_CRUMB_CONFIG_PACKAGE_DETAILS } from "@/components/BreadCrumb/brea
 import { mapActionLabel } from "@/utils";
 import { Link } from "react-router-dom";
 import { useGetPackageActions } from "@/api/useGetPackageActions";
+import { PropsWithChildren } from "react";
 
+const DetailCardWrapper = ({
+  title,
+  children,
+}: PropsWithChildren<{
+  title: string;
+}>) => (
+  <CardWithTopBorder className="max-w-[18rem]">
+    <div className="p-4">
+      <h2>{title}</h2>
+      {children}
+    </div>
+  </CardWithTopBorder>
+);
+const StatusCard = ({ isCms, data }: { isCms: boolean; data: ItemResult }) => (
+  <DetailCardWrapper title={"Status"}>
+    <div>
+      <h2 className="text-xl font-semibold">
+        {isCms ? data._source.cmsStatus : data._source.stateStatus}
+      </h2>
+    </div>
+  </DetailCardWrapper>
+);
 const PackageActionsCard = ({ id }: { id: string }) => {
   const { data, error } = useGetPackageActions(id);
   if (!data?.actions || error) return <LoadingSpinner />;
   return (
-    <section id="package-actions" className="block md:flex mb-8 gap-8">
-      <CardWithTopBorder>
-        <div className="p-4">
-          <p className="text-gray-600 font-semibold mb-2">Actions</p>
-          <div>
-            <ul>
-              {data.actions.map((action, idx) => (
-                <Link
-                  className="text-sky-500 underline"
-                  to={`/action/${action}`}
-                  key={`${idx}-${action}`}
-                >
-                  <li>{mapActionLabel(action)}</li>
-                </Link>
-              ))}
-            </ul>
-          </div>
-        </div>
-      </CardWithTopBorder>
-    </section>
+    <DetailCardWrapper title={"Actions"}>
+      <div>
+        <ul>
+          {data.actions.map((action, idx) => (
+            <Link
+              className="text-sky-500 underline"
+              to={`/action/${action}`}
+              key={`${idx}-${action}`}
+            >
+              <li>{mapActionLabel(action)}</li>
+            </Link>
+          ))}
+        </ul>
+      </div>
+    </DetailCardWrapper>
   );
 };
 
@@ -71,23 +89,13 @@ export const DetailsContent = ({ data }: { data?: ItemResult }) => {
         ))}
       </aside>
       <div className="flex-1">
-        <div className="flex gap-8">
-          <section id="package-overview" className="block md:flex mb-8 gap-8">
-            <CardWithTopBorder>
-              <div className="p-4">
-                <p className="text-gray-600 font-semibold mb-2">Status</p>
-                <div>
-                  <h2 className="text-xl font-semibold mb-2">
-                    {user?.isCms
-                      ? data._source.cmsStatus
-                      : data._source.stateStatus}
-                  </h2>
-                </div>
-              </div>
-            </CardWithTopBorder>
-          </section>
+        <section
+          id="package-overview"
+          className="sm:flex lg:grid lg:grid-cols-2 gap-4 my-6"
+        >
+          <StatusCard isCms={user?.isCms || false} data={data} />
           <PackageActionsCard id={data._id} />
-        </div>
+        </section>
         <DetailsSection id="package-details" title="Package Details">
           <ChipSpaPackageDetails {...data?._source} />
         </DetailsSection>

--- a/src/services/ui/src/pages/detail/index.tsx
+++ b/src/services/ui/src/pages/detail/index.tsx
@@ -16,7 +16,7 @@ import { useGetItem } from "@/api";
 import { DetailNav } from "./detailNav";
 import { BreadCrumbs } from "@/components/BreadCrumb";
 import { BREAD_CRUMB_CONFIG_PACKAGE_DETAILS } from "@/components/BreadCrumb/bread-crumb-config";
-import { mapActionLabel } from "@/utils";
+import { mapActionLabel, mapActionLink } from "@/utils";
 import { Link } from "react-router-dom";
 import { ROUTES } from "@/routes";
 
@@ -69,7 +69,7 @@ export const DetailsContent = ({ data }: { data?: ItemResult }) => {
                     {data.actions.map((action, idx) => (
                       <Link
                         className="text-sky-500 underline"
-                        to={ROUTES.DASHBOARD}
+                        to={mapActionLink(action)}
                         key={`${idx}-${action}`}
                       >
                         <li>{mapActionLabel(action)}</li>

--- a/src/services/ui/src/pages/detail/index.tsx
+++ b/src/services/ui/src/pages/detail/index.tsx
@@ -52,7 +52,7 @@ const PackageActionsCard = ({ id }: { id: string }) => {
           {data.actions.map((action, idx) => (
             <Link
               className="text-sky-500 underline"
-              to={`/action/${action}`}
+              to={`/action/${id}/${action}`}
               key={`${idx}-${action}`}
             >
               <li>{mapActionLabel(action)}</li>

--- a/src/services/ui/src/pages/detail/index.tsx
+++ b/src/services/ui/src/pages/detail/index.tsx
@@ -10,15 +10,13 @@ import {
   SubmissionInfo,
 } from "@/components";
 import { useGetUser } from "@/api/useGetUser";
-import { Action, ItemResult, OsHit, OsMainSourceItem } from "shared-types";
+import { ItemResult } from "shared-types";
 import { useQuery } from "@/hooks";
 import { useGetItem } from "@/api";
-import { DetailNav } from "./detailNav";
 import { BreadCrumbs } from "@/components/BreadCrumb";
 import { BREAD_CRUMB_CONFIG_PACKAGE_DETAILS } from "@/components/BreadCrumb/bread-crumb-config";
-import { mapActionLabel, mapActionLink } from "@/utils";
+import { mapActionLabel } from "@/utils";
 import { Link } from "react-router-dom";
-import { ROUTES } from "@/routes";
 
 export const DetailsContent = ({ data }: { data?: ItemResult }) => {
   const { data: user } = useGetUser();
@@ -69,7 +67,7 @@ export const DetailsContent = ({ data }: { data?: ItemResult }) => {
                     {data.actions.map((action, idx) => (
                       <Link
                         className="text-sky-500 underline"
-                        to={mapActionLink(action)}
+                        to={`/action/${action}`}
                         key={`${idx}-${action}`}
                       >
                         <li>{mapActionLabel(action)}</li>

--- a/src/services/ui/src/pages/detail/index.tsx
+++ b/src/services/ui/src/pages/detail/index.tsx
@@ -17,6 +17,34 @@ import { BreadCrumbs } from "@/components/BreadCrumb";
 import { BREAD_CRUMB_CONFIG_PACKAGE_DETAILS } from "@/components/BreadCrumb/bread-crumb-config";
 import { mapActionLabel } from "@/utils";
 import { Link } from "react-router-dom";
+import { useGetPackageActions } from "@/api/useGetPackageActions";
+
+const PackageActionsCard = ({ id }: { id: string }) => {
+  const { data, error } = useGetPackageActions(id);
+  if (!data?.actions || error) return <LoadingSpinner />;
+  return (
+    <section id="package-actions" className="block md:flex mb-8 gap-8">
+      <CardWithTopBorder>
+        <div className="p-4">
+          <p className="text-gray-600 font-semibold mb-2">Actions</p>
+          <div>
+            <ul>
+              {data.actions.map((action, idx) => (
+                <Link
+                  className="text-sky-500 underline"
+                  to={`/action/${action}`}
+                  key={`${idx}-${action}`}
+                >
+                  <li>{mapActionLabel(action)}</li>
+                </Link>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </CardWithTopBorder>
+    </section>
+  );
+};
 
 export const DetailsContent = ({ data }: { data?: ItemResult }) => {
   const { data: user } = useGetUser();
@@ -58,26 +86,7 @@ export const DetailsContent = ({ data }: { data?: ItemResult }) => {
               </div>
             </CardWithTopBorder>
           </section>
-          <section id="package-actions" className="block md:flex mb-8 gap-8">
-            <CardWithTopBorder>
-              <div className="p-4">
-                <p className="text-gray-600 font-semibold mb-2">Actions</p>
-                <div>
-                  <ul>
-                    {data.actions.map((action, idx) => (
-                      <Link
-                        className="text-sky-500 underline"
-                        to={`/action/${action}`}
-                        key={`${idx}-${action}`}
-                      >
-                        <li>{mapActionLabel(action)}</li>
-                      </Link>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-            </CardWithTopBorder>
-          </section>
+          <PackageActionsCard id={data._id} />
         </div>
         <DetailsSection id="package-details" title="Package Details">
           <ChipSpaPackageDetails {...data?._source} />

--- a/src/services/ui/src/pages/detail/index.tsx
+++ b/src/services/ui/src/pages/detail/index.tsx
@@ -48,17 +48,23 @@ const PackageActionsCard = ({ id }: { id: string }) => {
   return (
     <DetailCardWrapper title={"Actions"}>
       <div>
-        <ul>
-          {data.actions.map((action, idx) => (
-            <Link
-              className="text-sky-500 underline"
-              to={`/action/${id}/${action}`}
-              key={`${idx}-${action}`}
-            >
-              <li>{mapActionLabel(action)}</li>
-            </Link>
-          ))}
-        </ul>
+        {!data.actions.length ? (
+          <em className="text-gray-400">
+            No actions are currently available for this submission.
+          </em>
+        ) : (
+          <ul>
+            {data.actions.map((action, idx) => (
+              <Link
+                className="text-sky-500 underline"
+                to={`/action/${id}/${action}`}
+                key={`${idx}-${action}`}
+              >
+                <li>{mapActionLabel(action)}</li>
+              </Link>
+            ))}
+          </ul>
+        )}
       </div>
     </DetailCardWrapper>
   );

--- a/src/services/ui/src/pages/detail/index.tsx
+++ b/src/services/ui/src/pages/detail/index.tsx
@@ -10,18 +10,17 @@ import {
   SubmissionInfo,
 } from "@/components";
 import { useGetUser } from "@/api/useGetUser";
-import { OsHit, OsMainSourceItem } from "shared-types";
+import { Action, ItemResult, OsHit, OsMainSourceItem } from "shared-types";
 import { useQuery } from "@/hooks";
 import { useGetItem } from "@/api";
 import { DetailNav } from "./detailNav";
 import { BreadCrumbs } from "@/components/BreadCrumb";
 import { BREAD_CRUMB_CONFIG_PACKAGE_DETAILS } from "@/components/BreadCrumb/bread-crumb-config";
+import { mapActionLabel } from "@/utils";
+import { Link } from "react-router-dom";
+import { ROUTES } from "@/routes";
 
-export const DetailsContent = ({
-  data,
-}: {
-  data?: OsHit<OsMainSourceItem>;
-}) => {
+export const DetailsContent = ({ data }: { data?: ItemResult }) => {
   const { data: user } = useGetUser();
   if (!data?._source) return <LoadingSpinner />;
   return (
@@ -46,20 +45,42 @@ export const DetailsContent = ({
         ))}
       </aside>
       <div className="flex-1">
-        <section id="package-overview" className="block md:flex mb-8 gap-8">
-          <CardWithTopBorder>
-            <div className="p-4">
-              <p className="text-gray-600 font-semibold mb-2">Status</p>
-              <div>
-                <h2 className="text-xl font-semibold mb-2">
-                  {user?.isCms
-                    ? data._source.cmsStatus
-                    : data._source.stateStatus}
-                </h2>
+        <div className="flex gap-8">
+          <section id="package-overview" className="block md:flex mb-8 gap-8">
+            <CardWithTopBorder>
+              <div className="p-4">
+                <p className="text-gray-600 font-semibold mb-2">Status</p>
+                <div>
+                  <h2 className="text-xl font-semibold mb-2">
+                    {user?.isCms
+                      ? data._source.cmsStatus
+                      : data._source.stateStatus}
+                  </h2>
+                </div>
               </div>
-            </div>
-          </CardWithTopBorder>
-        </section>
+            </CardWithTopBorder>
+          </section>
+          <section id="package-actions" className="block md:flex mb-8 gap-8">
+            <CardWithTopBorder>
+              <div className="p-4">
+                <p className="text-gray-600 font-semibold mb-2">Actions</p>
+                <div>
+                  <ul>
+                    {data.actions.map((action, idx) => (
+                      <Link
+                        className="text-sky-500 underline"
+                        to={ROUTES.DASHBOARD}
+                        key={`${idx}-${action}`}
+                      >
+                        <li>{mapActionLabel(action)}</li>
+                      </Link>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </CardWithTopBorder>
+          </section>
+        </div>
         <DetailsSection id="package-details" title="Package Details">
           <ChipSpaPackageDetails {...data?._source} />
         </DetailsSection>

--- a/src/services/ui/src/pages/index.ts
+++ b/src/services/ui/src/pages/index.ts
@@ -4,3 +4,4 @@ export * from "./welcome";
 export * from "./detail";
 export * from "./faq";
 export * from "./form";
+export * from "./actions";

--- a/src/services/ui/src/router.tsx
+++ b/src/services/ui/src/router.tsx
@@ -66,6 +66,7 @@ export const router = createBrowserRouter([
         element: <P.CHIPEligibilityLandingPage />,
       },
       { path: ROUTES.CREATE, element: <P.Create /> },
+      { path: ROUTES.ACTION, element: <P.ActionFormIndex /> },
       // TODO: Remove "/form" and ExampleForm if there's no usage; the Create page
       //  is our current SEATool integration test form.
       { path: "/form", element: <P.ExampleForm /> },

--- a/src/services/ui/src/routes.ts
+++ b/src/services/ui/src/routes.ts
@@ -17,6 +17,7 @@ export enum ROUTES {
   MEDICAID_ABP_LANDING = "/new-submission/spa/medicaid/landing/medicaid-abp",
   MEDICAID_ELIGIBILITY_LANDING = "/new-submission/spa/medicaid/landing/medicaid-eligibility",
   CHIP_ELIGIBILITY_LANDING = "/new-submission/spa/chip/landing/chip-eligibility",
+  ACTION = "/action/:type",
   CREATE = "/create",
 }
 

--- a/src/services/ui/src/routes.ts
+++ b/src/services/ui/src/routes.ts
@@ -17,7 +17,7 @@ export enum ROUTES {
   MEDICAID_ABP_LANDING = "/new-submission/spa/medicaid/landing/medicaid-abp",
   MEDICAID_ELIGIBILITY_LANDING = "/new-submission/spa/medicaid/landing/medicaid-eligibility",
   CHIP_ELIGIBILITY_LANDING = "/new-submission/spa/chip/landing/chip-eligibility",
-  ACTION = "/action/:type",
+  ACTION = "/action/:id/:type",
   CREATE = "/create",
 }
 

--- a/src/services/ui/src/utils/actionLabelMapper.ts
+++ b/src/services/ui/src/utils/actionLabelMapper.ts
@@ -1,0 +1,9 @@
+import { Action } from "shared-types";
+export const mapActionLabel = (a: Action) => {
+  switch (a) {
+    case Action.ENABLE_RAI_WITHDRAW:
+      return "Enable RAI Response Withdraw";
+    default:
+      return null;
+  }
+};

--- a/src/services/ui/src/utils/actionLabelMapper.ts
+++ b/src/services/ui/src/utils/actionLabelMapper.ts
@@ -1,5 +1,6 @@
 import { Action } from "shared-types";
-import { ROUTES } from "@/routes";
+import { ActionForms } from "@/pages";
+
 export const mapActionLabel = (a: Action) => {
   switch (a) {
     case Action.ENABLE_RAI_WITHDRAW:
@@ -7,9 +8,10 @@ export const mapActionLabel = (a: Action) => {
   }
 };
 
-export const mapActionLink = (a: Action): ROUTES => {
+export const mapActionLink = (a: Action): string => {
+  const prefixed = (route: ActionForms) => `/action/${route}`;
   switch (a) {
     case Action.ENABLE_RAI_WITHDRAW:
-      return ROUTES.DASHBOARD;
+      return prefixed(ActionForms.ENABLE_RAI_WITHDRAW);
   }
 };

--- a/src/services/ui/src/utils/actionLabelMapper.ts
+++ b/src/services/ui/src/utils/actionLabelMapper.ts
@@ -1,17 +1,8 @@
 import { Action } from "shared-types";
-import { ActionForms } from "@/pages";
 
 export const mapActionLabel = (a: Action) => {
   switch (a) {
     case Action.ENABLE_RAI_WITHDRAW:
       return "Enable RAI Response Withdraw";
-  }
-};
-
-export const mapActionLink = (a: Action): string => {
-  const prefixed = (route: ActionForms) => `/action/${route}`;
-  switch (a) {
-    case Action.ENABLE_RAI_WITHDRAW:
-      return prefixed(ActionForms.ENABLE_RAI_WITHDRAW);
   }
 };

--- a/src/services/ui/src/utils/actionLabelMapper.ts
+++ b/src/services/ui/src/utils/actionLabelMapper.ts
@@ -1,9 +1,15 @@
 import { Action } from "shared-types";
+import { ROUTES } from "@/routes";
 export const mapActionLabel = (a: Action) => {
   switch (a) {
     case Action.ENABLE_RAI_WITHDRAW:
       return "Enable RAI Response Withdraw";
-    default:
-      return null;
+  }
+};
+
+export const mapActionLink = (a: Action): ROUTES => {
+  switch (a) {
+    case Action.ENABLE_RAI_WITHDRAW:
+      return ROUTES.DASHBOARD;
   }
 };

--- a/src/services/ui/src/utils/index.ts
+++ b/src/services/ui/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from "./user";
 export * from "./date";
 export * from "./textHelpers";
 export * from "./createContextProvider";
+export * from "./actionLabelMapper";


### PR DESCRIPTION
## Purpose

This PR handles preliminary work necessary for all package actions tickets forthcoming. It enables developers to create the conditions in which a package action is to be added to the API response for an item, and render out the option on the Details page of the UI.

#### Linked Issues to Close

Does not close any issues.

## Approach

Package actions are not something that come through the sink in either data model (SEA Tool or OneMAC), so we have to infer package actions available based on the data within a package **and** a user's authorization to perform each action. There is precedent for this in OneMAC [here](https://github.com/Enterprise-CMCS/macpro-onemac/blob/develop/services/app-api/getDetail.js#L89-L97).

We've implemented a similar approach in this PR with one exception: we have a designated endpoint `getPackageActions` for this. We don't pack them into the `item` response.

**Form Routing**
The action strings given from the API will map to a dynamic URL (i.e. `/action/:type`). To make use of React Router's dynamic segments, we have a single ActionFormIndex. We use that `:type` segment to return the proper UI from this component.

Dynamic segments are enumerated in the `Action` enum in `shared-types`

## Assorted Notes/Considerations/Learning

Set up a new action:
1. Add the action conditions to the `packageActionsForResult` function
2. Add the UI-friendly name to the `mapActionLabel` function
4. Return your action form component via `ActionFormIndex`
