### PR TITLE
feat(package actions): Update Enable/Disable RAI Withdraw UI to use ConfirmationModal

### DIFF
--- a/src/services/ui/src/components/Modal/ConfirmationModal.tsx
+++ b/src/services/ui/src/components/Modal/ConfirmationModal.tsx
@@ -21,7 +21,8 @@ type Props = {
   acceptButtonVisible?: boolean;
 };
 
-export function Modal({
+/** A modal with optional Cancel and Accept buttons */
+export function ConfirmationModal({
   open,
   description,
   title,

--- a/src/services/ui/src/pages/form/medicaid-form.tsx
+++ b/src/services/ui/src/pages/form/medicaid-form.tsx
@@ -14,7 +14,7 @@ import {
   LoadingSpinner,
   BreadCrumbs,
 } from "@/components";
-import { Modal } from "@/components/Modal/Modal";
+import { ConfirmationModal } from "@/components/Modal/ConfirmationModal";
 import { FAQ_TARGET, ROUTES } from "@/routes";
 import { getUserStateCodes } from "@/utils";
 import { NEW_SUBMISSION_CRUMBS } from "@/pages/create/create-breadcrumbs";
@@ -385,7 +385,7 @@ export const MedicaidForm = () => {
             </I.Button>
 
             {/* Success Modal */}
-            <Modal
+            <ConfirmationModal
               open={successModalIsOpen}
               onAccept={() => {
                 setSuccessModalIsOpen(false);
@@ -404,7 +404,7 @@ export const MedicaidForm = () => {
             />
 
             {/* Cancel Modal */}
-            <Modal
+            <ConfirmationModal
               open={cancelModalIsOpen}
               onAccept={() => {
                 setCancelModalIsOpen(false);


### PR DESCRIPTION
## Purpose

This PR gets rid of our debounced reload on the ToggleRAIResponseWithdraw form page and replaces it with a ConfirmationModal.

#### Linked Issues to Close

N/A

## Approach

N/A

## Assorted Notes/Considerations/Learning

N/A
