### PR TITLE
fix(multi upload):  Refactor submission service fix

### DIFF
--- a/src/services/ui/src/api/submissionService.ts
+++ b/src/services/ui/src/api/submissionService.ts
@@ -1,15 +1,21 @@
 import { API } from "aws-amplify";
-import {OnemacAttachmentSchema, Authority, ReactQueryApiError, Action, attachmentTitleMap} from "shared-types";
-import {buildActionUrl, SubmissionServiceEndpoint} from "@/lib";
-import {OneMacUser} from "@/api/useGetUser";
-import {useMutation, UseMutationOptions} from "@tanstack/react-query";
+import {
+  OnemacAttachmentSchema,
+  Authority,
+  ReactQueryApiError,
+  Action,
+  attachmentTitleMap,
+} from "shared-types";
+import { buildActionUrl, SubmissionServiceEndpoint } from "@/lib";
+import { OneMacUser } from "@/api/useGetUser";
+import { useMutation, UseMutationOptions } from "@tanstack/react-query";
 
 type SubmissionServiceParameters<T> = {
-  data: T,
-  endpoint: SubmissionServiceEndpoint
-  user: OneMacUser | undefined,
-  authority?: Authority
-}
+  data: T;
+  endpoint: SubmissionServiceEndpoint;
+  user: OneMacUser | undefined;
+  authority?: Authority;
+};
 type SubmissionServiceResponse = {
   body: {
     message: string;
@@ -21,23 +27,28 @@ type PreSignedURL = {
   bucket: string;
 };
 type UploadRecipe = PreSignedURL & {
-  data: File[],
-  title: string
-}
-type AttachmentsSchema = Record<string, File[] | undefined>
+  data: File;
+  title: string;
+  name: string;
+};
 
 /** Pass in an array of UploadRecipes and get a back-end compatible object
  * to store attachment data */
 const buildAttachmentObject = (
   recipes: UploadRecipe[]
 ): OnemacAttachmentSchema[] => {
-  return recipes.map((r) => r.data.map(f => ({
-    key: r.key,
-    filename: f.name,
-    title: r.title,
-    bucket: r.bucket,
-    uploadDate: Date.now()
-  }) satisfies OnemacAttachmentSchema)).flat();
+  return recipes
+    .map(
+      (r) =>
+        ({
+          key: r.key,
+          filename: r.name,
+          title: r.title,
+          bucket: r.bucket,
+          uploadDate: Date.now(),
+        } as OnemacAttachmentSchema)
+    )
+    .flat();
 };
 
 /** Builds the payload for submission based on which variant a developer has
@@ -47,14 +58,15 @@ const buildSubmissionPayload = <T extends Record<string, unknown>>(
   user: OneMacUser | undefined,
   endpoint: SubmissionServiceEndpoint,
   authority?: string,
-  attachments?: UploadRecipe[],
+  attachments?: UploadRecipe[]
 ) => {
   const userDetails = {
     submitterEmail: user?.user?.email ?? "N/A",
     submitterName:
-      `${user?.user?.given_name} ${user?.user?.family_name}` ?? "N/A"
+      `${user?.user?.given_name} ${user?.user?.family_name}` ?? "N/A",
   };
-  const seaToolFriendlyTimestamp = Math.floor(new Date().getTime() / 1000) * 1000; // Truncating to match seatool
+  const seaToolFriendlyTimestamp =
+    Math.floor(new Date().getTime() / 1000) * 1000; // Truncating to match seatool
 
   switch (endpoint) {
     case "/submit":
@@ -72,14 +84,14 @@ const buildSubmissionPayload = <T extends Record<string, unknown>>(
         ...data,
         ...userDetails,
         requestedDate: seaToolFriendlyTimestamp,
-        attachments: attachments ? buildAttachmentObject(attachments) : null
+        attachments: attachments ? buildAttachmentObject(attachments) : null,
       };
     case buildActionUrl(Action.RESPOND_TO_RAI):
       return {
         ...data,
         ...userDetails,
         responseDate: seaToolFriendlyTimestamp,
-        attachments: attachments ? buildAttachmentObject(attachments) : null
+        attachments: attachments ? buildAttachmentObject(attachments) : null,
       };
     case buildActionUrl(Action.ENABLE_RAI_WITHDRAW):
     case buildActionUrl(Action.DISABLE_RAI_WITHDRAW):
@@ -87,7 +99,7 @@ const buildSubmissionPayload = <T extends Record<string, unknown>>(
       return {
         ...data,
         ...userDetails,
-        attachments: attachments ? buildAttachmentObject(attachments) : null
+        attachments: attachments ? buildAttachmentObject(attachments) : null,
       };
   }
 };
@@ -97,32 +109,59 @@ export const submit = async <T extends Record<string, unknown>>({
   data,
   endpoint,
   user,
-  authority
+  authority,
 }: SubmissionServiceParameters<T>): Promise<SubmissionServiceResponse> => {
   if (data?.attachments) {
-    const attachments = data.attachments as AttachmentsSchema;
-    const validFilesetKeys = Object.keys(attachments).filter(key => attachments[key] !== undefined);
-    // TODO: Can this be a GET instead of POST w/ empty body
-    const preSignedURLs: PreSignedURL[] = await Promise.all(validFilesetKeys.map(() =>
-      API.post("os", "/getUploadUrl", {
-        body: {},
-      })
-    ));
-    const uploadRecipes: UploadRecipe[] = preSignedURLs.map((obj, idx) => ({
-      ...obj,
-      data: attachments[validFilesetKeys[idx]] as File[],
-      // Add your attachments object key and file label value to the attachmentTitleMap
-      // for this transform to work. Else the title will just be the object key.
-      title: attachmentTitleMap?.[validFilesetKeys[idx]] || validFilesetKeys[idx]
-    }));
+    const validAttachmentSets = Object.fromEntries(
+      Object.entries(data.attachments).filter(([, value]) => value !== null)
+    );
+    const preSignedURLs: PreSignedURL[] = await Promise.all(
+      Object.values(validAttachmentSets)
+        .flat()
+        .map(() =>
+          API.post("os", "/getUploadUrl", {
+            body: {},
+          })
+        )
+    );
+
+    const uploadRecipes: UploadRecipe[] = [];
+    let idx = 0;
+    for (const key in validAttachmentSets) {
+      if (Array.isArray(validAttachmentSets[key])) {
+        // Iterate over each object in the array
+        validAttachmentSets[key].forEach((obj: File) => {
+          // Add a new key "title" with the value of the key
+          uploadRecipes.push({
+            data: obj,
+            title: attachmentTitleMap[key] || key,
+            ...preSignedURLs[idx],
+            name: obj.name,
+          });
+          idx++;
+        });
+      }
+    }
+
     // Upload attachments
-    await Promise.all(uploadRecipes.map(({url, data}) => data.map((file) => fetch(url, {
-      body: file,
-      method: "PUT",
-    }))));
+    await Promise.all(
+      uploadRecipes.map(({ url, data }) => {
+        fetch(url, {
+          body: data,
+          method: "PUT",
+        });
+      })
+    );
+
     // Submit form data
     return await API.post("os", endpoint, {
-      body: buildSubmissionPayload(data, user, endpoint, authority, uploadRecipes),
+      body: buildSubmissionPayload(
+        data,
+        user,
+        endpoint,
+        authority,
+        uploadRecipes
+      ),
     });
   } else {
     // Submit form data
@@ -138,8 +177,9 @@ export const submit = async <T extends Record<string, unknown>>({
 export const useSubmissionService = <T extends Record<string, unknown>>(
   config: SubmissionServiceParameters<T>,
   options?: UseMutationOptions<SubmissionServiceResponse, ReactQueryApiError>
-) => useMutation<SubmissionServiceResponse, ReactQueryApiError>(
-  ["submit"],
-  () => submit(config),
-  options
-);
+) =>
+  useMutation<SubmissionServiceResponse, ReactQueryApiError>(
+    ["submit"],
+    () => submit(config),
+    options
+  );

--- a/src/services/ui/src/api/submissionService.ts
+++ b/src/services/ui/src/api/submissionService.ts
@@ -120,7 +120,7 @@ export const submit = async <T extends Record<string, unknown>>({
 }: SubmissionServiceParameters<T>): Promise<SubmissionServiceResponse> => {
   if (data?.attachments) {
     // Drop nulls and non arrays
-    const validAttachmentSets = Object.entries(data.attachments)
+    const attachments = Object.entries(data.attachments)
       .filter(([, val]) => val !== undefined && (val as File[]).length)
       .map(([key, value]) => {
         return (value as File[]).map((file) => ({
@@ -129,28 +129,25 @@ export const submit = async <T extends Record<string, unknown>>({
         }));
       })
       .flat();
-
     // Generate a presigned url for each attachment
     const preSignedURLs: PreSignedURL[] = await Promise.all(
-      validAttachmentSets.map(() =>
+      attachments.map(() =>
         API.post("os", "/getUploadUrl", {
           body: {},
         })
       )
     );
-
     // For each attachment, add name, title, and a presigned url... and push to uploadRecipes
     const uploadRecipes: UploadRecipe[] = preSignedURLs.map((obj, idx) => ({
       ...obj, // Spreading the presigned url
-      data: validAttachmentSets[idx].file, // The attachment file object
+      data: attachments[idx].file, // The attachment file object
       // Add your attachments object key and file label value to the attachmentTitleMap
       // for this transform to work. Else the title will just be the object key.
       title:
-        attachmentTitleMap?.[validAttachmentSets[idx].attachmentKey] ||
-        validAttachmentSets[idx].attachmentKey,
-      name: validAttachmentSets[idx].attachmentKey,
+        attachmentTitleMap?.[attachments[idx].attachmentKey] ||
+        attachments[idx].attachmentKey,
+      name: attachments[idx].file.name,
     }));
-
     // Upload attachments
     await Promise.all(
       uploadRecipes.map(({ url, data }) => {
@@ -160,7 +157,6 @@ export const submit = async <T extends Record<string, unknown>>({
         });
       })
     );
-
     // Submit form data
     return await API.post("os", endpoint, {
       body: buildSubmissionPayload(

--- a/src/services/ui/src/api/submissionService.ts
+++ b/src/services/ui/src/api/submissionService.ts
@@ -120,37 +120,35 @@ export const submit = async <T extends Record<string, unknown>>({
 }: SubmissionServiceParameters<T>): Promise<SubmissionServiceResponse> => {
   if (data?.attachments) {
     // Drop nulls and non arrays
-    const validAttachmentSets = Object.fromEntries(
-      Object.entries(data.attachments).filter(([, value]) => value !== null)
-    );
+    const validAttachmentSets = Object.entries(data.attachments)
+      .filter(([, val]) => val !== undefined && (val as File[]).length)
+      .map(([key, value]) => {
+        return (value as File[]).map((file) => ({
+          attachmentKey: key,
+          file: file,
+        }));
+      })
+      .flat();
 
     // Generate a presigned url for each attachment
     const preSignedURLs: PreSignedURL[] = await Promise.all(
-      Object.values(validAttachmentSets)
-        .flat()
-        .map(() =>
-          API.post("os", "/getUploadUrl", {
-            body: {},
-          })
-        )
+      validAttachmentSets.map(() =>
+        API.post("os", "/getUploadUrl", {
+          body: {},
+        })
+      )
     );
 
     // For each attachment, add name, title, and a presigned url... and push to uploadRecipes
-    const uploadRecipes: UploadRecipe[] = [];
-    let idx = 0;
-    for (const key in validAttachmentSets) {
-      if (Array.isArray(validAttachmentSets[key])) {
-        validAttachmentSets[key].forEach((obj: File) => {
-          uploadRecipes.push({
-            data: obj,
-            name: obj.name,
-            title: attachmentTitleMap[key] || key,
-            ...preSignedURLs[idx],
-          });
-          idx++;
-        });
-      }
-    }
+    const uploadRecipes: UploadRecipe[] = preSignedURLs.map((obj, idx) => ({
+      ...obj, // Spreading the presigned url
+      data: validAttachmentSets[idx].file, // The attachment file object
+      // Add your attachments object key and file label value to the attachmentTitleMap
+      // for this transform to work. Else the title will just be the object key.
+      title:
+        attachmentTitleMap?.[validAttachmentSets[idx].attachmentKey] ||
+        validAttachmentSets[idx].attachmentKey,
+      name: validAttachmentSets[idx].attachmentKey,
 
     // Upload attachments
     await Promise.all(

--- a/src/services/ui/src/api/submissionService.ts
+++ b/src/services/ui/src/api/submissionService.ts
@@ -149,6 +149,7 @@ export const submit = async <T extends Record<string, unknown>>({
         attachmentTitleMap?.[validAttachmentSets[idx].attachmentKey] ||
         validAttachmentSets[idx].attachmentKey,
       name: validAttachmentSets[idx].attachmentKey,
+    }));
 
     // Upload attachments
     await Promise.all(


### PR DESCRIPTION
## Purpose

This changeset fixes an issue whereby multiple uploads of the same type were not handled correctly.

#### Linked Issues to Close

None.

## Approach

This was found on a dev branch while looking into a finding by Padma.  It was found regarding RAI attachments, but it can be seen on dev for new submissions as well. 

Looking into it, the submission service looked to not handle having more than one of each file type.  For example, if you attached two files for 'Other' attachments, they would be reduced to just one object within the service, with only one S3 key, and ultimately only one file would be stored in S3.  Looking at package details, you would see the files that were uploaded, but clicking each of a given type would yield the same single file repeatedly.

The approach kept the service ins/outs the same, and modified upload recipe to hold a single file rather than an array.  Initial submission attachments and rai lifecycle attachments are working as intended.

## Assorted Notes/Considerations/Learning

None