### PR TITLE
chore(cognito):  Enable cognito for QE

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,7 +128,7 @@ jobs:
       - deploy
     env:
       baseurl: ${{ needs.deploy.outputs.app-url }}
-    if: ${{ github.ref != 'refs/heads/production' && github.ref != 'refs/heads/val' }}
+    if: ${{ github.ref != 'refs/heads/production' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/src/services/auth/serverless.yml
+++ b/src/services/auth/serverless.yml
@@ -85,13 +85,9 @@ resources:
             - ${self:custom.idmInfo.oidc_issuer, ""}
     BackWithCognito:
       Fn::Not:
-        - Fn::Or:
-            - Fn::Equals:
-                - ${sls:stage}
-                - production
-            - Fn::Equals:
-                - ${sls:stage}
-                - val
+        - Fn::Equals:
+            - ${sls:stage}
+            - production
   Resources:
     CognitoUserPool:
       Type: AWS::Cognito::UserPool


### PR DESCRIPTION
## Purpose

This changeset re-enables cognito login for val.  This is to support QE activity and automated testing.

#### Linked Issues to Close

None, direct ask.

## Approach

This functionality had been in place for months; we removed it in november.  So this was easy to undo... i just reverted the november commit.

## Assorted Notes/Considerations/Learning

None