### PR TITLE
fix(package-actions): Wrap `RespondToRai` with package action checks

### DIFF
--- a/src/services/ui/src/pages/actions/RespondToRai.tsx
+++ b/src/services/ui/src/pages/actions/RespondToRai.tsx
@@ -19,6 +19,7 @@ import { useGetUser } from "@/api/useGetUser";
 import { submit } from "@/api/submissionService";
 import { useGetItem } from "@/api";
 import { buildActionUrl } from "@/lib";
+import { PackageActionForm } from "@/pages/actions/PackageActionForm";
 
 const formSchema = z.object({
   additionalInformation: z.string().max(4000).optional(),
@@ -60,7 +61,7 @@ const FormDescriptionText = () => {
   );
 };
 
-export const RespondToRai = () => {
+export const RespondToRaiForm = () => {
   const { id, type } = useParams<{
     id: string;
     type: Action;
@@ -316,3 +317,9 @@ export const RespondToRai = () => {
     </SimplePageContainer>
   );
 };
+
+export const RespondToRai = () => (
+  <PackageActionForm>
+    <RespondToRaiForm />
+  </PackageActionForm>
+);


### PR DESCRIPTION
## Purpose

This PR wraps an action form we missed during creation with the component that checks auth for an action.

#### Linked Issues to Close

N/A

## Approach

N/A

## Assorted Notes/Considerations/Learning

Can be tested by arriving at any action url (i.e. `/action/{packageId}/{actionType}`), for a package that is not authorized to respond to an RAI yet, and replacing the `actionType` with `respond-to-rai` 

<img width="800" alt="Screen Shot 2023-12-21 at 9 23 49 AM" src="https://github.com/Enterprise-CMCS/macpro-mako/assets/4022304/1ad1fdc3-f1cc-407a-a712-0036f5d95587">
