### PR TITLE
fix(downloadall):  Fix a bug causing failure to dwonload all

### DIFF
--- a/src/services/api/handlers/getAttachmentUrl.ts
+++ b/src/services/api/handlers/getAttachmentUrl.ts
@@ -51,8 +51,8 @@ export const handler = async (event: APIGatewayEvent) => {
     const allAttachments = [
       ...(results.hits.hits[0]._source.attachments || []),
       ...Object.values(results.hits.hits[0]._source.rais).flatMap((entry) => [
-        ...(entry.request.attachments || []),
-        ...(entry.response.attachments || []),
+        ...(entry.request?.attachments || []),
+        ...(entry.response?.attachments || []),
       ]),
     ];
 


### PR DESCRIPTION
## Purpose

This changeset fixes a bug where downloadall was broken in some scenarios where RAIs were in flight.

#### Linked Issues to Close

Closes https://qmacbis.atlassian.net/browse/OY2-26461

## Approach

A simple check if request or response exists before calling on their possible attachments fixed the issue.

## Assorted Notes/Considerations/Learning

None