### PR TITLE
fix(breadcrumbs):  Fix breadcrumb posture for issue and responding to…

### DIFF
--- a/src/services/ui/src/pages/actions/IssueRai.tsx
+++ b/src/services/ui/src/pages/actions/IssueRai.tsx
@@ -4,13 +4,7 @@ import { useState } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { DETAILS_AND_ACTIONS_CRUMBS } from "@/pages/actions/actions-breadcrumbs";
-import {
-  SimplePageContainer,
-  Alert,
-  LoadingSpinner,
-  BreadCrumbs,
-} from "@/components";
+import { SimplePageContainer, Alert, LoadingSpinner } from "@/components";
 import { ConfirmationModal } from "@/components/Modal/ConfirmationModal";
 import { FAQ_TARGET } from "@/routes";
 import { Link, useNavigate } from "react-router-dom";
@@ -19,6 +13,7 @@ import { useGetUser } from "@/api/useGetUser";
 import { useGetItem } from "@/api";
 import { submit } from "@/api/submissionService";
 import { buildActionUrl } from "@/lib";
+import { PackageActionForm } from "@/pages/actions/PackageActionForm";
 
 const formSchema = z.object({
   additionalInformation: z.string().max(4000),
@@ -62,7 +57,7 @@ const FormDescriptionText = () => {
   );
 };
 
-export const RaiIssue = () => {
+export const RaiIssueForm = () => {
   const { id, type } = useParams<{
     id: string;
     type: Action;
@@ -97,12 +92,6 @@ export const RaiIssue = () => {
 
   return (
     <SimplePageContainer>
-      <BreadCrumbs
-        options={DETAILS_AND_ACTIONS_CRUMBS({
-          id: id || "",
-          action: Action.ISSUE_RAI,
-        })}
-      />
       <I.Form {...form}>
         <form
           onSubmit={form.handleSubmit(handleSubmit)}
@@ -316,3 +305,9 @@ export const RaiIssue = () => {
     </SimplePageContainer>
   );
 };
+
+export const RaiIssue = () => (
+  <PackageActionForm>
+    <RaiIssueForm />
+  </PackageActionForm>
+);

--- a/src/services/ui/src/pages/actions/RespondToRai.tsx
+++ b/src/services/ui/src/pages/actions/RespondToRai.tsx
@@ -4,13 +4,7 @@ import { useState } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { DETAILS_AND_ACTIONS_CRUMBS } from "@/pages/actions/actions-breadcrumbs";
-import {
-  SimplePageContainer,
-  Alert,
-  LoadingSpinner,
-  BreadCrumbs,
-} from "@/components";
+import { SimplePageContainer, Alert, LoadingSpinner } from "@/components";
 import { ConfirmationModal } from "@/components/Modal/ConfirmationModal";
 import { FAQ_TARGET } from "@/routes";
 import { Link, useNavigate } from "react-router-dom";
@@ -96,12 +90,6 @@ export const RespondToRaiForm = () => {
 
   return (
     <SimplePageContainer>
-      <BreadCrumbs
-        options={DETAILS_AND_ACTIONS_CRUMBS({
-          id: id || "",
-          action: Action.RESPOND_TO_RAI,
-        })}
-      />
       <I.Form {...form}>
         <form
           onSubmit={form.handleSubmit(handleSubmit)}


### PR DESCRIPTION
## Purpose

Fixes a duplicate breadcrumb bug on respond to rai.

#### Linked Issues to Close

Closes https://qmacbis.atlassian.net/browse/OY2-26857

## Approach

For respond to RAI, since the breadcrumbs are now handled by the form wrapper, the breadcrumbs were simply removed.

While working this, I noticed issue rai didnt yet have the wrapper... so I added the wrapper and removed the breadcrumbs

After changes:
<img width="1125" alt="Screen Shot 2023-12-21 at 11 28 24 AM" src="https://github.com/Enterprise-CMCS/macpro-mako/assets/48921055/dc175d11-a5b3-4029-bba0-3f9722321459">
<img width="1201" alt="Screen Shot 2023-12-21 at 11 28 47 AM" src="https://github.com/Enterprise-CMCS/macpro-mako/assets/48921055/ffabd82f-e04b-4ac9-b3f1-75a94d29c296">

## Assorted Notes/Considerations/Learning

None.