### PR TITLE
fix(faq btn): remove asChild from faq btn

### DIFF
--- a/src/services/ui/src/pages/welcome/index.tsx
+++ b/src/services/ui/src/pages/welcome/index.tsx
@@ -188,7 +188,7 @@ export const Welcome = () => {
       <section>
         <div className="flex justify-around items-center text-xl px-10 py-4 max-w-screen-xl mx-auto">
           <h4>Do you have questions or need support?</h4>
-          <Button asChild>
+          <Button>
             <Link path={"/faq"} target={FAQ_TAB}>
               View FAQ
             </Link>


### PR DESCRIPTION
removing asChild prop from faq button link on home page 

![image](https://github.com/Enterprise-CMCS/macpro-mako/assets/3784116/af465fe3-7814-4163-8a57-a65954cdef4d)
