### PR TITLE
chore(add val as prerelease):  Tell semantic release to publish prereleases off val.

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,11 @@
   },
   "release": {
     "branches": [
-      "production"
+      "production",
+      {
+        "name": "val",
+        "prerelease": true
+      }
     ],
     "plugins": [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
## Purpose

Prereleases will now be generated (like 1.0.0-val) when things ship to val.  Releases on production will continue.  
This will have the effect of notifying QE in slack of all things that were released, as soon as they are.  Hands off.  
