### PR TITLE
Update confirmation banner for TE submission

### DIFF
--- a/src/services/ui/src/features/package-actions/TemporaryExtension.tsx
+++ b/src/services/ui/src/features/package-actions/TemporaryExtension.tsx
@@ -10,7 +10,6 @@ import {
   FormMessage,
   Input,
   RequiredIndicator,
-  SectionCard,
   Select,
   SelectContent,
   SelectItem,
@@ -36,7 +35,6 @@ import { submit } from "@/api/submissionService";
 import { FormProvider, useForm, useFormContext } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { getItem } from "@/api";
-import { ItemResult } from "shared-types/opensearch/changelog";
 import { SlotAdditionalInfo } from "@/features";
 
 type Attachments = keyof z.infer<typeof tempExtensionSchema>["attachments"];
@@ -133,11 +131,9 @@ export const TempExtensionWrapper = () => {
 export const TemporaryExtension = () => {
   const { handleSubmit, formMethods } = SC.useSubmitForm();
   const { id: urlId, authority: urlAuthority } = useParams();
-  const formId = formMethods.getValues("originalWaiverNumber");
   const formAuthority = formMethods.getValues("authority");
   const authority = urlAuthority ? urlAuthority : formAuthority;
 
-  const parentId = urlId ? urlId : formId;
   SC.useDisplaySubmissionAlert(
     "Temporary Extension Request submitted.",
     "Your submission has been received.",

--- a/src/services/ui/src/features/package-actions/TemporaryExtension.tsx
+++ b/src/services/ui/src/features/package-actions/TemporaryExtension.tsx
@@ -139,8 +139,8 @@ export const TemporaryExtension = () => {
 
   const parentId = urlId ? urlId : formId;
   SC.useDisplaySubmissionAlert(
-    "Temporary Extension issued",
-    `The Temporary Extension Request for ${parentId} has been submitted.`,
+    "Temporary Extension Request submitted.",
+    "Your submission has been received.",
   );
 
   return (


### PR DESCRIPTION
## Purpose
> Update verbiage on submission confirmation banner for Temporary Extension request to: Temporary Extension Request submitted. Your submission has been received.

#### Linked Issues to Close
Jira Ticket: [OY2-27938 ](https://qmacbis.atlassian.net/browse/OY2-27938)
_Links to issue(s) that are closed by this PR. Be sure to use the phrase "Closes #XXX" for each issue, so they automatically close_

## Approach

Changed the text passed into the SC.useDisplaySubmissionAlert function.

## Assorted Notes/Considerations/Learning
- Andie still needs to wait on vpn access to run the repo to see if this looks as we want ❤️ 
