### PR TITLE
fix(waivers): only allow Renewal and Initial waiver ids for Renew/Amend actions

### DIFF
--- a/src/services/ui/src/api/mocks/item.ts
+++ b/src/services/ui/src/api/mocks/item.ts
@@ -3,22 +3,41 @@ import { setupServer } from "msw/node";
 import { opensearch, SEATOOL_STATUS } from "shared-types";
 
 type GetItemBody = { id: string };
+type ItemTestFields = Pick<
+  opensearch.main.Document,
+  "id" | "seatoolStatus" | "actionType"
+>;
+
+const ID_SEPARATOR = "-";
+type IdParamKey = keyof opensearch.main.Document;
+// Because getItem(id: string) doesn't allow for easy object mocking,
+// to make tests easier, you can add params to the ids your tests use
+// and mock specific attributes.
+// e.x. existing-approved-at=New
+const getIdParam = (id: string, key: IdParamKey) =>
+  id
+    .split(ID_SEPARATOR)
+    .find((param: string) => param.includes(key))
+    ?.slice(key.length + 1); // + 1 to cover the `=` sign
 
 const handlers = [
   http.post<GetItemBody, GetItemBody>(
     "/item-mock-server",
     async ({ request }) => {
-      const { id} = await request.json();
+      const { id } = await request.json();
       return id.includes("existing")
         ? HttpResponse.json({
-          _id: id,
-          _source: {
-            id: id,
-            seatoolStatus: id.includes("approved") ? SEATOOL_STATUS.APPROVED : SEATOOL_STATUS.PENDING
-          } satisfies Pick<opensearch.main.Document, "id" | "seatoolStatus">,
-        })
+            _id: id,
+            _source: {
+              id: id,
+              seatoolStatus: id.includes("approved")
+                ? SEATOOL_STATUS.APPROVED
+                : SEATOOL_STATUS.PENDING,
+              actionType: getIdParam(id, "actionType") || "New",
+            } satisfies ItemTestFields,
+          })
         : new HttpResponse(null, { status: 404 });
-    }
+    },
   ),
 ];
 

--- a/src/services/ui/src/api/mocks/item.ts
+++ b/src/services/ui/src/api/mocks/item.ts
@@ -13,7 +13,7 @@ type IdParamKey = keyof opensearch.main.Document;
 // Because getItem(id: string) doesn't allow for easy object mocking,
 // to make tests easier, you can add params to the ids your tests use
 // and mock specific attributes.
-// e.x. existing-approved-at=New
+// e.x. existing-approved-actionType=New
 const getIdParam = (id: string, key: IdParamKey) =>
   id
     .split(ID_SEPARATOR)

--- a/src/services/ui/src/api/useGetItem.test.ts
+++ b/src/services/ui/src/api/useGetItem.test.ts
@@ -44,7 +44,6 @@ describe("zod schema helpers", () => {
   });
   afterEach(() => mockItem.server.resetHandlers());
   afterAll(() => mockItem.server.close());
-
   describe("idIsApproved", () => {
     it("returns false if no getItem fails", async () => {
       expect(await unit.idIsApproved("not-found")).toBe(false);
@@ -56,6 +55,24 @@ describe("zod schema helpers", () => {
 
     it("returns true if status is approved", async () => {
       expect(await unit.idIsApproved("existing-approved")).toBe(true);
+    });
+  });
+
+  describe("canBeRenewedOrAmended", () => {
+    it("returns true if item is New or Renew actionType", async () => {
+      const newCanRenewOrAmend = await unit.canBeRenewedOrAmended(
+        "existing-approved-actionType=New",
+      );
+      const renewCanRenewOrAmend = await unit.canBeRenewedOrAmended(
+        "existing-approved-actionType=Renew",
+      );
+      expect(newCanRenewOrAmend).toBe(true);
+      expect(renewCanRenewOrAmend).toBe(true);
+    });
+    it("returns false if an item is Amend actionType", async () => {
+      expect(
+        await unit.canBeRenewedOrAmended("existing-approved-actionType=Amend"),
+      ).toBe(false);
     });
   });
 });

--- a/src/services/ui/src/api/useGetItem.ts
+++ b/src/services/ui/src/api/useGetItem.ts
@@ -7,7 +7,7 @@ import { API } from "aws-amplify";
 import { opensearch, ReactQueryApiError, SEATOOL_STATUS } from "shared-types";
 
 export const getItem = async (
-  id: string
+  id: string,
 ): Promise<opensearch.main.ItemResult> =>
   await API.post("os", "/item", { body: { id } });
 
@@ -21,14 +21,24 @@ export const idIsApproved = async (id: string) => {
   }
 };
 
+export const canBeRenewedOrAmended = async (id: string) => {
+  try {
+    const record = await getItem(id);
+    return ["New", "Renew"].includes(record._source.actionType);
+  } catch (e) {
+    console.error(e);
+    return false;
+  }
+};
+
 export const useGetItem = (
   id: string,
-  options?: UseQueryOptions<opensearch.main.ItemResult, ReactQueryApiError>
+  options?: UseQueryOptions<opensearch.main.ItemResult, ReactQueryApiError>,
 ) => {
   return useQuery<opensearch.main.ItemResult, ReactQueryApiError>(
     ["record", id],
     () => getItem(id),
-    options
+    options,
   );
 };
 

--- a/src/services/ui/src/utils/zod.ts
+++ b/src/services/ui/src/utils/zod.ts
@@ -98,7 +98,10 @@ export const zAmendmentOriginalWaiverNumberSchema = z
     message:
       "According to our records, this 1915(b) Waiver Number does not yet exist. Please check the 1915(b) Initial or Renewal Waiver Number and try entering it again.",
   })
