### PR TITLE
fix(e2e typo):  Add missing environment property to e2e tests, which was preventing val tests form running

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,6 +126,8 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       - deploy
+    environment:
+      name: ${{ startsWith(github.ref_name, 'snyk-') && 'snyk' || github.ref_name }}
     env:
       baseurl: ${{ needs.deploy.outputs.app-url }}
     if: ${{ github.ref != 'refs/heads/production' }}


### PR DESCRIPTION
## Purpose

This fixes an issue that was preventing e2e tests from successfully running in val.

#### Linked Issues to Close

None

## Approach

In short:  the e2e step has been looking at the dev acct in all cases, including val.  This corrects that, and now val's e2e tests will pull from the right acct.

## Assorted Notes/Considerations/Learning

None