### PR TITLE
feat(ABP 3) Adds ABP 3 form to OneMAC (Mako)

### DIFF
--- a/src/services/api/layers/ABP3/v1.ts
+++ b/src/services/api/layers/ABP3/v1.ts
@@ -34,6 +34,16 @@ const ABP3: FormSchema = {
               name: "benefit_package_name",
               label: "Benefit package name",
               rules: { required: "* Required" },
+              dependency: {
+                conditions: [
+                  {
+                    name: "benefit_package_details",
+                    type: "expectedValue",
+                    expectedValue: "benchmark_creating",
+                  },
+                ],
+                effect: { type: "show" },
+              },
             },
           ],
         },

--- a/src/services/api/layers/ABP3/v1.ts
+++ b/src/services/api/layers/ABP3/v1.ts
@@ -347,7 +347,6 @@ const ABP3: FormSchema = {
           slots: [
             {
               rhf: "Textarea",
-              label: "Additional information",
               name: "additional_information",
             },
           ],

--- a/src/services/api/layers/ABP3/v1.ts
+++ b/src/services/api/layers/ABP3/v1.ts
@@ -2,7 +2,7 @@ import { FormSchema } from "shared-types";
 
 const ABP3: FormSchema = {
   header:
-    "APB 3: Selection of benchmark benefit package or benchmark-equivalent benefit package",
+    "ABP 3: Selection of benchmark benefit package or benchmark-equivalent benefit package",
   sections: [
     {
       title: "Benefit package details",
@@ -129,7 +129,7 @@ const ABP3: FormSchema = {
                                             options: [
                                               {
                                                 label:
-                                                  "The state/territory offers the benefits provided in the approved state plan.",
+                                                  "The state/territory offers benefits based on the approved state plan.",
                                                 value: "approved_state_plan",
                                                 form: [
                                                   {

--- a/src/services/api/layers/ABP3/v1.ts
+++ b/src/services/api/layers/ABP3/v1.ts
@@ -267,6 +267,83 @@ const ABP3: FormSchema = {
         },
       ],
     },
+    {
+      title: "Selection of base benchmark plan",
+      form: [
+        {
+          description:
+            "The state/territory must select a base benchmark plan as the basis for providing essential health benefits in its benchmark or benchmark-equivalent package.",
+          slots: [
+            {
+              rhf: "Select",
+              label:
+                "Is the base benchmark plan the same as the Section 1937 coverage option?",
+              name: "base_benchmark_plan_same_as_section_1937",
+              rules: { required: "* Required" },
+              props: {
+                className: "w-[150px]",
+                options: [
+                  { label: "Yes", value: "yes" },
+                  { label: "No", value: "no" },
+                ],
+              },
+            },
+            {
+              rhf: "Radio",
+              label:
+                "Indicate which benchmark plan described at 45 CFR 156.100(a) the state/territory will use as its base benchmark plan.",
+              name: "base_benchmark_plan",
+              rules: { required: "* Required" },
+              props: {
+                options: [
+                  {
+                    label:
+                      "The largest plan by enrollment of the three largest small group insurance products in the state's small group market",
+                    value: "largest_plan_by_enrollment",
+                  },
+                  {
+                    label:
+                      "Any of the largest three state employee health benefit plans by enrollment",
+                    value: "any_of_largest_three_state",
+                  },
+                  {
+                    label:
+                      "Any of the largest three national FEHBP plan options open to federal employees in all geographies by enrollment",
+                    value: "any_of_largest_three_national_fehbp_plan_options",
+                  },
+                  {
+                    label: "The largest insured commercial non-Medicaid HMO",
+                    value: "largest_insured_commercial_hmo",
+                  },
+                ],
+              },
+            },
+            {
+              rhf: "Input",
+              label: "Plan name",
+              name: "base_benchmark_plan_name",
+              rules: { required: "* Required" },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title: "Additional information",
+      form: [
+        {
+          description:
+            "Other information related to selection of the Section 1937 coverage option and the base benchmark plan (optional)",
+          slots: [
+            {
+              rhf: "Textarea",
+              label: "Additional information",
+              name: "additional_information",
+            },
+          ],
+        },
+      ],
+    },
   ],
 };
 

--- a/src/services/api/layers/ABP3/v1.ts
+++ b/src/services/api/layers/ABP3/v1.ts
@@ -29,6 +29,240 @@ const ABP3: FormSchema = {
                 ],
               },
             },
+            {
+              rhf: "Input",
+              name: "benefit_package_name",
+              label: "Benefit package name",
+              rules: { required: "* Required" },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title: "Selection of Section 1937 coverage option",
+      form: [
+        {
+          description:
+            "The state/territory selects as its Section 1937 coverage option the following type of benchmark benefit package or benchmark-equivalent benefit package under this Alternative Benefit Plan:",
+          slots: [
+            {
+              rhf: "Radio",
+              name: "section_1937_coverage_option",
+              rules: { required: "* Required" },
+              props: {
+                options: [
+                  {
+                    label: "Benchmark benefit package",
+                    value: "benchmark_benefit_package",
+                    form: [
+                      {
+                        description:
+                          "The state/territory will provide the following benchmark benefit package:",
+                        slots: [
+                          {
+                            rhf: "Radio",
+                            name: "Benchmark_benefit_packag_options",
+                            rules: { required: "* Required" },
+                            props: {
+                              options: [
+                                {
+                                  label:
+                                    "The standard Blue Cross Blue Shield preferred provider option offered through the Federal Employee Health Benefit Program (FEHBP)",
+                                  value: "blue_cross_blue_shield",
+                                },
+                                {
+                                  label:
+                                    "State employee coverage that is offered and generally available to state employees (state employee coverage)",
+                                  value: "state_employee_coverage",
+                                  form: [
+                                    {
+                                      slots: [
+                                        {
+                                          rhf: "Input",
+                                          label: "Plan name",
+                                          name: "state_employee_coverage_plan_name",
+                                          rules: { required: "* Required" },
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                },
+                                {
+                                  label:
+                                    "A commercial HMO with the largest insured commercial, non-Medicaid enrollment in the state/territory (commercial HMO)",
+                                  value: "commercial_hmo",
+                                  form: [
+                                    {
+                                      slots: [
+                                        {
+                                          rhf: "Input",
+                                          label: "Plan name",
+                                          name: "commercial_hmo_plan_name",
+                                          rules: { required: "* Required" },
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                },
+                                {
+                                  label: "Secretary-approved coverage",
+                                  value: "secretary_approved_coverage",
+                                  form: [
+                                    {
+                                      slots: [
+                                        {
+                                          rhf: "Radio",
+                                          name: "secretary_approved_coverage_options",
+                                          rules: { required: "* Required" },
+                                          props: {
+                                            options: [
+                                              {
+                                                label:
+                                                  "The state/territory offers the benefits provided in the approved state plan.",
+                                                value: "approved_state_plan",
+                                                form: [
+                                                  {
+                                                    slots: [
+                                                      {
+                                                        rhf: "Radio",
+                                                        name: "approved_state_plan_options",
+                                                        rules: {
+                                                          required:
+                                                            "* Required",
+                                                        },
+                                                        props: {
+                                                          options: [
+                                                            {
+                                                              label:
+                                                                "The state/territory offers the benefits provided in the approved state plan.",
+                                                              value:
+                                                                "approved_state_plan",
+                                                            },
+                                                            {
+                                                              label:
+                                                                "Benefits include all those provided in the approved state plan plus additional benefits.",
+                                                              value:
+                                                                "additional_benefits",
+                                                            },
+                                                            {
+                                                              label:
+                                                                "Benefits are the same as provided in the approved state plan but in a different amount, duration, and/or scope.",
+                                                              value:
+                                                                "different_amount_duration_scope",
+                                                            },
+                                                            {
+                                                              label:
+                                                                "The state/territory offers only a partial list of benefits provided in the approved state plan.",
+                                                              value:
+                                                                "partial_list_of_benefits",
+                                                            },
+                                                            {
+                                                              label:
+                                                                "The state/territory offers a partial list of benefits provided in the approved state plan plus additional benefits.",
+                                                              value:
+                                                                "partial_list_of_benefits_plus_additional_benefits",
+                                                            },
+                                                          ],
+                                                        },
+                                                      },
+                                                    ],
+                                                  },
+                                                ],
+                                              },
+                                              {
+                                                label:
+                                                  "The state/territory offers an array of benefits from the Section 1937 coverage option and/or base benchmark plan benefit packages, the approved state plan, or a combination of these benefit packages.",
+                                                value: "array_of_benefits",
+                                              },
+                                            ],
+                                          },
+                                        },
+                                        {
+                                          rhf: "Textarea",
+                                          name: "benefits_and_limitations",
+                                          rules: { required: "* Required" },
+                                          label:
+                                            "Briefly identify the benefits, the source of benefits, and any limitations.",
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    label: "Benchmark-equivalent benefit package",
+                    value: "benchmark_equivalent_benefit_package",
+                    form: [
+                      {
+                        description:
+                          "The state/territory will provide the following benchmark-equivalent benefit package:",
+                        slots: [
+                          {
+                            rhf: "Radio",
+                            name: "benchmark_equivalent",
+                            rules: { required: "* Required" },
+                            props: {
+                              options: [
+                                {
+                                  label:
+                                    "The standard Blue Cross Blue Shield preferred provider option offered through the Federal Employee Health Benefit Program (FEHBP)",
+                                  value: "blue_cross_blue_shield",
+                                },
+                                {
+                                  label:
+                                    "State employee coverage that is offered and generally available to state employees (state employee coverage)",
+                                  value: "state_employee_coverage",
+                                  form: [
+                                    {
+                                      slots: [
+                                        {
+                                          rhf: "Input",
+                                          name: "state_employee_coverage_plan_name",
+                                          label: "Plan name",
+                                          rules: { required: "* Required" },
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                },
+                                {
+                                  label:
+                                    "A commercial HMO with the largest insured commercial, non-Medicaid enrollment in the state/territory (commercial HMO)",
+                                  value: "commercial_hmo",
+                                  form: [
+                                    {
+                                      slots: [
+                                        {
+                                          rhf: "Input",
+                                          name: "commercial_hmo_plan_name",
+                                          label: "Plan name",
+                                          rules: { required: "* Required" },
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                },
+                                {
+                                  label: "Secretary-approved coverage",
+                                  value: "secretary_approved_coverage",
+                                },
+                              ],
+                            },
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
           ],
         },
       ],

--- a/src/services/api/layers/ABP3/v1.ts
+++ b/src/services/api/layers/ABP3/v1.ts
@@ -1,0 +1,39 @@
+import { FormSchema } from "shared-types";
+
+const ABP3: FormSchema = {
+  header:
+    "APB 3: Selection of benchmark benefit package or benchmark-equivalent benefit package",
+  sections: [
+    {
+      title: "Benefit package details",
+      form: [
+        {
+          description: "Select one of the following",
+          slots: [
+            {
+              rhf: "Radio",
+              name: "benefit_package_details",
+              rules: { required: "* Required" },
+              props: {
+                options: [
+                  {
+                    label:
+                      "The state/territory is amending one existing benefit package for the population defined in section 1.",
+                    value: "benchmark_amending",
+                  },
+                  {
+                    label:
+                      "The state/territory is creating a single new benefit package for the population defined in section 1.",
+                    value: "benchmark_creating",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+export const form = ABP3;

--- a/src/services/ui/src/components/RHF/Document.tsx
+++ b/src/services/ui/src/components/RHF/Document.tsx
@@ -13,7 +13,7 @@ export const RHFDocument = <TFieldValues extends FieldValues>(props: {
       <div className="h-[5px] bg-gradient-to-r from-primary from-50% to-[#02bfe7] to-[66%] rounded-t"></div>
       <div className="py-4 px-8 border-2 border-t-0 mt-0">
         <div className="mb-3 mt-9">
-          <FormLabel className="font-bold text-4xl px-8 font-serif">
+          <FormLabel className="font-bold text-4xl px-8 inline-block leading-[48px]">
             {props.document.header}
           </FormLabel>
         </div>

--- a/src/services/ui/src/components/Webform/footer.tsx
+++ b/src/services/ui/src/components/Webform/footer.tsx
@@ -7,19 +7,19 @@ export const Footer = () => {
           "All State Medicaid agencies administering or supervising the \
         administration of 1915(c) home and community-based services (HCBS) \
         waivers are required to submit an annual Form CMS-372(S) Report for each \
-        approved waiver. Section 1915(c)(2)(E) of the SocialSecurity Act \
+        approved waiver. Section 1915(c)(2)(E) of the Social Security Act \
         requires states to annually provide CMS with information on the waiver's \
         impact on the type, amount and cost of services provided under the state \
-        plan in addition to the health and welgare of recipients. Under the \
+        plan in addition to the health and welfare of recipients. Under the \
         Privacy Act of 1974 any personally identifying information obatined will \
         be kept private to the extent of the law."
         }
       </p>
       <p>
         {
-          "Accordint to the Paperwork Reduction Act of 1995, no persons are required to respond \
+          "According to the Paperwork Reduction Act of 1995, no persons are required to respond \
         to a collection of information unless it displays a valid OMB control number. The valid OMB \
-        control number for this information colleciton is 0938-0272. The time required to complete \
+        control number for this information collection is 0938-0272. The time required to complete \
         this information collection is estimated to average 44 hours per response, including the time to \
         review instructions, search existing data resources, gather the data needed, and complete and \
         review the information collection. If you have comments concerning the accuracy of the time \

--- a/src/services/ui/src/components/Webform/index.tsx
+++ b/src/services/ui/src/components/Webform/index.tsx
@@ -20,8 +20,9 @@ export const Webforms = () => {
             path="/webform/:id/:version"
             params={{ id: "abp1", version: 1 }}
           >
-            ABP1
+            ABP 1
           </Link>
+          <br />
           <Link
             path="/webform/:id/:version"
             params={{ id: "abp3", version: 1 }}

--- a/src/services/ui/src/components/Webform/index.tsx
+++ b/src/services/ui/src/components/Webform/index.tsx
@@ -22,6 +22,12 @@ export const Webforms = () => {
           >
             ABP1
           </Link>
+          <Link
+            path="/webform/:id/:version"
+            params={{ id: "abp3", version: 1 }}
+          >
+            ABP 3
+          </Link>
         </div>
       </section>
     </>


### PR DESCRIPTION
## Purpose

Adds v1 of the ABP 3 webform to OneMAC (Mako).

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-26327

Test link: https://d268ha2bu9uwx3.cloudfront.net/

## Approach

I added a `v1.ts` file for ABP 3, modeled after the existing `v1.ts` for ABP 1.
