### PR TITLE
fix(assorted):  Rare race condition and improved destroys

### DIFF
--- a/src/services/data/serverless.yml
+++ b/src/services/data/serverless.yml
@@ -27,6 +27,10 @@ provider:
       path: /delegatedadmin/developer/
       permissionsBoundary: arn:aws:iam::${aws:accountId}:policy/cms-cloud-admin/developer-boundary-policy
       statements:
+        - Effect: Deny # Prevents delayed custom resource logs from re-creating log groups after deletion.
+          Action:
+            - logs:CreateLogGroup
+          Resource: "*"
         - Effect: "Allow"
           Action:
             - cognito-idp:AdminCreateUser

--- a/src/services/ui-infra/serverless.yml
+++ b/src/services/ui-infra/serverless.yml
@@ -18,6 +18,10 @@ provider:
       path: /delegatedadmin/developer/
       permissionsBoundary: arn:aws:iam::${aws:accountId}:policy/cms-cloud-admin/developer-boundary-policy
       statements:
+        - Effect: Deny # Prevents delayed custom resource logs from re-creating log groups after deletion.
+          Action:
+            - logs:CreateLogGroup
+          Resource: "*"
         - Effect: "Allow"
           Action:
             - s3:ListBucketVersions

--- a/src/services/uploads/serverless.yml
+++ b/src/services/uploads/serverless.yml
@@ -21,6 +21,10 @@ provider:
       path: /delegatedadmin/developer/
       permissionsBoundary: arn:aws:iam::${aws:accountId}:policy/cms-cloud-admin/developer-boundary-policy
       statements:
+        - Effect: Deny # Prevents delayed custom resource logs from re-creating log groups after deletion.
+          Action:
+            - logs:CreateLogGroup
+          Resource: "*"
         - Effect: "Allow"
           Action:
             - s3:GetObject


### PR DESCRIPTION
## Purpose

This holds a few assorted bug fixes.

#### Linked Issues to Close

None

## Approach

- Race condition on data deployment:  On first deployment, there's occasionally a failure if the MapRole custom resource does not run and complete before the reindex step function begins.  This is solved with a DependsOn attribute.
- Log group cleanup on destroy:  When we destroy branches, we often have some cloudwatch log groups left behind, not deleted.  It's inconsistent, but there's usually at least one.  In addition, it was noticed that all log groups that get orphaned are ones tied to a lambda function that backs a custom resource.  After a lot of tedious investigation, it was found that the custom resource can complete, which then allows the lambda and the log group to be deleted (in that order)... but there can be a small delay between the custom resource complete and its transmittal of the final log statement to cloudwatch.  When the log group has been deleted before this last log comes in, the log group gets recreated.  This is an annoyance if we were to redeploy that branch, as the log group would fail to create as one already exists with that name.  This was solved by explicitly denying createloggroup permissions from the lambda's IAM role.  Our lambdas don't create log groups - cloudformation does - so this is no impact to our app.  By removing that permission, the last log message is not able to auto recreate the log group, fixing the original issue.  We don't care about that final log message because we know that it was a success, and we intended to immediately delete it anyway.

## Assorted Notes/Considerations/Learning

None