### PR TITLE
fix(checkbox): using formContext hook outside of forms

### DIFF
--- a/src/services/ui/src/components/RHF/dependencyWrapper.tsx
+++ b/src/services/ui/src/components/RHF/dependencyWrapper.tsx
@@ -26,7 +26,22 @@ const checkTriggeringValue = (
   });
 };
 
-export const DependencyWrapper = ({
+export const DependencyWrapper = (
+  props: PropsWithChildren<DependencyWrapperProps>
+) => {
+  // Check for dependencies which won't exist outside of forms
+  if (
+    !props.dependency ||
+    !props.dependency.conditions ||
+    !props.dependency.effect
+  ) {
+    return <>{props.children}</>;
+  }
+
+  return <DependencyWrapperHandler {...props} />;
+};
+
+const DependencyWrapperHandler = ({
   name,
   dependency,
   children,


### PR DESCRIPTION
## Purpose

DependencyWrapper wraps the options in a rendered checkbox, but was pulling in a RHF hook into a non-form context. This adds a layer to prevent that in those cases. 