### PR TITLE
feat(move to OR instance class):  Use the new opensearch instance class for our clusters.

### DIFF
--- a/src/services/data/serverless.yml
+++ b/src/services/data/serverless.yml
@@ -261,27 +261,19 @@ stepFunctions:
 params:
   master:
     osInstanceType: or1.large.search
-    osVolumeType: gp3
-    osVolumeSize: 20
     topicNamespace: ""
     sinkProvisionedConcurrency: 2
   val:
     osInstanceType: or1.large.search
-    osVolumeType: gp3
-    osVolumeSize: 20
     topicNamespace: ""
     sinkProvisionedConcurrency: 2
   production:
     bootstrapKibanaUsers: "false"
     osInstanceType: or1.large.search
-    osVolumeType: gp3
-    osVolumeSize: 20
     topicNamespace: ""
     sinkProvisionedConcurrency: 2
   default:
     osInstanceType: or1.medium.search
-    osVolumeType: gp3
-    osVolumeSize: 20
     bootstrapKibanaUsers: "true"
     topicNamespace: --${self:custom.project}--${sls:stage}--
     sinkProvisionedConcurrency: 0
@@ -610,8 +602,8 @@ resources:
             Value: ${sls:stage}
         EBSOptions:
           EBSEnabled: true
-          VolumeType: ${param:osVolumeType}
-          VolumeSize: ${param:osVolumeSize}
+          VolumeType: gp3
+          VolumeSize: 20
         ClusterConfig:
           InstanceType: ${param:osInstanceType}
           InstanceCount:


### PR DESCRIPTION
## Purpose

Last year, amazon released some opensearch specific instance types, 'or'.  This moves to that, and also upgrades opensearch from 2.3 to 2.11, a requirement of using the new type.

#### Linked Issues to Close

Closes https://qmacbis.atlassian.net/browse/OY2-27044

## Approach

The upper environments remain on a large, which is a bit more expensive but has twice the ram.

The lower environments are moved from the smallest t3 instance to the smallest or instance.  There is a price increase, but for the increased performance in the lower level, it seems a reasonable trade.

## Assorted Notes/Considerations/Learning

- Due to lifecycle nuance, the data service needs to be destroyed before this code will successfully deploy.