### PR TITLE
"fix(bugs): disable actions for help desk, drop 2nd clock, add withdraw package when RAI is issued"

### DIFF
--- a/src/packages/shared-types/seatool.ts
+++ b/src/packages/shared-types/seatool.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { SEATOOL_STATUS, getStatus } from "./statusHelper";
+import { SEATOOL_STATUS, getStatus, finalDispositionStatuses } from "./statusHelper";
 import { PlanType } from "./planType";
 
 type AuthorityType = "SPA" | "WAIVER" | "MEDICAID" | "CHIP";
@@ -146,11 +146,7 @@ const compileSrtList = (
   officers?.length ? officers.map((o) => `${o.FIRST_NAME} ${o.LAST_NAME}`) : [];
 
 const getFinalDispositionDate = (status: string, record: SeaToolSink) => {
-  const finalDispositionStatuses = [
-    SEATOOL_STATUS.APPROVED,
-    SEATOOL_STATUS.DISAPPROVED,
-    SEATOOL_STATUS.WITHDRAWN,
-  ];
+
   return status && finalDispositionStatuses.includes(status)
     ? getDateStringOrNullFromEpoc(record.STATE_PLAN.STATUS_DATE)
     : null;

--- a/src/packages/shared-types/statusHelper.ts
+++ b/src/packages/shared-types/statusHelper.ts
@@ -38,6 +38,12 @@ const statusToDisplayToCmsUser = {
   [SEATOOL_STATUS.PENDING_OFF_THE_CLOCK]: "Pending - Off the Clock",
 };
 
+export const finalDispositionStatuses = [
+  SEATOOL_STATUS.APPROVED,
+  SEATOOL_STATUS.DISAPPROVED,
+  SEATOOL_STATUS.WITHDRAWN,
+];
+
 export const getStatus = (seatoolStatus?: string | null) => {
   const stateStatus = statusToDisplayToStateUser[seatoolStatus ?? "Unknown"];
   const cmsStatus = statusToDisplayToCmsUser[seatoolStatus ?? "Unknown"];

--- a/src/packages/shared-utils/package-actions/getAvailableActions.ts
+++ b/src/packages/shared-utils/package-actions/getAvailableActions.ts
@@ -12,13 +12,8 @@ export const getAvailableActions = (
   result: OsMainSourceItem
 ) => {
   const checks = PackageCheck(result);
-  const finalChecks = checks.planTypeIs([PlanType.MED_SPA])
+  return checks.planTypeIs([PlanType.MED_SPA])
     ? rules.filter((r) => r.check(checks, user)).map((r) => r.action)
     : [];
 
-  // checking if the package is 
-  if (finalChecks?.includes(Action.RESPOND_TO_RAI)) {
-    finalChecks.push(Action.WITHDRAW_PACKAGE)
-  }
-  return finalChecks
 };

--- a/src/packages/shared-utils/package-actions/getAvailableActions.ts
+++ b/src/packages/shared-utils/package-actions/getAvailableActions.ts
@@ -3,7 +3,6 @@ import {
   OsMainSourceItem,
   PlanType,
 } from "../../shared-types";
-import { Action } from '../../shared-types/actions'
 import rules from "./rules";
 import { PackageCheck } from "../packageCheck";
 
@@ -15,5 +14,4 @@ export const getAvailableActions = (
   return checks.planTypeIs([PlanType.MED_SPA])
     ? rules.filter((r) => r.check(checks, user)).map((r) => r.action)
     : [];
-
 };

--- a/src/packages/shared-utils/package-actions/getAvailableActions.ts
+++ b/src/packages/shared-utils/package-actions/getAvailableActions.ts
@@ -3,6 +3,7 @@ import {
   OsMainSourceItem,
   PlanType,
 } from "../../shared-types";
+import { Action } from '../../shared-types/actions'
 import rules from "./rules";
 import { PackageCheck } from "../packageCheck";
 
@@ -11,7 +12,13 @@ export const getAvailableActions = (
   result: OsMainSourceItem
 ) => {
   const checks = PackageCheck(result);
-  return checks.planTypeIs([PlanType.MED_SPA])
+  const finalChecks = checks.planTypeIs([PlanType.MED_SPA])
     ? rules.filter((r) => r.check(checks, user)).map((r) => r.action)
     : [];
+
+  // checking if the package is 
+  if (finalChecks?.includes(Action.RESPOND_TO_RAI)) {
+    finalChecks.push(Action.WITHDRAW_PACKAGE)
+  }
+  return finalChecks
 };

--- a/src/packages/shared-utils/package-actions/rules.ts
+++ b/src/packages/shared-utils/package-actions/rules.ts
@@ -1,10 +1,11 @@
 import { Action, ActionRule, SEATOOL_STATUS } from "../../shared-types";
-import { isCmsUser, isStateUser } from "../user-helper";
+import { isCmsUser, isStateUser, isCmsReadonlyUser } from "../user-helper";
 import { PackageCheck } from "../packageCheck";
 
 const arIssueRai: ActionRule = {
   action: Action.ISSUE_RAI,
   check: (checker, user) =>
+    !isCmsReadonlyUser(user) &&
     checker.isInActivePendingStatus &&
     (!checker.hasLatestRai || checker.hasRequestedRai) &&
     isCmsUser(user),
@@ -13,6 +14,7 @@ const arIssueRai: ActionRule = {
 const arRespondToRai: ActionRule = {
   action: Action.RESPOND_TO_RAI,
   check: (checker, user) =>
+    !isCmsReadonlyUser(user) &&
     checker.hasStatus(SEATOOL_STATUS.PENDING_RAI) &&
     checker.hasRequestedRai &&
     isStateUser(user),
@@ -21,6 +23,7 @@ const arRespondToRai: ActionRule = {
 const arEnableWithdrawRaiResponse: ActionRule = {
   action: Action.ENABLE_RAI_WITHDRAW,
   check: (checker, user) =>
+    !isCmsReadonlyUser(user) &&
     checker.isNotWithdrawn &&
     checker.hasRaiResponse &&
     !checker.hasEnabledRaiWithdraw &&
@@ -30,6 +33,7 @@ const arEnableWithdrawRaiResponse: ActionRule = {
 const arDisableWithdrawRaiResponse: ActionRule = {
   action: Action.DISABLE_RAI_WITHDRAW,
   check: (checker, user) =>
+    !isCmsReadonlyUser(user) &&
     checker.isNotWithdrawn &&
     checker.hasRaiResponse &&
     checker.hasEnabledRaiWithdraw &&
@@ -39,6 +43,7 @@ const arDisableWithdrawRaiResponse: ActionRule = {
 const arWithdrawRaiResponse: ActionRule = {
   action: Action.WITHDRAW_RAI,
   check: (checker, user) =>
+    !isCmsReadonlyUser(user) &&
     checker.isInActivePendingStatus &&
     checker.hasRaiResponse &&
     checker.hasEnabledRaiWithdraw &&
@@ -48,7 +53,8 @@ const arWithdrawRaiResponse: ActionRule = {
 const arWithdrawPackage: ActionRule = {
   action: Action.WITHDRAW_PACKAGE,
   check: (checker, user) =>
-    checker.isInActivePendingStatus && isStateUser(user),
+    !isCmsReadonlyUser(user) &&
+    (checker.isInActivePendingStatus || checker.hasRaiResponse) && isStateUser(user),
 };
 
 export default [

--- a/src/packages/shared-utils/package-actions/rules.ts
+++ b/src/packages/shared-utils/package-actions/rules.ts
@@ -1,4 +1,4 @@
-import { Action, ActionRule, SEATOOL_STATUS } from "../../shared-types";
+import { Action, ActionRule, SEATOOL_STATUS, finalDispositionStatuses } from "../../shared-types";
 import { isCmsUser, isStateUser, isCmsReadonlyUser, isCmsWriteUser } from "../user-helper";
 import { PackageCheck } from "../packageCheck";
 
@@ -47,8 +47,8 @@ const arWithdrawRaiResponse: ActionRule = {
 const arWithdrawPackage: ActionRule = {
   action: Action.WITHDRAW_PACKAGE,
   check: (checker, user) =>
-    !checker.hasStatus([SEATOOL_STATUS.APPROVED, SEATOOL_STATUS.DISAPPROVED, SEATOOL_STATUS.WITHDRAWN]) &&
-    checker.isInActivePendingStatus
+    (!checker.hasStatus(finalDispositionStatuses)
+      || checker.isInActivePendingStatus)
     && isStateUser(user),
 };
 

--- a/src/packages/shared-utils/package-actions/rules.ts
+++ b/src/packages/shared-utils/package-actions/rules.ts
@@ -47,8 +47,7 @@ const arWithdrawRaiResponse: ActionRule = {
 const arWithdrawPackage: ActionRule = {
   action: Action.WITHDRAW_PACKAGE,
   check: (checker, user) =>
-    (!checker.hasStatus(finalDispositionStatuses)
-      || checker.isInActivePendingStatus)
+    !checker.hasStatus(finalDispositionStatuses)
     && isStateUser(user),
 };
 

--- a/src/packages/shared-utils/package-actions/rules.ts
+++ b/src/packages/shared-utils/package-actions/rules.ts
@@ -1,20 +1,18 @@
 import { Action, ActionRule, SEATOOL_STATUS } from "../../shared-types";
-import { isCmsUser, isStateUser, isCmsReadonlyUser } from "../user-helper";
+import { isCmsUser, isStateUser, isCmsReadonlyUser, isCmsWriteUser } from "../user-helper";
 import { PackageCheck } from "../packageCheck";
 
 const arIssueRai: ActionRule = {
   action: Action.ISSUE_RAI,
   check: (checker, user) =>
-    !isCmsReadonlyUser(user) &&
     checker.isInActivePendingStatus &&
     (!checker.hasLatestRai || checker.hasRequestedRai) &&
-    isCmsUser(user),
+    isCmsWriteUser(user),
 };
 
 const arRespondToRai: ActionRule = {
   action: Action.RESPOND_TO_RAI,
   check: (checker, user) =>
-    !isCmsReadonlyUser(user) &&
     checker.hasStatus(SEATOOL_STATUS.PENDING_RAI) &&
     checker.hasRequestedRai &&
     isStateUser(user),
@@ -23,27 +21,24 @@ const arRespondToRai: ActionRule = {
 const arEnableWithdrawRaiResponse: ActionRule = {
   action: Action.ENABLE_RAI_WITHDRAW,
   check: (checker, user) =>
-    !isCmsReadonlyUser(user) &&
     checker.isNotWithdrawn &&
     checker.hasRaiResponse &&
     !checker.hasEnabledRaiWithdraw &&
-    isCmsUser(user),
+    isCmsWriteUser(user)
 };
 
 const arDisableWithdrawRaiResponse: ActionRule = {
   action: Action.DISABLE_RAI_WITHDRAW,
   check: (checker, user) =>
-    !isCmsReadonlyUser(user) &&
     checker.isNotWithdrawn &&
     checker.hasRaiResponse &&
     checker.hasEnabledRaiWithdraw &&
-    isCmsUser(user),
+    isCmsWriteUser(user)
 };
 
 const arWithdrawRaiResponse: ActionRule = {
   action: Action.WITHDRAW_RAI,
   check: (checker, user) =>
-    !isCmsReadonlyUser(user) &&
     checker.isInActivePendingStatus &&
     checker.hasRaiResponse &&
     checker.hasEnabledRaiWithdraw &&
@@ -53,7 +48,6 @@ const arWithdrawRaiResponse: ActionRule = {
 const arWithdrawPackage: ActionRule = {
   action: Action.WITHDRAW_PACKAGE,
   check: (checker, user) =>
-    !isCmsReadonlyUser(user) &&
     ((checker.hasStatus(SEATOOL_STATUS.PENDING_RAI) &&
       checker.hasRequestedRai)
       || checker.isInActivePendingStatus)

--- a/src/packages/shared-utils/package-actions/rules.ts
+++ b/src/packages/shared-utils/package-actions/rules.ts
@@ -54,7 +54,10 @@ const arWithdrawPackage: ActionRule = {
   action: Action.WITHDRAW_PACKAGE,
   check: (checker, user) =>
     !isCmsReadonlyUser(user) &&
-    (checker.isInActivePendingStatus || checker.hasRaiResponse) && isStateUser(user),
+    ((checker.hasStatus(SEATOOL_STATUS.PENDING_RAI) &&
+      checker.hasRequestedRai)
+      || checker.isInActivePendingStatus)
+    && isStateUser(user),
 };
 
 export default [

--- a/src/packages/shared-utils/package-actions/rules.ts
+++ b/src/packages/shared-utils/package-actions/rules.ts
@@ -44,13 +44,11 @@ const arWithdrawRaiResponse: ActionRule = {
     checker.hasEnabledRaiWithdraw &&
     isStateUser(user),
 };
-
 const arWithdrawPackage: ActionRule = {
   action: Action.WITHDRAW_PACKAGE,
   check: (checker, user) =>
-    ((checker.hasStatus(SEATOOL_STATUS.PENDING_RAI) &&
-      checker.hasRequestedRai)
-      || checker.isInActivePendingStatus)
+    //checker.hasStatus([SEATOOL_STATUS.APPROVED, SEATOOL_STATUS.DISAPPROVED, SEATOOL_STATUS.WITHDRAWN]) &&
+    checker.isInActivePendingStatus
     && isStateUser(user),
 };
 

--- a/src/packages/shared-utils/package-actions/rules.ts
+++ b/src/packages/shared-utils/package-actions/rules.ts
@@ -47,7 +47,7 @@ const arWithdrawRaiResponse: ActionRule = {
 const arWithdrawPackage: ActionRule = {
   action: Action.WITHDRAW_PACKAGE,
   check: (checker, user) =>
-    //checker.hasStatus([SEATOOL_STATUS.APPROVED, SEATOOL_STATUS.DISAPPROVED, SEATOOL_STATUS.WITHDRAWN]) &&
+    !checker.hasStatus([SEATOOL_STATUS.APPROVED, SEATOOL_STATUS.DISAPPROVED, SEATOOL_STATUS.WITHDRAWN]) &&
     checker.isInActivePendingStatus
     && isStateUser(user),
 };

--- a/src/packages/shared-utils/packageCheck.ts
+++ b/src/packages/shared-utils/packageCheck.ts
@@ -59,7 +59,7 @@ export const PackageCheck = ({
     /** Latest RAI has been responded to **/
     hasRaiResponse: latestRai?.status === "received",
     /** RAI Withdraw has been enabled **/
-    hasEnabledRaiWithdraw: raiWithdrawEnabled,
+    hasEnabledRaiWithdraw: latestRai?.status === "requested" || raiWithdrawEnabled,
   };
   return {
     ...planChecks,

--- a/src/packages/shared-utils/packageCheck.ts
+++ b/src/packages/shared-utils/packageCheck.ts
@@ -59,7 +59,7 @@ export const PackageCheck = ({
     /** Latest RAI has been responded to **/
     hasRaiResponse: latestRai?.status === "received",
     /** RAI Withdraw has been enabled **/
-    hasEnabledRaiWithdraw: latestRai?.status === "requested" || raiWithdrawEnabled,
+    hasEnabledRaiWithdraw: raiWithdrawEnabled,
   };
   return {
     ...planChecks,

--- a/src/services/api/handlers/getPackageActions.ts
+++ b/src/services/api/handlers/getPackageActions.ts
@@ -7,7 +7,6 @@ import {
   lookupUserAttributes,
 } from "../libs/auth/user";
 import { response } from "../libs/handler";
-import { isCmsReadonlyUser } from "../../../packages/shared-utils/user-helper";
 
 type GetPackageActionsBody = {
   id: string;
@@ -39,15 +38,6 @@ export const getPackageActions = async (event: APIGatewayEvent) => {
       authDetails.userId,
       authDetails.poolId
     );
-
-    if (isCmsReadonlyUser(userAttr)) {
-      return response({
-        statusCode: 200,
-        body: {
-          actions: []
-        },
-      });
-    }
 
     return response({
       statusCode: 200,

--- a/src/services/api/handlers/getPackageActions.ts
+++ b/src/services/api/handlers/getPackageActions.ts
@@ -7,6 +7,7 @@ import {
   lookupUserAttributes,
 } from "../libs/auth/user";
 import { response } from "../libs/handler";
+import { isCmsReadonlyUser } from "../../../packages/shared-utils/user-helper";
 
 type GetPackageActionsBody = {
   id: string;
@@ -38,6 +39,16 @@ export const getPackageActions = async (event: APIGatewayEvent) => {
       authDetails.userId,
       authDetails.poolId
     );
+
+    if (isCmsReadonlyUser(userAttr)) {
+      return response({
+        statusCode: 200,
+        body: {
+          actions: []
+        },
+      });
+    }
+
     return response({
       statusCode: 200,
       body: {

--- a/src/services/ui/src/pages/actions/WithdrawPackage.tsx
+++ b/src/services/ui/src/pages/actions/WithdrawPackage.tsx
@@ -94,7 +94,7 @@ const WithdrawPackageForm: React.FC = ({ item }: { item?: ItemResult }) => {
             </p>
           </ActionFormIntro>
           <PackageInfo item={item} />
-          <ActionFormIntro title="Attachments"></ActionFormIntro>
+          <h3 className="font-bold text-2xl font-sans">Attachments</h3>
           <p className="font-normal mb-4">
             Upload your supporting documentation for withdrawal or explain your
             need for withdrawal in the <em>Additional Information section.</em>

--- a/src/services/ui/src/pages/actions/WithdrawPackage.tsx
+++ b/src/services/ui/src/pages/actions/WithdrawPackage.tsx
@@ -94,14 +94,11 @@ const WithdrawPackageForm: React.FC = ({ item }: { item?: ItemResult }) => {
             </p>
           </ActionFormIntro>
           <PackageInfo item={item} />
-          <br />
-          <h3 className="font-bold text-2xl font-sans">Attachments</h3>
-          <br />
-          <p className="font-normal">
+          <ActionFormIntro title="Attachments"></ActionFormIntro>
+          <p className="font-normal mb-4">
             Upload your supporting documentation for withdrawal or explain your
             need for withdrawal in the <em>Additional Information section.</em>
           </p>
-          <br />
           <I.Form {...form}>
             <form onSubmit={form.handleSubmit(handleSubmit)}>
               {/* Change faqLink once we know the anchor */}

--- a/src/services/ui/src/pages/actions/WithdrawPackage.tsx
+++ b/src/services/ui/src/pages/actions/WithdrawPackage.tsx
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as I from "@/components/Inputs";
-import { LoadingSpinner } from "@/components";
+import { LoadingSpinner, SectionCard } from "@/components";
 import { AttachmentRecipe, buildActionUrl } from "@/lib";
 import { useGetUser } from "@/api/useGetUser";
 import { submit } from "@/api/submissionService";
@@ -94,6 +94,8 @@ const WithdrawPackageForm: React.FC = ({ item }: { item?: ItemResult }) => {
             </p>
           </ActionFormIntro>
           <PackageInfo item={item} />
+          <br />
+          <h3 className="font-bold text-2xl font-sans">Attachments</h3>
           <br />
           <p className="font-normal">
             Upload your supporting documentation for withdrawal or explain your

--- a/src/services/ui/src/pages/actions/WithdrawPackage.tsx
+++ b/src/services/ui/src/pages/actions/WithdrawPackage.tsx
@@ -94,6 +94,12 @@ const WithdrawPackageForm: React.FC = ({ item }: { item?: ItemResult }) => {
             </p>
           </ActionFormIntro>
           <PackageInfo item={item} />
+          <br />
+          <p className="font-normal">
+            Upload your supporting documentation for withdrawal or explain your
+            need for withdrawal in the <em>Additional Information section.</em>
+          </p>
+          <br />
           <I.Form {...form}>
             <form onSubmit={form.handleSubmit(handleSubmit)}>
               {/* Change faqLink once we know the anchor */}

--- a/src/services/ui/src/pages/actions/WithdrawPackage.tsx
+++ b/src/services/ui/src/pages/actions/WithdrawPackage.tsx
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as I from "@/components/Inputs";
-import { LoadingSpinner, SectionCard } from "@/components";
+import { LoadingSpinner } from "@/components";
 import { AttachmentRecipe, buildActionUrl } from "@/lib";
 import { useGetUser } from "@/api/useGetUser";
 import { submit } from "@/api/submissionService";

--- a/src/services/ui/src/pages/detail/index.tsx
+++ b/src/services/ui/src/pages/detail/index.tsx
@@ -54,7 +54,7 @@ const StatusCard = (data: OsMainSourceItem) => {
             : transformedStatuses.stateStatus}
         </h2>
         {checker.hasEnabledRaiWithdraw && (
-          <em className="text-xs my-4">
+          <em className="text-xs my-4 mr-2">
             {"Withdraw Formal RAI Response - Enabled"}
           </em>
         )}

--- a/src/services/ui/src/pages/detail/index.tsx
+++ b/src/services/ui/src/pages/detail/index.tsx
@@ -55,7 +55,7 @@ const StatusCard = (data: OsMainSourceItem) => {
         </h2>
         {checker.hasEnabledRaiWithdraw && (
           <em className="text-xs my-4">
-            {"Withdraw Formal RAI Response - Enabled"}
+            {"Withdraw Formal RAI Response - Enabled"}{" "}
           </em>
         )}
         {user?.isCms && checker.isInSecondClock && (

--- a/src/services/ui/src/pages/detail/index.tsx
+++ b/src/services/ui/src/pages/detail/index.tsx
@@ -55,11 +55,13 @@ const StatusCard = (data: OsMainSourceItem) => {
         </h2>
         {checker.hasEnabledRaiWithdraw && (
           <em className="text-xs my-4">
-            {"Withdraw Formal RAI Response - Enabled"}{" "}
+            {"Withdraw Formal RAI Response - Enabled"}
           </em>
         )}
         {user?.isCms && checker.isInSecondClock && (
-          <span id="secondclock">2nd Clock</span>
+          <span id="secondclock" className="ml-2">
+            2nd Clock
+          </span>
         )}
       </div>
     </DetailCardWrapper>


### PR DESCRIPTION
## Purpose

The intent of this PR address multiple bug fixes. 
1. Drop the `2nd Clock` status down to a separate line from the sub status . 
2. Make changes to ensure `HELPDESK` UsersRole and `CMS_READ_ONLY` roles do not have access to take actions on packages. 
3. Implement a change to add `Withdraw Package` action for state users after an RAI as been issued 

#### Linked Issues to Close
https://qmacbis.atlassian.net/browse/OY2-26876
https://qmacbis.atlassian.net/browse/OY2-26873
https://qmacbis.atlassian.net/browse/OY2-26875


## Approach

1. I added ml-2 class to give space between substatus and the 2nd clock as we currently only have one substatus 

2. here i am using the `!isCmsReadonlyUser(user)` In all the checks, as we do not want any action for read-only user.

3. Here i used the same checks From `arRespondToRai` in the `arWithdrawPackage`.
Which is  `((checker.hasStatus(SEATOOL_STATUS.PENDING_RAI) &&
      checker.hasRequestedRai)`





