### PR TITLE
fix(text typo):  Fix language in the withdraw rai response text

### DIFF
--- a/src/services/ui/src/pages/detail/admin-changes/index.tsx
+++ b/src/services/ui/src/pages/detail/admin-changes/index.tsx
@@ -17,7 +17,7 @@ export const AC_WithdrawEnabled: FC<opensearch.changelog.Document> = (
     <div className="flex flex-col gap-2">
       <p className="font-bold">Change made</p>
       <p>
-        {props.submitterName} has enabled package action to submit formal RAI
+        {props.submitterName} has enabled package action to withdraw formal RAI
         response
       </p>
     </div>
@@ -31,7 +31,7 @@ export const AC_WithdrawDisabled: FC<opensearch.changelog.Document> = (
     <div className="flex flex-col gap-2">
       <p className="font-bold">Change made</p>
       <p>
-        {props.submitterName} has disabled package action to submit formal RAI
+        {props.submitterName} has disabled package action to withdraw formal RAI
         response
       </p>
     </div>


### PR DESCRIPTION
## Purpose

This updates the text for enable/disable rai response withdraw to use the word 'withdraw' rather than 'submit'.

#### Linked Issues to Close

None

## Approach

N/A

## Assorted Notes/Considerations/Learning

None