### PR TITLE
feat(add auto users):  Add users for automated testing

### DIFF
--- a/src/services/auth/libs/users.json
+++ b/src/services/auth/libs/users.json
@@ -29,6 +29,35 @@
     ]
   },
   {
+    "username": "automated-state@example.com",
+    "attributes": [
+      {
+        "Name": "email",
+        "Value": "automated-state@example.com"
+      },
+      {
+        "Name": "given_name",
+        "Value": "Otto"
+      },
+      {
+        "Name": "family_name",
+        "Value": "State"
+      },
+      {
+        "Name": "email_verified",
+        "Value": "true"
+      },
+      {
+        "Name": "custom:state",
+        "Value": "TX,CA,NY,FL"
+      },
+      {
+        "Name": "custom:cms-roles",
+        "Value": "onemac-micro-statesubmitter"
+      }
+    ]
+  },
+  {
     "username": "readonly@example.com",
     "attributes": [
       {
@@ -42,6 +71,35 @@
       {
         "Name": "family_name",
         "Value": "Only"
+      },
+      {
+        "Name": "email_verified",
+        "Value": "true"
+      },
+      {
+        "Name": "custom:state",
+        "Value": ""
+      },
+      {
+        "Name": "custom:cms-roles",
+        "Value": "onemac-micro-readonly"
+      }
+    ]
+  },
+  {
+    "username": "automated-readonly@example.com",
+    "attributes": [
+      {
+        "Name": "email",
+        "Value": "automated-readonly@example.com"
+      },
+      {
+        "Name": "given_name",
+        "Value": "Otto"
+      },
+      {
+        "Name": "family_name",
+        "Value": "Readonly"
       },
       {
         "Name": "email_verified",
@@ -87,6 +145,35 @@
     ]
   },
   {
+    "username": "automated-reviewer@example.com",
+    "attributes": [
+      {
+        "Name": "email",
+        "Value": "automated-reviewer@example.com"
+      },
+      {
+        "Name": "given_name",
+        "Value": "Otto"
+      },
+      {
+        "Name": "family_name",
+        "Value": "Reviewer"
+      },
+      {
+        "Name": "email_verified",
+        "Value": "true"
+      },
+      {
+        "Name": "custom:state",
+        "Value": ""
+      },
+      {
+        "Name": "custom:cms-roles",
+        "Value": "onemac-micro-reviewer"
+      }
+    ]
+  },
+  {
     "username": "helpdesk@example.com",
     "attributes": [
       {
@@ -96,6 +183,35 @@
       {
         "Name": "given_name",
         "Value": "CMS"
+      },
+      {
+        "Name": "family_name",
+        "Value": "Helpdesk"
+      },
+      {
+        "Name": "email_verified",
+        "Value": "true"
+      },
+      {
+        "Name": "custom:state",
+        "Value": ""
+      },
+      {
+        "Name": "custom:cms-roles",
+        "Value": "onemac-micro-helpdesk"
+      }
+    ]
+  },
+  {
+    "username": "automated-helpdesk@example.com",
+    "attributes": [
+      {
+        "Name": "email",
+        "Value": "automated-helpdesk@example.com"
+      },
+      {
+        "Name": "given_name",
+        "Value": "Otto"
       },
       {
         "Name": "family_name",


### PR DESCRIPTION
## Purpose

This adds new state, reviewer, helpdesk, and readonly users to all dev pipelines and master.  These are for the exclusive use of the automated test framework being built.

#### Linked Issues to Close

None

## Approach

- Added a user for state, reviewer, helpdesk, and readonly.
- Emails/usernames are of the format automated-state@example.com and so on.
- Names are of the format Otto State as so on.
- Otto State has no overlapping states with George.

## Assorted Notes/Considerations/Learning

Need to communicate the addition of these users to devs doing the tests.  We should show them where in source (the file being change in this PR) the users are defined.