### PR TITLE
fix(wf-reset): Small updates to webforms to improve testing

### DIFF
--- a/src/services/ui/src/components/Webform/index.tsx
+++ b/src/services/ui/src/components/Webform/index.tsx
@@ -8,6 +8,7 @@ import { LoadingSpinner } from "@/components";
 import { Footer } from "./footer";
 import { Link, useParams } from "../Routing";
 import { useReadOnlyUser } from "./useReadOnlyUser";
+import { useState } from "react";
 
 export const Webforms = () => {
   return (
@@ -72,6 +73,7 @@ function WebformBody({
   const form = useForm({
     defaultValues: values,
   });
+  const [subData, setSubData] = useState("");
 
   const onSave = () => {
     const values = form.getValues();
@@ -80,15 +82,16 @@ function WebformBody({
   };
 
   const reset = () => {
+    setSubData("");
     form.reset(documentInitializer(data));
     localStorage.removeItem(`${id}v${version}`);
+    alert("Data Cleared");
   };
 
   const onSubmit = form.handleSubmit(
     (draft) => {
       console.log({ draft });
-      alert(JSON.stringify(draft));
-      alert(JSON.stringify(draft, undefined, 2));
+      setSubData(JSON.stringify(draft, undefined, 2));
       /**
        * The validator is intended to be a replica of RHF validation.
        * To be used in backend api handlers to validate incoming/outgoing form data against document when...
@@ -131,6 +134,7 @@ function WebformBody({
           </fieldset>
         </form>
       </Form>
+      {subData && <pre className="my-2 text-sm">{subData}</pre>}
       <Footer />
     </div>
   );


### PR DESCRIPTION
## Purpose

for webforms... adding a reset button to clear data (especially helpful for saved data in local storage) also adding submitted data to bottom of form instead of console which should make editing and troubleshooting easier for the time being. 

No real impact other than some small improvements that make hcd testing easier. 

this doesnt need qa testing... if it looks functional ship it. 

![image](https://github.com/Enterprise-CMCS/macpro-mako/assets/3784116/3b9b8834-1e67-4f4d-995e-a8d38e5a37c7)

