### PR TITLE
fix(substatus):  Make substatus disappear after withdrawing the rai

### DIFF
--- a/src/packages/shared-types/action-types/withdraw-rai.ts
+++ b/src/packages/shared-types/action-types/withdraw-rai.ts
@@ -17,6 +17,7 @@ export type RaiWithdraw = z.infer<typeof raiWithdrawSchema>;
 export const transformRaiWithdraw = (id: string) => {
   return raiWithdrawSchema.transform((data) => ({
     id,
+    raiWithdrawEnabled: false,
     rais: {
       [data.requestedDate]: {
         withdraw: {


### PR DESCRIPTION
## Purpose

Bug against https://github.com/Enterprise-CMCS/macpro-mako/pull/280
This does the same, resetting withdraw rai response enabled, but for withdrawing the rai response.  The pr above was to reset enable/disable rai withdraw after the package was withdrawn.

#### Linked Issues to Close

Bug against https://qmacbis.atlassian.net/browse/OY2-26858

## Approach

We use the main index's transform for the withdraw rai event to set the enable boolean to false.

Before withdraw of response:
<img width="1489" alt="Screen Shot 2023-12-22 at 4 32 37 PM" src="https://github.com/Enterprise-CMCS/macpro-mako/assets/48921055/4b15acb2-f66b-48b4-b6d7-368b44e3cc57">

After withdraw of response:
<img width="1510" alt="Screen Shot 2023-12-22 at 4 32 54 PM" src="https://github.com/Enterprise-CMCS/macpro-mako/assets/48921055/d41f76bc-55cf-40de-86ab-4d89e7e2a6e6">


## Assorted Notes/Considerations/Learning

None