### PR TITLE
feat(UI): Add query/hook for forms API to UI 

### DIFF
--- a/src/services/api/handlers/forms.ts
+++ b/src/services/api/handlers/forms.ts
@@ -9,12 +9,12 @@ export const forms = async (event: APIGatewayEvent) => {
     const formId = body.formId;
     const formVersion = body.formVersion;
 
-    // if (!formId) {
-    //   return response({
-    //     statusCode: 400,
-    //     body: JSON.stringify({ error: "File ID was not provided" }),
-    //   });
-    // }
+    if (!formId) {
+      return response({
+        statusCode: 400,
+        body: JSON.stringify({ error: "File ID was not provided" }),
+      });
+    }
 
     const filePath = getFilepathForIdAndVersion("testform", formVersion);
     const jsonData = await fs.promises.readFile(filePath, "utf-8");

--- a/src/services/api/handlers/forms.ts
+++ b/src/services/api/handlers/forms.ts
@@ -5,8 +5,6 @@ import { APIGatewayEvent } from "aws-lambda";
 
 export const forms = async (event: APIGatewayEvent) => {
   try {
-    const body = event.body ? JSON.parse(event.body) : {};
-    // const formId = body.formId;
     const formId = event.queryStringParameters.formId;
     const formVersion = event.queryStringParameters.formVersion;
 

--- a/src/services/api/handlers/forms.ts
+++ b/src/services/api/handlers/forms.ts
@@ -5,8 +5,10 @@ import { APIGatewayEvent } from "aws-lambda";
 
 export const forms = async (event: APIGatewayEvent) => {
   try {
+    console.info("*** event", event);
     const body = event.body ? JSON.parse(event.body) : {};
-    const formId = body.formId;
+    // const formId = body.formId;
+    const formId = "testForm";
     const formVersion = body.formVersion;
 
     if (!formId) {
@@ -16,7 +18,7 @@ export const forms = async (event: APIGatewayEvent) => {
       });
     }
 
-    const filePath = getFilepathForIdAndVersion("testform", formVersion);
+    const filePath = getFilepathForIdAndVersion(formId, formVersion);
     const jsonData = await fs.promises.readFile(filePath, "utf-8");
 
     if (!jsonData) {

--- a/src/services/api/handlers/forms.ts
+++ b/src/services/api/handlers/forms.ts
@@ -7,17 +7,17 @@ export const forms = async (event: APIGatewayEvent) => {
     const formId = body.formId;
     const formVersion = body.formVersion;
 
-    if (!formId) {
-      return {
-        statusCode: 400,
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ error: "File ID was not provided" }),
-      };
-    }
+    // if (!formId) {
+    //   return {
+    //     statusCode: 400,
+    //     headers: {
+    //       "Content-Type": "application/json",
+    //     },
+    //     body: JSON.stringify({ error: "File ID was not provided" }),
+    //   };
+    // }
 
-    const filePath = getFilepathForIdAndVersion(formId, formVersion);
+    const filePath = getFilepathForIdAndVersion("testform", formVersion);
     const jsonData = await fs.promises.readFile(filePath, "utf-8");
 
     if (!jsonData) {

--- a/src/services/api/handlers/forms.ts
+++ b/src/services/api/handlers/forms.ts
@@ -5,11 +5,10 @@ import { APIGatewayEvent } from "aws-lambda";
 
 export const forms = async (event: APIGatewayEvent) => {
   try {
-    console.info("*** event", event);
     const body = event.body ? JSON.parse(event.body) : {};
     // const formId = body.formId;
-    const formId = "testForm";
-    const formVersion = body.formVersion;
+    const formId = event.queryStringParameters.formId;
+    const formVersion = event.queryStringParameters.formVersion;
 
     if (!formId) {
       return response({

--- a/src/services/api/handlers/forms.ts
+++ b/src/services/api/handlers/forms.ts
@@ -1,3 +1,5 @@
+import { response } from "../libs/handler";
+
 import * as fs from "fs";
 import { APIGatewayEvent } from "aws-lambda";
 
@@ -7,46 +9,37 @@ export const forms = async (event: APIGatewayEvent) => {
     const formId = body.formId;
     const formVersion = body.formVersion;
 
-    // if (!formId) {
-    //   return {
-    //     statusCode: 400,
-    //     headers: {
-    //       "Content-Type": "application/json",
-    //     },
-    //     body: JSON.stringify({ error: "File ID was not provided" }),
-    //   };
-    // }
+    if (!formId) {
+      return response({
+        statusCode: 400,
+        body: JSON.stringify({ error: "File ID was not provided" }),
+      });
+    }
 
     const filePath = getFilepathForIdAndVersion("testform", formVersion);
     const jsonData = await fs.promises.readFile(filePath, "utf-8");
 
     if (!jsonData) {
-      return {
+      return response({
         statusCode: 404,
-        headers: {
-          "Content-Type": "application/json",
-        },
         body: JSON.stringify({
           error: "No file was found with provided formId and formVersion",
         }),
-      };
+      });
     }
     console.log(jsonData);
-    return {
+    return response({
       statusCode: 200,
-      headers: {
-        "Content-Type": "application/json",
-      },
       body: jsonData,
-    };
+    });
   } catch (error) {
     console.error("Error:", error);
-    return {
+    return response({
       statusCode: 500,
       body: JSON.stringify({
         error: error.message ? error.message : "Internal server error",
       }),
-    };
+    });
   }
 };
 

--- a/src/services/api/handlers/forms.ts
+++ b/src/services/api/handlers/forms.ts
@@ -9,12 +9,12 @@ export const forms = async (event: APIGatewayEvent) => {
     const formId = body.formId;
     const formVersion = body.formVersion;
 
-    if (!formId) {
-      return response({
-        statusCode: 400,
-        body: JSON.stringify({ error: "File ID was not provided" }),
-      });
-    }
+    // if (!formId) {
+    //   return response({
+    //     statusCode: 400,
+    //     body: JSON.stringify({ error: "File ID was not provided" }),
+    //   });
+    // }
 
     const filePath = getFilepathForIdAndVersion("testform", formVersion);
     const jsonData = await fs.promises.readFile(filePath, "utf-8");

--- a/src/services/api/serverless.yml
+++ b/src/services/api/serverless.yml
@@ -171,7 +171,7 @@ functions:
           path: /forms
           method: get
           cors: true
-          authorizer: aws_iam
+          # authorizer: aws_iam
     vpc:
       securityGroupIds:
         - Ref: SecurityGroup

--- a/src/services/api/serverless.yml
+++ b/src/services/api/serverless.yml
@@ -171,7 +171,7 @@ functions:
           path: /forms
           method: get
           cors: true
-          # authorizer: aws_iam
+          authorizer: aws_iam
     vpc:
       securityGroupIds:
         - Ref: SecurityGroup

--- a/src/services/ui/src/api/index.ts
+++ b/src/services/ui/src/api/index.ts
@@ -1,3 +1,4 @@
 export * from "./useSearch";
+export * from "./useGetForm";
 export * from "./useGetItem";
 export * from "./getAttachmentUrl";

--- a/src/services/ui/src/api/useGetForm.ts
+++ b/src/services/ui/src/api/useGetForm.ts
@@ -1,18 +1,20 @@
 import { useQuery } from "@tanstack/react-query";
 import { API } from "aws-amplify";
-import { OsHit, OsMainSourceItem, ReactQueryApiError } from "shared-types";
+import { ReactQueryApiError } from "shared-types";
 
-export const getForm = async (id: string): Promise<OsHit<OsMainSourceItem>> => {
-  const form = await API.post("os", "/forms", { body: { id } });
-
-  console.info("form", form);
+export const getForm = async (
+  formId: string,
+  formVersion?: string
+): Promise<any> => {
+  const form = await API.get("os", "/forms", {
+    queryStringParameters: { formId, formVersion },
+  });
 
   return form;
 };
 
-export const useGetForm = (id: string) => {
-  return useQuery<OsHit<OsMainSourceItem>, ReactQueryApiError>(
-    ["formID", id],
-    () => getForm(id)
+export const useGetForm = (formId: string, formVersion?: string) => {
+  return useQuery<any, ReactQueryApiError>(["formID"], () =>
+    getForm(formId, formVersion)
   );
 };

--- a/src/services/ui/src/api/useGetForm.ts
+++ b/src/services/ui/src/api/useGetForm.ts
@@ -1,4 +1,4 @@
-import { useQuery, useQueryOptions } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { API } from "aws-amplify";
 import { OsHit, OsMainSourceItem, ReactQueryApiError } from "shared-types";
 
@@ -13,9 +13,9 @@ export const getForm = async (
   return form;
 };
 
-export const useGetForm = (formId: string, formVersion?: number) => {
+export const useGetForm = (id: string, formVersion?: number) => {
   return useQuery<OsHit<OsMainSourceItem>, ReactQueryApiError>(
-    ["form", formId],
-    () => getForm(formId, formVersion)
+    ["formID", id],
+    () => getForm(id, formVersion)
   );
 };

--- a/src/services/ui/src/api/useGetForm.ts
+++ b/src/services/ui/src/api/useGetForm.ts
@@ -2,20 +2,17 @@ import { useQuery } from "@tanstack/react-query";
 import { API } from "aws-amplify";
 import { OsHit, OsMainSourceItem, ReactQueryApiError } from "shared-types";
 
-export const getForm = async (
-  formId: string,
-  formVersion?: number
-): Promise<OsHit<OsMainSourceItem>> => {
-  const form = await API.post("os", "/forms", {
-    body: { formId, formVersion },
-  });
+export const getForm = async (id: string): Promise<OsHit<OsMainSourceItem>> => {
+  const form = await API.post("os", "/forms", { body: { id } });
+
+  console.info("form", form);
 
   return form;
 };
 
-export const useGetForm = (id: string, formVersion?: number) => {
+export const useGetForm = (id: string) => {
   return useQuery<OsHit<OsMainSourceItem>, ReactQueryApiError>(
     ["formID", id],
-    () => getForm(id, formVersion)
+    () => getForm(id)
   );
 };

--- a/src/services/ui/src/api/useGetForm.ts
+++ b/src/services/ui/src/api/useGetForm.ts
@@ -14,7 +14,7 @@ export const getForm = async (
 };
 
 export const useGetForm = (formId: string, formVersion?: string) => {
-  return useQuery<any, ReactQueryApiError>(["formID"], () =>
+  return useQuery<any, ReactQueryApiError>([formId], () =>
     getForm(formId, formVersion)
   );
 };

--- a/src/services/ui/src/api/useGetForm.ts
+++ b/src/services/ui/src/api/useGetForm.ts
@@ -1,0 +1,21 @@
+import { useQuery, useQueryOptions } from "@tanstack/react-query";
+import { API } from "aws-amplify";
+import { OsHit, OsMainSourceItem, ReactQueryApiError } from "shared-types";
+
+export const getForm = async (
+  formId: string,
+  formVersion?: number
+): Promise<OsHit<OsMainSourceItem>> => {
+  const form = await API.post("os", "/forms", {
+    body: { formId, formVersion },
+  });
+
+  return form;
+};
+
+export const useGetForm = (formId: string, formVersion?: number) => {
+  return useQuery<OsHit<OsMainSourceItem>, ReactQueryApiError>(
+    ["form", formId],
+    () => getForm(formId, formVersion)
+  );
+};

--- a/src/services/ui/src/api/useGetForm.ts
+++ b/src/services/ui/src/api/useGetForm.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { API } from "aws-amplify";
 import { ReactQueryApiError } from "shared-types";
 
+// TODO: Use the Document type here once it is in a shared location.
 export const getForm = async (
   formId: string,
   formVersion?: string

--- a/src/services/ui/src/pages/form/index.tsx
+++ b/src/services/ui/src/pages/form/index.tsx
@@ -1,6 +1,5 @@
 import { useForm } from "react-hook-form";
 import { Button, Form } from "@/components/Inputs";
-import { useGetForm } from "@/api/useGetForm";
 import { RHFDocument } from "@/components/RHF";
 import { ABP1 } from "./proto";
 import { documentInitializer } from "@/components/RHF";
@@ -21,13 +20,8 @@ export function ExampleForm() {
     }
   );
 
-  const { data, isLoading, error } = useGetForm("testform");
-  console.info(data, isLoading, error);
-
   return (
     <div className="max-w-screen-xl mx-auto p-4 py-8 lg:px-8">
-      {isLoading}
-
       <Form {...form}>
         <form onSubmit={onSubmit} className="space-y-6">
           <RHFDocument document={ABP1} {...form} />

--- a/src/services/ui/src/pages/form/index.tsx
+++ b/src/services/ui/src/pages/form/index.tsx
@@ -1,6 +1,6 @@
 import { useForm } from "react-hook-form";
 import { Button, Form } from "@/components/Inputs";
-
+import { useGetForm } from "@/api/useGetForm";
 import { RHFDocument } from "@/components/RHF";
 import { ABP1 } from "./proto";
 import { documentInitializer } from "@/components/RHF";
@@ -21,8 +21,13 @@ export function ExampleForm() {
     }
   );
 
+  const { data, isLoading, error } = useGetForm("testform");
+  console.info(data, isLoading, error);
+
   return (
     <div className="max-w-screen-xl mx-auto p-4 py-8 lg:px-8">
+      {isLoading}
+
       <Form {...form}>
         <form onSubmit={onSubmit} className="space-y-6">
           <RHFDocument document={ABP1} {...form} />


### PR DESCRIPTION
## Purpose

This allows the UI to receive form data from the API

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-25508

## Approach

It adds a `useGetForm` method that submits a form ID and form version and receives a JSON object for the requested form.

## Assorted Notes/Considerations/Learning

We wrapped the returned data in the `response` wrapper to handle CORS issues, etc.