### PR TITLE
fix(setupIndex):  fix case where index already exists

### DIFF
--- a/src/libs/opensearch-lib.ts
+++ b/src/libs/opensearch-lib.ts
@@ -119,19 +119,27 @@ export async function getItem(host:string, index:string, id:string){
   }
 }
 
-export async function createIndexIfNotExists(host:string, index:string) {
+export async function indexExists(host:string, index:string) {
   client = client || (await getClient(host));
   try {
       const indexExists = await client.indices.exists({ index, });
-      if (!indexExists.body) {
-          const createResponse = await client.indices.create({
-              index,
-          });
-
-          console.log('Index created:', createResponse);
+      if (indexExists.body) {
+          return true;
       } else {
-          console.log('Index already exists.');
+          return false;
       }
+  } catch (error) {
+      console.error('Error creating index:', error);
+      throw error;
+  }
+}
+
+export async function createIndex(host:string, index:string) {
+  client = client || (await getClient(host));
+  try {
+    const createResponse = await client.indices.create({
+        index,
+    });
   } catch (error) {
       console.error('Error creating index:', error);
       throw error;

--- a/src/services/data/handlers/index.ts
+++ b/src/services/data/handlers/index.ts
@@ -26,23 +26,24 @@ export const handler: Handler = async (event) => {
 
 async function manageIndex() {
   try {
-    const createIndexReponse = await os.createIndexIfNotExists(
-      process.env.osDomain,
-      "main"
-    );
-    console.log(createIndexReponse);
-
-    const updateFieldMappingResponse = await os.updateFieldMapping(
-      process.env.osDomain,
-      "main",
-      {
-        rais: {
-          type: "object",
-          enabled: false,
-        },
-      }
-    );
-    console.log(updateFieldMappingResponse);
+    if (!(await os.indexExists(process.env.osDomain, "main"))) {
+      const createIndexReponse = await os.createIndex(
+        process.env.osDomain,
+        "main"
+      );
+      console.log(createIndexReponse);
+      const updateFieldMappingResponse = await os.updateFieldMapping(
+        process.env.osDomain,
+        "main",
+        {
+          rais: {
+            type: "object",
+            enabled: false,
+          },
+        }
+      );
+      console.log(updateFieldMappingResponse);
+    }
   } catch (error) {
     console.log(error);
     throw "ERROR:  Error occured during index management.";


### PR DESCRIPTION
## Purpose

This changeset fixes a bug seen during re-deployment of existing environments with the new setupIndex code.

#### Linked Issues to Close

Bug against RAI Issue / Withdraw

## Approach

While we were guarding against attempting to create the index if it already exists, we were not guarding against attempting to update the field mapping if one already existed.  This is an edge case, and is handled with a reindex, so we will stick the 'update field mapping' inside the 'if exists' guard.

## Assorted Notes/Considerations/Learning

None