### PR TITLE
remove actionType from SPA tab filters

### DIFF
--- a/src/services/ui/src/components/Opensearch/Filtering/useFilterDrawer.ts
+++ b/src/services/ui/src/components/Opensearch/Filtering/useFilterDrawer.ts
@@ -77,6 +77,25 @@ export const useFilterDrawer = () => {
     setAccordionValues(updateAccordions);
   }, [params.state.filters, drawerOpen]);
 
+  // remove action type from SPAs filter options
+  useEffect(() => {
+    if (params.state.tab === "spas") {
+      setFilters((s) => {
+        const newState = { ...s };
+        delete newState["actionType.keyword"];
+        return newState;
+      });
+    } else {
+      setFilters((s) => {
+        return {
+          ...s,
+          "actionType.keyword":
+            Consts.FILTER_GROUPS(user)["actionType.keyword"],
+        };
+      });
+    }
+  }, [params.state.tab]);
+
   const aggs = useMemo(() => {
     return Object.entries(_aggs || {}).reduce((STATE, [KEY, AGG]) => {
       return {

--- a/src/services/ui/src/pages/dashboard/Lists/spas/consts.tsx
+++ b/src/services/ui/src/pages/dashboard/Lists/spas/consts.tsx
@@ -39,15 +39,6 @@ export const TABLE_COLUMNS = (props?: {
     cell: (data) => removeUnderscoresAndCapitalize(data.planType),
   },
   {
-    field: "actionType.keyword",
-    label: "Action Type",
-    visible: false,
-    cell: (data) =>
-      data.actionType
-        ? LABELS[data.actionType as keyof typeof LABELS] || data.actionType
-        : BLANK_VALUE,
-  },
-  {
     field: props?.isCms ? "cmsStatus.keyword" : "stateStatus.keyword",
     label: "Status",
     cell: (data) =>


### PR DESCRIPTION
## Purpose

Removes action type from filter options and table category options  for the SPA tab of the opensearch table.

#### Linked Issues to Close

[ticket oy2-26360](https://qmacbis.atlassian.net/browse/OY2-26360?atlOrigin=eyJpIjoiZWJkNTUzMDdmMGRkNGQwZTkyYTUwYjdkNjZiMjI5NTUiLCJwIjoiaiJ9)