-  .refine(async (value) => canBeRenewedOrAmended(value), { message: "" })
+  .refine(async (value) => canBeRenewedOrAmended(value), {
+    message:
+      "The 1915(b) Waiver Number entered does not seem to match our records. Please enter an approved 1915(b) Initial or Renewal Waiver Number, using a dash after the two character state abbreviation.",
+  })
   .refine(async (value) => idIsApproved(value), {
     message:
       "According to our records, this 1915(b) Waiver Number is not approved. You must supply an approved 1915(b) Initial or Renewal Waiver Number.",
@@ -118,7 +121,10 @@ export const zRenewalOriginalWaiverNumberSchema = z
     message:
       "According to our records, this 1915(b) Waiver Number does not yet exist. Please check the 1915(b) Initial or Renewal Waiver Number and try entering it again.",
   })
-  .refine(async (value) => canBeRenewedOrAmended(value), { message: "" })
+  .refine(async (value) => canBeRenewedOrAmended(value), {
+    message:
+      "The 1915(b) Waiver Number entered does not seem to match our records. Please enter an approved 1915(b) Initial or Renewal Waiver Number, using a dash after the two character state abbreviation.",
+  })
   .refine(async (value) => idIsApproved(value), {
     message:
       "According to our records, this 1915(b) Waiver Number is not approved. You must supply an approved 1915(b) Initial or Renewal Waiver Number.",

--- a/src/services/ui/src/utils/zod.ts
+++ b/src/services/ui/src/utils/zod.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { isAuthorizedState } from "@/utils";
-import { idIsApproved, itemExists } from "@/api";
+import { canBeRenewedOrAmended, idIsApproved, itemExists } from "@/api";
 
 export const zSpaIdSchema = z
   .string()
@@ -98,6 +98,7 @@ export const zAmendmentOriginalWaiverNumberSchema = z
     message:
       "According to our records, this 1915(b) Waiver Number does not yet exist. Please check the 1915(b) Initial or Renewal Waiver Number and try entering it again.",
   })
+  .refine(async (value) => canBeRenewedOrAmended(value), { message: "" })
   .refine(async (value) => idIsApproved(value), {
     message:
       "According to our records, this 1915(b) Waiver Number is not approved. You must supply an approved 1915(b) Initial or Renewal Waiver Number.",
@@ -117,6 +118,7 @@ export const zRenewalOriginalWaiverNumberSchema = z
     message:
       "According to our records, this 1915(b) Waiver Number does not yet exist. Please check the 1915(b) Initial or Renewal Waiver Number and try entering it again.",
   })
+  .refine(async (value) => canBeRenewedOrAmended(value), { message: "" })
   .refine(async (value) => idIsApproved(value), {
     message:
       "According to our records, this 1915(b) Waiver Number is not approved. You must supply an approved 1915(b) Initial or Renewal Waiver Number.",
@@ -134,7 +136,7 @@ export const zExtensionWaiverNumberSchema = z
   .string()
   .regex(
     /^[A-Z]{2}-\d{4,5}\.R\d{2}\.TE\d{2}$/,
-    "The Temporary Extension Request Number must be in the format of SS-####.R##.TE## or SS-#####.R##.TE##"
+    "The Temporary Extension Request Number must be in the format of SS-####.R##.TE## or SS-#####.R##.TE##",
   )
   .refine((value) => isAuthorizedState(value), {
     message:
@@ -149,7 +151,7 @@ export const zExtensionOriginalWaiverNumberSchema = z
   .string()
   .regex(
     /^[A-Z]{2}-\d{4,5}\.R\d{2}\.00$/,
-    "The Approved Initial or Renewal Waiver Number must be in the format of SS-####.R##.00 or SS-#####.R##.00."
+    "The Approved Initial or Renewal Waiver Number must be in the format of SS-####.R##.00 or SS-#####.R##.00.",
   )
   .refine((value) => isAuthorizedState(value), {
     message:


### PR DESCRIPTION
## Purpose

This fixes a bug where you could Renew/Amend a Waiver Amendment. Only initial waivers and renewal waivers are renewable/amendable.

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-27691

## Approach

Added a helper func to `useGetItem.ts` and tested accordingly

## Assorted Notes/Considerations/Learning

Because `getItem` only takes an ID, we have to pipe custom value overrides thru test ids, such as `existing-approved-actionType=Amend`. I set up the tool to make this happen for any key in the `Document` type meaning anything can be customized so long as we plug it into the response body.
