### PR TITLE
feat: add readonly view for webforms

### DIFF
--- a/src/packages/shared-types/forms.ts
+++ b/src/packages/shared-types/forms.ts
@@ -20,6 +20,7 @@ export interface FormSchema {
 
 export type RHFSlotProps = {
   name: string;
+  readonly?: boolean;
   label?: string;
   labelStyling?: string;
   formItemStyling?: string;
@@ -97,6 +98,7 @@ export type FieldArrayProps<
 > = {
   control: Control<T, unknown>;
   name: TFieldArrayName;
+  readonly?: boolean;
   fields: RHFSlotProps[];
   groupNamePrefix?: string;
   appendText?: string;
@@ -107,6 +109,7 @@ export type FieldGroupProps<
   TFieldArrayName extends FieldArrayPath<T> = FieldArrayPath<T>
 > = {
   control: Control<T, unknown>;
+  readonly?: boolean;
   name: TFieldArrayName;
   fields: RHFSlotProps[];
   appendText?: string;

--- a/src/services/ui/src/components/RHF/Document.tsx
+++ b/src/services/ui/src/components/RHF/Document.tsx
@@ -3,28 +3,32 @@ import { Control, FieldValues } from "react-hook-form";
 import { FormLabel } from "../Inputs";
 import { RHFSection } from "./Section";
 import { FormSchema } from "shared-types";
+import { ReadOnlyContextProvider } from "./utils";
 
 export const RHFDocument = <TFieldValues extends FieldValues>(props: {
   document: FormSchema;
   control: Control<TFieldValues>;
+  readonly?: boolean;
 }) => {
   return (
     <div>
-      <div className="h-[5px] bg-gradient-to-r from-primary from-50% to-[#02bfe7] to-[66%] rounded-t"></div>
-      <div className="py-4 px-8 border-2 border-t-0 mt-0">
-        <div className="mb-3 mt-9">
-          <FormLabel className="font-bold text-4xl px-8 inline-block leading-[48px]">
-            {props.document.header}
-          </FormLabel>
+      <ReadOnlyContextProvider readonly={!!props.readonly}>
+        <div className="h-[5px] bg-gradient-to-r from-primary from-50% to-[#02bfe7] to-[66%] rounded-t"></div>
+        <div className="py-4 px-8 border-2 border-t-0 mt-0">
+          <div className="mb-3 mt-9">
+            <FormLabel className="font-bold text-4xl px-8 inline-block leading-[48px]">
+              {props.document.header}
+            </FormLabel>
+          </div>
+          {props.document.sections.map((SEC, index) => (
+            <RHFSection
+              key={`rhf-section-${index}-${SEC.title}`}
+              control={props.control}
+              section={SEC}
+            />
+          ))}
         </div>
-        {props.document.sections.map((SEC, index) => (
-          <RHFSection
-            key={`rhf-section-${index}-${SEC.title}`}
-            control={props.control}
-            section={SEC}
-          />
-        ))}
-      </div>
+      </ReadOnlyContextProvider>
     </div>
   );
 };

--- a/src/services/ui/src/components/RHF/FieldArray.tsx
+++ b/src/services/ui/src/components/RHF/FieldArray.tsx
@@ -38,18 +38,20 @@ export const RHFFieldArray = <TFields extends FieldValues>(
                 <FormField
                   key={adjustedSlotName}
                   control={props.control}
+                  disabled={!!props.readonly}
                   name={adjustedSlotName as never}
                   {...(SLOT.rules && { rules: SLOT.rules })}
                   render={RHFSlot({
                     ...SLOT,
                     control: props.control,
+                    readonly: props.readonly,
                     name: adjustedSlotName,
                     groupNamePrefix: adjustedPrefix,
                   })}
                 />
               );
             })}
-            {index >= 1 && (
+            {!props.readonly && index >= 1 && (
               <Trash2
                 className="self-end mb-4 cursor-pointer stroke-primary"
                 onClick={() => fieldArr.remove(index)}
@@ -59,10 +61,12 @@ export const RHFFieldArray = <TFields extends FieldValues>(
         );
       })}
       <div className="flex items-center mt-2">
-        <Button type="button" size="sm" onClick={onAppend} variant="outline">
-          <Plus className="h-5 w-5 mr-2" />
-          {props.appendText ?? "New Row"}
-        </Button>
+        {!props.readonly && (
+          <Button type="button" size="sm" onClick={onAppend} variant="outline">
+            <Plus className="h-5 w-5 mr-2" />
+            {props.appendText ?? "New Row"}
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/src/services/ui/src/components/RHF/FieldGroup.tsx
+++ b/src/services/ui/src/components/RHF/FieldGroup.tsx
@@ -39,17 +39,19 @@ export const FieldGroup = <TFields extends FieldValues>(
                   key={adjustedSlotName}
                   control={props.control}
                   name={adjustedSlotName as never}
+                  disabled={!!props.readonly}
                   {...(SLOT.rules && { rules: SLOT.rules })}
                   render={RHFSlot({
                     ...SLOT,
                     control: props.control,
+                    readonly: props.readonly,
                     name: adjustedSlotName,
                     groupNamePrefix: adjustedPrefix,
                   })}
                 />
               );
             })}
-            {index >= 1 && (
+            {!props.readonly && index >= 1 && (
               <Button
                 className="self-end m-2 mr-0"
                 variant={"destructive"}
@@ -66,12 +68,14 @@ export const FieldGroup = <TFields extends FieldValues>(
           </div>
         );
       })}
-      <div className="flex items-center mt-2 self-end">
-        <Button type="button" size="sm" onClick={onAppend} variant="default">
-          <Plus className="h-5 w-5 mr-2" />
-          {props.appendText ?? "New Group"}
-        </Button>
-      </div>
+      {!props.readonly && (
+        <div className="flex items-center mt-2 self-end">
+          <Button type="button" size="sm" onClick={onAppend} variant="default">
+            <Plus className="h-5 w-5 mr-2" />
+            {props.appendText ?? "New Group"}
+          </Button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/services/ui/src/components/RHF/FormGroup.tsx
+++ b/src/services/ui/src/components/RHF/FormGroup.tsx
@@ -3,12 +3,16 @@ import { FormLabel, FormField } from "../Inputs";
 import { DependencyWrapper } from "./dependencyWrapper";
 import { RHFSlot } from "./Slot";
 import * as TRhf from "shared-types";
+import { useReadOnlyContext } from "./utils";
 
 export const RHFFormGroup = <TFieldValues extends FieldValues>(props: {
   form: TRhf.FormGroup;
   control: Control<TFieldValues>;
   groupNamePrefix?: string;
+  childReadonly?: boolean;
 }) => {
+  const { readonly } = useReadOnlyContext();
+
   return (
     <DependencyWrapper {...props.form}>
       <div className="py-4">
@@ -24,10 +28,12 @@ export const RHFFormGroup = <TFieldValues extends FieldValues>(props: {
             <DependencyWrapper key={SLOT.name} {...SLOT}>
               <FormField
                 control={props.control}
+                disabled={props.childReadonly ?? readonly}
                 name={((props.groupNamePrefix ?? "") + SLOT.name) as never}
                 {...(SLOT.rules && { rules: SLOT.rules })}
                 render={RHFSlot({
                   ...SLOT,
+                  readonly: props.childReadonly ?? readonly,
                   control: props.control as Control,
                   groupNamePrefix: props.groupNamePrefix,
                 })}

--- a/src/services/ui/src/components/RHF/Slot.tsx
+++ b/src/services/ui/src/components/RHF/Slot.tsx
@@ -36,6 +36,7 @@ export const RHFSlot = <
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
 >({
   control,
+  readonly,
   rhf,
   label,
   description,
@@ -77,21 +78,21 @@ export const RHFSlot = <
             {rhf === "Input" &&
               (() => {
                 const hops = props as RHFComponentMap["Input"];
-                return <Input {...hops} {...field} />;
+                return <Input disabled={!!readonly} {...hops} {...field} />;
               })()}
 
             {/* ----------------------------------------------------------------------------- */}
             {rhf === "Textarea" &&
               (() => {
                 const hops = props as RHFComponentMap["Textarea"];
-                return <Textarea {...hops} {...field} />;
+                return <Textarea disabled={!!readonly} {...hops} {...field} />;
               })()}
 
             {/* ----------------------------------------------------------------------------- */}
             {rhf === "Switch" &&
               (() => {
                 const hops = props as RHFComponentMap["Switch"];
-                return <Switch {...hops} {...field} />;
+                return <Switch disabled={!!readonly} {...hops} {...field} />;
               })()}
 
             {/* ----------------------------------------------------------------------------- */}
@@ -114,6 +115,7 @@ export const RHFSlot = <
                     {...hops}
                     onValueChange={field.onChange}
                     defaultValue={field.value}
+                    disabled={!!readonly}
                   >
                     <SelectTrigger {...hops}>
                       <SelectValue {...hops} />
@@ -138,6 +140,7 @@ export const RHFSlot = <
                     onValueChange={field.onChange}
                     defaultValue={field.value}
                     className="flex flex-col space-y-1"
+                    disabled={!!readonly}
                   >
                     {hops.options.map((OPT) => {
                       return (
@@ -165,6 +168,7 @@ export const RHFSlot = <
                                     form={FORM}
                                     control={control}
                                     groupNamePrefix={groupNamePrefix}
+                                    childReadonly={readonly}
                                   />
                                 </div>
                               );
@@ -179,8 +183,13 @@ export const RHFSlot = <
                                 <FormField
                                   control={control}
                                   name={(groupNamePrefix ?? "") + SLOT.name}
+                                  disabled={readonly}
                                   {...(SLOT.rules && { rules: SLOT.rules })}
-                                  render={RHFSlot({ ...SLOT, control })}
+                                  render={RHFSlot({
+                                    ...SLOT,
+                                    control,
+                                    readonly,
+                                  })}
                                 />
                               </div>
                             ))}
@@ -202,6 +211,7 @@ export const RHFSlot = <
                         <Checkbox
                           label={OPT.label}
                           value={OPT.value}
+                          disabled={!!readonly}
                           checked={field.value?.includes(OPT.value)}
                           onCheckedChange={(c) => {
                             const filtered =
@@ -225,9 +235,10 @@ export const RHFSlot = <
                             >
                               <FormField
                                 control={control}
+                                disabled={readonly}
                                 name={(groupNamePrefix ?? "") + SLOT.name}
                                 {...(SLOT.rules && { rules: SLOT.rules })}
-                                render={RHFSlot({ ...SLOT, control })}
+                                render={RHFSlot({ ...SLOT, control, readonly })}
                               />
                             </div>
                           ))}
@@ -242,6 +253,7 @@ export const RHFSlot = <
                               <RHFFormGroup
                                 control={control}
                                 form={FORM}
+                                childReadonly={readonly}
                                 groupNamePrefix={groupNamePrefix}
                               />
                             </div>
@@ -262,6 +274,7 @@ export const RHFSlot = <
                       <FormControl>
                         <Button
                           variant={"outline"}
+                          disabled={!!readonly}
                           className={cn(
                             "w-[240px] pl-3 text-left font-normal",
                             !field.value && "text-muted-foreground"
@@ -295,6 +308,7 @@ export const RHFSlot = <
                 control={control}
                 name={name}
                 fields={rest.fields ?? []}
+                readonly={!!readonly}
                 groupNamePrefix={groupNamePrefix}
                 {...(props as RHFComponentMap["FieldArray"])}
               />
@@ -306,6 +320,7 @@ export const RHFSlot = <
                 control={control}
                 name={name}
                 fields={rest.fields ?? []}
+                readonly={!!readonly}
                 groupNamePrefix={groupNamePrefix}
                 {...(props as RHFComponentMap["FieldGroup"])}
               />

--- a/src/services/ui/src/components/RHF/utils/index.ts
+++ b/src/services/ui/src/components/RHF/utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./initializer";
 export * from "./validator";
+export * from "./readonlyContext";

--- a/src/services/ui/src/components/RHF/utils/readonlyContext.tsx
+++ b/src/services/ui/src/components/RHF/utils/readonlyContext.tsx
@@ -1,0 +1,22 @@
+import { PropsWithChildren, createContext, useContext } from "react";
+
+interface ReadOnlyContextType {
+  readonly: boolean;
+}
+
+export const ReadOnlyContext = createContext<ReadOnlyContextType>({
+  readonly: false,
+});
+
+export const useReadOnlyContext = () => useContext(ReadOnlyContext);
+
+export const ReadOnlyContextProvider = ({
+  children,
+  ...props
+}: PropsWithChildren<ReadOnlyContextType>) => {
+  return (
+    <ReadOnlyContext.Provider value={props}>
+      {children}
+    </ReadOnlyContext.Provider>
+  );
+};

--- a/src/services/ui/src/components/Webform/footer.tsx
+++ b/src/services/ui/src/components/Webform/footer.tsx
@@ -1,6 +1,6 @@
 export const Footer = () => {
   return (
-    <div className="flex flex-col gap-2 my-6 text-sm text-slate-500">
+    <footer className="flex flex-col gap-2 my-6 text-sm text-slate-500">
       <b>{"PRA Disclosure Statement"}</b>
       <p>
         {
@@ -31,6 +31,6 @@ export const Footer = () => {
           "CMS, 7500 Security Boulevard, Attn: PRA Reports Clearance Officer, Mail Stop C4-26-05, Baltimore, Maryland 21244-1850."
         }
       </p>
-    </div>
+    </footer>
   );
 };

--- a/src/services/ui/src/components/Webform/index.tsx
+++ b/src/services/ui/src/components/Webform/index.tsx
@@ -91,12 +91,14 @@ function WebformBody({
       <Form {...form}>
         <form onSubmit={onSubmit} className="space-y-6">
           <RHFDocument document={data} {...form} readonly={readonly} />
-          <div className="flex justify-between text-blue-700 underline">
-            <Button type="button" onClick={onSave} variant="ghost">
-              Save draft
-            </Button>
-            <Button type="submit">Submit</Button>
-          </div>
+          {!readonly && (
+            <div className="flex justify-between text-blue-700 underline">
+              <Button type="button" onClick={onSave} variant="ghost">
+                Save draft
+              </Button>
+              <Button type="submit">Submit</Button>
+            </div>
+          )}
         </form>
       </Form>
       <Footer />
@@ -124,7 +126,7 @@ export function Webform() {
   return (
     <WebformBody
       data={data}
-      readonly={readonly}
+      readonly={true}
       id={id}
       version={version}
       values={savedData ? JSON.parse(savedData) : defaultValues}

--- a/src/services/ui/src/components/Webform/index.tsx
+++ b/src/services/ui/src/components/Webform/index.tsx
@@ -7,6 +7,8 @@ import { useGetForm } from "@/api";
 import { LoadingSpinner } from "@/components";
 import { Footer } from "./footer";
 import { Link, useParams } from "../Routing";
+import { FormSchema } from "shared-types";
+import { useReadOnlyUser } from "./useReadOnlyUser";
 
 export const Webforms = () => {
   return (
@@ -41,15 +43,23 @@ export const Webforms = () => {
   );
 };
 
-export function Webform() {
-  const { id, version } = useParams("/webform/:id/:version");
+interface WebformBodyProps {
+  id: string;
+  version: string;
+  data: FormSchema;
+  readonly: boolean;
+  values: any;
+}
 
-  const { data, isLoading, error } = useGetForm(id as string, version);
-
-  const defaultValues = data ? documentInitializer(data) : {};
-  const savedData = localStorage.getItem(`${id}v${version}`);
+function WebformBody({
+  version,
+  id,
+  data,
+  values,
+  readonly,
+}: WebformBodyProps) {
   const form = useForm({
-    defaultValues: savedData ? JSON.parse(savedData) : defaultValues,
+    defaultValues: values,
   });
 
   const onSave = () => {
@@ -76,20 +86,11 @@ export function Webform() {
     }
   );
 
-  if (isLoading) return <LoadingSpinner />;
-  if (error || !data) {
-    return (
-      <div className="max-w-screen-xl mx-auto p-4 py-8 lg:px-8">
-        {`There was an error loading ${id}`}
-      </div>
-    );
-  }
-
   return (
     <div className="max-w-screen-xl mx-auto p-4 py-8 lg:px-8">
       <Form {...form}>
         <form onSubmit={onSubmit} className="space-y-6">
-          <RHFDocument document={data} {...form} />
+          <RHFDocument document={data} {...form} readonly={readonly} />
           <div className="flex justify-between text-blue-700 underline">
             <Button type="button" onClick={onSave} variant="ghost">
               Save draft
@@ -100,5 +101,33 @@ export function Webform() {
       </Form>
       <Footer />
     </div>
+  );
+}
+
+export function Webform() {
+  const { id, version } = useParams("/webform/:id/:version");
+
+  const { data, isLoading, error } = useGetForm(id as string, version);
+  const readonly = useReadOnlyUser();
+  const defaultValues = data ? documentInitializer(data) : {};
+  const savedData = localStorage.getItem(`${id}v${version}`);
+
+  if (isLoading) return <LoadingSpinner />;
+  if (error || !data) {
+    return (
+      <div className="max-w-screen-xl mx-auto p-4 py-8 lg:px-8">
+        {`There was an error loading ${id}`}
+      </div>
+    );
+  }
+
+  return (
+    <WebformBody
+      data={data}
+      readonly={readonly}
+      id={id}
+      version={version}
+      values={savedData ? JSON.parse(savedData) : defaultValues}
+    />
   );
 }

--- a/src/services/ui/src/components/Webform/useReadOnlyUser.tsx
+++ b/src/services/ui/src/components/Webform/useReadOnlyUser.tsx
@@ -1,0 +1,8 @@
+import { useGetUser } from "@/api/useGetUser";
+import { CMS_READ_ONLY_ROLES } from "shared-types";
+
+export const useReadOnlyUser = () => {
+  const { data } = useGetUser();
+  const role = data?.user?.["custom:cms-roles"];
+  return CMS_READ_ONLY_ROLES.some((el) => role?.includes(el));
+};


### PR DESCRIPTION
## Purpose

Automatically sets forms into read only mode for certain CMS roles as noted in OY2-26331. Also adds a few minor bug/chore fixes.

#### Linked Issues to Close

Ticket [OY2-26331](https://qmacbis.atlassian.net/browse/OY2-26331?atlOrigin=eyJpIjoiMWQ0Mjc3NTk1MGIzNGZiYjhiYzEwMTU3YTk3ZDQxMzIiLCJwIjoiaiJ9)

## Approach

Three different approaches attempted
- transparent div blocking interaction (bad idea carried from previous project)
- readonly being set via a context every input read (wasted time and interacted with too many files for this goal)
- context sets read only specifically in the rhf wrappers for components, passing in a disabled for the controller and readonly for the component.

## Assorted Notes/Considerations/Learning

- Changed footer to be a footer based on feedback many weeks prior
- Altered Webform component to do loading of values before useFormHook to set default values properly. This should remove the error message of interacting with an uncontrolled component whose value was undefined.
