### PR TITLE
fix(auth):  Do not allow cognito auth for production

### DIFF
--- a/src/services/auth/serverless.yml
+++ b/src/services/auth/serverless.yml
@@ -83,6 +83,11 @@ resources:
         - Fn::Equals:
             - ""
             - ${self:custom.idmInfo.oidc_issuer, ""}
+    BackWithCognito:
+      Fn::Not:
+        - Fn::Equals:
+            - ${sls:stage}
+            - production
   Resources:
     CognitoUserPool:
       Type: AWS::Cognito::UserPool
@@ -157,7 +162,10 @@ resources:
           - ${param:ApplicationEndpointUrl}
           - http://localhost:5000/
         SupportedIdentityProviders:
-          - COGNITO
+          - Fn::If:
+              - BackWithCognito
+              - COGNITO
+              - !Ref AWS::NoValue
           - Fn::If:
               - BackWithIDM
               - !Ref UserPoolIdentityProviderIDM


### PR DESCRIPTION
## Purpose

This disables cognito for the production environment.

#### Linked Issues to Close

None

## Approach

Cloudformation condition.

## Assorted Notes/Considerations/Learning

None