### PR TITLE
fix(status date):  Set Status_Date when updating a seatool record's status

### DIFF
--- a/src/services/api/handlers/packageActions.ts
+++ b/src/services/api/handlers/packageActions.ts
@@ -124,7 +124,7 @@ export async function withdrawRai(body: RaiWithdraw, rais: any) {
       const query2 = `
       UPDATE SEA.dbo.State_Plan
         SET 
-          SPW_Status_ID = (Select SPW_Status_ID from SEA.dbo.SPW_Status where SPW_Status_DESC = '${SEATOOL_STATUS.PENDING}')
+          SPW_Status_ID = (SELECT SPW_Status_ID FROM SEA.dbo.SPW_Status WHERE SPW_Status_DESC = '${SEATOOL_STATUS.PENDING}'),
           Status_Date = dateadd(s, convert(int, left(${today}, 10)), cast('19700101' as datetime))
         WHERE ID_Number = '${result.data.id}'
     `;
@@ -187,7 +187,7 @@ export async function respondToRai(body: RaiResponse, rais: any) {
     const query2 = `
       UPDATE SEA.dbo.State_Plan
         SET 
-          SPW_Status_ID = (Select SPW_Status_ID from SEA.dbo.SPW_Status where SPW_Status_DESC = '${SEATOOL_STATUS.PENDING}')
+          SPW_Status_ID = (SELECT SPW_Status_ID FROM SEA.dbo.SPW_Status WHERE SPW_Status_DESC = '${SEATOOL_STATUS.PENDING}'),
           Status_Date = dateadd(s, convert(int, left(${today}, 10)), cast('19700101' as datetime))
         WHERE ID_Number = '${body.id}'
     `;
@@ -256,7 +256,7 @@ export async function withdrawPackage(body: WithdrawPackage) {
   const query = `
     UPDATE SEA.dbo.State_Plan
       SET 
-        SPW_Status_ID = (Select SPW_Status_ID from SEA.dbo.SPW_Status where SPW_Status_DESC = '${SEATOOL_STATUS.WITHDRAWN}')
+        SPW_Status_ID = (SELECT SPW_Status_ID FROM SEA.dbo.SPW_Status WHERE SPW_Status_DESC = '${SEATOOL_STATUS.WITHDRAWN}'),
         Status_Date = dateadd(s, convert(int, left(${today}, 10)), cast('19700101' as datetime))
       WHERE ID_Number = '${body.id}'
   `;


### PR DESCRIPTION
## Purpose

This fixes behavior whereby the Status_Date field in seatool, mapping to Status Date in our UI, would not be updated when the status changed.

#### Linked Issues to Close

Closes https://qmacbis.atlassian.net/browse/OY2-26938

## Approach

A little history:  We previously had been showing the Changed Date field from seatool underneath the Status Date label in our UI.  This field would automatically update anytime something in the record changed, so status date had been updating on change.  A few weeks ago we received guidance that the Status Date field should show seatool's Status_Date, so we made that change.  But Status_Date, it turns out, does not auto update on status change.  When we discovered it wasn't updating as expected, we learned that it's the Seatool C# frontend that affects the Status_Date change.  So, we replicate that behavior here.

Any time we make a submission or take action that updates the status in seatool, we now set Status_Date as well.  This field behaves much like other dates in seatool, only representing the current day at midnight UTC.  So, the status date value is set in the api layer and uses the same seatoolFriendlyTimestamp() as others.

Also affected is the Final Disposition Date in our UI.  This field is inferred by either the approved date or status date from seatool.  So, now when a package is withdrawn or approved, the Final Disposition Date correctly shows that final status change date.

This doesn't show much, but here's the status date reflected correctly for a withdrawn package, along with Final Disposition Date.
<img width="1211" alt="Screen Shot 2024-01-11 at 7 08 28 AM" src="https://github.com/Enterprise-CMCS/macpro-mako/assets/48921055/d1bc9574-6bfd-4e32-8a86-0590a306f07f">


## Assorted Notes/Considerations/Learning

None