### PR TITLE
chore(semver fix):  Remove dependency on e2e so production branch can be the release branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -223,7 +223,6 @@ jobs:
     needs:
       - test
       - cfn-nag
-      - e2e
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Purpose

This allows production to resume producing releases powered by semver!
