### PR TITLE
fix(idm home page):  Make the href to idm home page a parameter

### DIFF
--- a/src/services/ui/serverless.yml
+++ b/src/services/ui/serverless.yml
@@ -20,6 +20,7 @@ custom:
   project: ${env:PROJECT}
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
+  idmInfo: ${ssm:/aws/reference/secretsmanager/${self:custom.project}/${sls:stage}/idmInfo, ""}
   serverlessTerminationProtection:
     stages:
       - master
@@ -44,6 +45,7 @@ custom:
         VITE_COGNITO_USER_POOL_CLIENT_DOMAIN=${param:CognitoUserPoolClientDomain}
         VITE_COGNITO_REDIRECT_SIGNIN=${param:ApplicationEndpointUrl}
         VITE_COGNITO_REDIRECT_SIGNOUT=${param:ApplicationEndpointUrl}
+        VITE_IDM_HOME_URL=${self:custom.idmInfo.home_url, "https://test.home.idm.cms.gov"}
         """ > .env.local
         yarn build
       deploy:finalize: |

--- a/src/services/ui/src/components/UsaBanner/index.tsx
+++ b/src/services/ui/src/components/UsaBanner/index.tsx
@@ -6,6 +6,7 @@ import UsFlag from "@/assets/us_flag_small.png";
 import { useMediaQuery } from "@/hooks";
 import { useUserContext } from "../Context/userContext";
 import { useLoaderData } from "react-router-dom";
+import config from "@/config";
 
 export const UsaBanner = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -135,7 +136,7 @@ const NoRole = () => {
         You do not have access to view the entire application.{" "}
         <a
           rel="noreferrer"
-          href="https://test.home.idm.cms.gov/"
+          href={config.idm.home_url}
           target="_blank"
           className="text-blue-600 inline  no-underline"
         >

--- a/src/services/ui/src/config.tsx
+++ b/src/services/ui/src/config.tsx
@@ -12,6 +12,9 @@ const config = {
     REDIRECT_SIGNIN: import.meta.env.VITE_COGNITO_REDIRECT_SIGNIN,
     REDIRECT_SIGNOUT: import.meta.env.VITE_COGNITO_REDIRECT_SIGNOUT,
   },
+  idm: {
+    home_url: import.meta.env.VITE_IDM_HOME_URL,
+  },
 };
 
 export default config;


### PR DESCRIPTION
## Purpose

This avoids a static url to the idm homepage, although we do keep a static (dev) default.

#### Linked Issues to Close

bug against https://qmacbis.atlassian.net/browse/OY2-25702

## Approach

secrets manager pattern

## Assorted Notes/Considerations/Learning

none