### PR TITLE
fix(respon to rai modal):  Typo causing bad modal behavior.. fixed

### DIFF
--- a/src/services/ui/src/pages/actions/RespondToRai.tsx
+++ b/src/services/ui/src/pages/actions/RespondToRai.tsx
@@ -75,7 +75,7 @@ export const RespondToRai = ({
         user,
         authority,
       });
-      setCancelModalOpen(true);
+      setSuccessModalOpen(true);
     } catch (err) {
       console.log(err);
       setErrorModalOpen(true);


### PR DESCRIPTION
## Purpose

This fixes a bug where the cancel modal is shown to the user on success, rather than the success modal.  The bug was only present in the respond to rai form, so that is the only file updated.

#### Linked Issues to Close

None

## Approach

setCancelModalOpen(true) -> setSuccessModalOpen(true)

## Assorted Notes/Considerations/Learning

None