### PR TITLE
fix(only show onemac):  Filter out any records from dashboard that did not originate from onemac legacy or micro

### DIFF
--- a/src/packages/shared-types/opensearch/main/index.ts
+++ b/src/packages/shared-types/opensearch/main/index.ts
@@ -36,9 +36,3 @@ export type State = QueryState<Field>;
 export type Aggs = AggQuery<Field>;
 
 export * from "./transforms";
-
-export const onemacOriginFilter = {
-  terms: {
-    "origin.keyword": ["OneMAC"],
-  },
-};

--- a/src/services/api/handlers/search.ts
+++ b/src/services/api/handlers/search.ts
@@ -2,7 +2,6 @@ import { response } from "../libs/handler";
 import { APIGatewayEvent } from "aws-lambda";
 import { getStateFilter } from "../libs/auth/user";
 import * as os from "./../../../libs/opensearch-lib";
-import { onemacOriginFilter } from "shared-types/opensearch/main";
 if (!process.env.osDomain) {
   throw "ERROR:  osDomain env variable is required,";
 }
@@ -28,7 +27,13 @@ export const getSearchData = async (event: APIGatewayEvent) => {
     if (stateFilter) {
       query.query.bool.must.push(stateFilter);
     }
-    query.query.bool.must.push(onemacOriginFilter);
+
+    // Only return records originating from OneMAC
+    query.query.bool.must.push({
+      terms: {
+        "origin.keyword": ["OneMAC"],
+      },
+    });
 
     query.from = query.from || 0;
     query.size = query.size || 100;


### PR DESCRIPTION
## Purpose

This removes any records from being returned by search, and displayed on the Dashboard, that did not originate from OneMAC Legacy or Micro

#### Linked Issues to Close

None

## Approach

env: https://d3rb3uospjoq1n.cloudfront.net/ 

It's time we now hide any records from the dashboard that did not originate from OneMAC legacy or micro.  The business has wanted this so people in OneMAC can't see and don't take action on records submitted directly through seatool, such as for another system.  Ex:  An MMDL submission was made, and a human input it into seatool; we don't want to show that record in OneMAC, to prevent confusion.

Long term, the plan is to include records from more origins.  Or perhaps have a convetion in the seatool record that can tell us "show this in onemac".  Ex:  We could say "if the seatool record's status memo has 'send to onemac' in its body, set a flag in the index to show this record".  The business doesn't need anything like this yet.

For now, we filter out anything that doesn't have an origin of OneMAC.  This is done by adjusting the query for the search endpoint.  It's important that these non-onemac-originating records still be sunk to our main index, so we can do things like check if a new submission's id already exists in seatool; we just don't want to show them to the user.  The item endpoint, which fetches an individual record's data, has been left unchanged.  This was done for two reasons:
1. we currently use the item endpoint to check if a new submission's id already exists.  it would be ideal if we could continue using it in this capacity, and filtering out non-onemac-origin records would make this impossible without modification.
2. Our understanding is that the non-onemac-originating records are being hidden to prevent end user confusion and mistakes, not due to security concerns.  All auth remains in place for getting individual records or searching.  So, we should be able to not filter on origin when getting individual items.

## Assorted Notes/Considerations/Learning

None