### PR TITLE
fix(2nd clock): drop 2nd clock to new line

### DIFF
--- a/src/services/ui/src/pages/detail/index.tsx
+++ b/src/services/ui/src/pages/detail/index.tsx
@@ -59,9 +59,12 @@ const StatusCard = (data: opensearch.main.Document) => {
           </em>
         )}
         {user?.isCms && checker.isInSecondClock && (
-          <span id="secondclock" className="ml-2">
-            2nd Clock
-          </span>
+          <>
+            <br />
+            <span id="secondclock" className="ml-2">
+              2nd Clock
+            </span>
+          </>
         )}
       </div>
     </DetailCardWrapper>

--- a/src/services/ui/src/pages/detail/index.tsx
+++ b/src/services/ui/src/pages/detail/index.tsx
@@ -53,16 +53,13 @@ const StatusCard = (data: opensearch.main.Document) => {
             ? transformedStatuses.cmsStatus
             : transformedStatuses.stateStatus}
         </h2>
-        {checker.hasEnabledRaiWithdraw && (
-          <em className="text-xs my-4 mr-2">
-            {"Withdraw Formal RAI Response - Enabled"}
-          </em>
-        )}
         {user?.isCms && checker.isInSecondClock && (
-          <>
-            <br />
-            <span id="secondclock">2nd Clock</span>
-          </>
+          <span id="secondclock">2nd Clock</span>
+        )}
+        {checker.hasEnabledRaiWithdraw && (
+          <div className="text-xs italic">
+            {"Withdraw Formal RAI Response - Enabled"}
+          </div>
         )}
       </div>
     </DetailCardWrapper>

--- a/src/services/ui/src/pages/detail/index.tsx
+++ b/src/services/ui/src/pages/detail/index.tsx
@@ -54,8 +54,10 @@ const StatusCard = (data: opensearch.main.Document) => {
             : transformedStatuses.stateStatus}
         </h2>
         {checker.hasEnabledRaiWithdraw && (
-          <div className="text-xs italic">
-            {"Withdraw Formal RAI Response - Enabled"}
+          <div>
+            <em className="text-xs my-4 mr-2">
+              {"Withdraw Formal RAI Response - Enabled"}
+            </em>
           </div>
         )}
         {user?.isCms && checker.isInSecondClock && (

--- a/src/services/ui/src/pages/detail/index.tsx
+++ b/src/services/ui/src/pages/detail/index.tsx
@@ -53,13 +53,13 @@ const StatusCard = (data: opensearch.main.Document) => {
             ? transformedStatuses.cmsStatus
             : transformedStatuses.stateStatus}
         </h2>
-        {user?.isCms && checker.isInSecondClock && (
-          <span id="secondclock">2nd Clock</span>
-        )}
         {checker.hasEnabledRaiWithdraw && (
           <div className="text-xs italic">
             {"Withdraw Formal RAI Response - Enabled"}
           </div>
+        )}
+        {user?.isCms && checker.isInSecondClock && (
+          <span id="secondclock">2nd Clock</span>
         )}
       </div>
     </DetailCardWrapper>

--- a/src/services/ui/src/pages/detail/index.tsx
+++ b/src/services/ui/src/pages/detail/index.tsx
@@ -61,9 +61,7 @@ const StatusCard = (data: opensearch.main.Document) => {
         {user?.isCms && checker.isInSecondClock && (
           <>
             <br />
-            <span id="secondclock" className="ml-2">
-              2nd Clock
-            </span>
+            <span id="secondclock">2nd Clock</span>
           </>
         )}
       </div>


### PR DESCRIPTION
## Purpose

The intent of this PR is to drop the 2nd Clock status down to a separate line from the sub status .

#### Linked Issues to Close
https://qmacbis.atlassian.net/browse/OY2-26876

## Approach

Simply added a break to bring the sub status do the next line, also because the 2nd Clock is initiated before the Enabling of the RAI response I moved the responses status to the bottom.

