### PR TITLE
fix(dashboard): fix overlapping select menus

### DIFF
--- a/src/services/ui/src/components/Opensearch/Filtering/FilterableSelect.tsx
+++ b/src/services/ui/src/components/Opensearch/Filtering/FilterableSelect.tsx
@@ -17,7 +17,6 @@ export const FilterableSelect: FC<{
   return (
     <Select<any, any>
       isMulti
-      className="z-50"
       value={props.value.map((S) => ({ value: S, label: S }))}
       onChange={(val) => props.onChange(val.map((s: any) => s.value))}
       options={props.options}


### PR DESCRIPTION
## Purpose

On the Dashboard, the Submission Source select menu was overlapping with the CPOC select menu. This was caused by the  select menus' z-index being set to 50. Removing the z-index appears to resolve the issue.

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-26921

## Approach

Removing the z-index allows the select menus to display as expected.