### PR TITLE
feat(sub ststus): added sub status to dashboard column and exporting 

### DIFF
--- a/src/packages/shared-types/statusHelper.ts
+++ b/src/packages/shared-types/statusHelper.ts
@@ -49,3 +49,11 @@ export const getStatus = (seatoolStatus?: string | null) => {
   const cmsStatus = statusToDisplayToCmsUser[seatoolStatus ?? "Unknown"];
   return { stateStatus, cmsStatus };
 };
+
+export const stateUserSubStatus = {
+  WITHDRAW_FORMAL_RAI_RESPONSE_ENABLED: "Withdraw Formal RAI Response - Enabled"
+};
+
+export const cmsUserSubStatus = {
+  SECOND_CLOCK: "2nd Clock"
+};

--- a/src/services/ui/src/components/ExportButton/index.tsx
+++ b/src/services/ui/src/components/ExportButton/index.tsx
@@ -6,6 +6,8 @@ import { motion } from "framer-motion";
 import { format } from "date-fns";
 import { useOsUrl } from "@/components/Opensearch/main";
 import { opensearch } from "shared-types";
+import { PackageCheck } from "shared-utils";
+import { stateUserSubStatus } from "shared-types";
 
 type Props<TData extends Record<string, any>> = {
   data: TData[] | (() => Promise<TData[]>);
@@ -13,7 +15,7 @@ type Props<TData extends Record<string, any>> = {
   // | Record<string, HeaderOptions<TData>>
 };
 
-export const ExportButton = <TData extends Record<string, any>>({
+export const ExportButton = <TData extends opensearch.main.Document>({
   data,
   headers,
 }: Props<TData>) => {
@@ -34,6 +36,13 @@ export const ExportButton = <TData extends Record<string, any>>({
 
     for (const item of resolvedData) {
       const column: Record<any, any> = {};
+
+      const checker = PackageCheck(item);
+      if (checker.hasEnabledRaiWithdraw) {
+        item.stateStatus =
+          item.stateStatus +
+          ` (${stateUserSubStatus.WITHDRAW_FORMAL_RAI_RESPONSE_ENABLED})`;
+      }
 
       for (const header of headers) {
         column[header.name] = header.transform(item);

--- a/src/services/ui/src/pages/detail/index.tsx
+++ b/src/services/ui/src/pages/detail/index.tsx
@@ -65,7 +65,7 @@ const StatusCard = (data: opensearch.main.Document) => {
           </em>
         )}
         {user?.isCms && checker.isInSecondClock && (
-          <span id="secondclock" className="ml-2">
+          <span id="secondclock" className="block">
             {cmsUserSubStatus.SECOND_CLOCK}
           </span>
         )}

--- a/src/services/ui/src/pages/detail/index.tsx
+++ b/src/services/ui/src/pages/detail/index.tsx
@@ -9,7 +9,13 @@ import {
   LoadingSpinner,
 } from "@/components";
 import { useGetUser } from "@/api/useGetUser";
-import { Action, opensearch, UserRoles } from "shared-types";
+import {
+  Action,
+  opensearch,
+  UserRoles,
+  stateUserSubStatus,
+  cmsUserSubStatus,
+} from "shared-types";
 import { PackageCheck } from "shared-utils";
 import { useQuery } from "@/hooks";
 import { getAttachmentUrl, useGetItem } from "@/api";
@@ -55,12 +61,12 @@ const StatusCard = (data: opensearch.main.Document) => {
         </h2>
         {checker.hasEnabledRaiWithdraw && (
           <em className="text-xs my-4 mr-2">
-            {"Withdraw Formal RAI Response - Enabled"}
+            {stateUserSubStatus.WITHDRAW_FORMAL_RAI_RESPONSE_ENABLED}
           </em>
         )}
         {user?.isCms && checker.isInSecondClock && (
           <span id="secondclock" className="ml-2">
-            2nd Clock
+            {cmsUserSubStatus.SECOND_CLOCK}
           </span>
         )}
       </div>

--- a/src/services/ui/src/utils/user.ts
+++ b/src/services/ui/src/utils/user.ts
@@ -1,6 +1,11 @@
 import { CognitoUserAttributes, STATE_CODES, StateCode } from "shared-types";
 import { isCmsUser, isStateUser } from "shared-utils";
 import { getUser } from "@/api/useGetUser";
+import {
+  opensearch,
+  stateUserSubStatus
+} from "shared-types";
+import { PackageCheck } from "shared-utils";
 
 export const getUserStateCodes = (
   user: CognitoUserAttributes | null | undefined
@@ -24,4 +29,38 @@ export const isAuthorizedState = async (id: string) => {
     console.error(e);
     return false;
   }
+};
+
+export const getStateStatusWithSubStatus = (data: opensearch.main.Document): { status: string, subStatus: string | null } => {
+  const checker = PackageCheck(data);
+
+  if (checker.hasEnabledRaiWithdraw) {
+    return {
+      status: data.stateStatus,
+      subStatus: stateUserSubStatus.WITHDRAW_FORMAL_RAI_RESPONSE_ENABLED
+    };
+  }
+
+  // by default we return subStatus as null
+  return {
+    status: data.stateStatus,
+    subStatus: null
+  };
+};
+
+export const getCmsStatusWithSubStatus = (data: opensearch.main.Document): { status: string, subStatus: string | null } => {
+  const checker = PackageCheck(data);
+
+  if (checker.hasEnabledRaiWithdraw) {
+    return {
+      status: data.cmsStatus,
+      subStatus: stateUserSubStatus.WITHDRAW_FORMAL_RAI_RESPONSE_ENABLED
+    };
+  }
+
+  // we return substatus as null, if there is no sub status 
+  return {
+    status: data.cmsStatus,
+    subStatus: null
+  };
 };


### PR DESCRIPTION
## Purpose
The purpose of this PR is to add sub status to to the status column on the dashboard

#### Linked Issues to Close
https://qmacbis.atlassian.net/browse/OY2-26539

## Approach
To display the substatus on dashboard as well as putting it in the export file I used the `PackageCheck` function That takes in the input record and returns us the checker I used `checker.hasEnabledRaiWithdraw` for both `stateUsers` and the `cmsUser`. Using this approach I was able to add the sub status along with the original status on dashboard and in the exported excel file.