### PR TITLE
feat(webforms): Allow zero as a value in numeric input fields

### DIFF
--- a/src/services/api/webforms/ABP1/v202401.ts
+++ b/src/services/api/webforms/ABP1/v202401.ts
@@ -530,7 +530,7 @@ export const v202401: FormSchema = {
                                                         },
                                                         rules: {
                                                           pattern: {
-                                                            value: /^[1-9]\d*$/,
+                                                            value: /^[0-9]\d*$/,
                                                             message:
                                                               "Must be a positive integer value",
                                                           },
@@ -663,7 +663,7 @@ export const v202401: FormSchema = {
                                                             rules: {
                                                               pattern: {
                                                                 value:
-                                                                  /^[1-9]\d*$/,
+                                                                  /^[0-9]\d*$/,
                                                                 message:
                                                                   "Must be a positive integer value",
                                                               },
@@ -800,7 +800,7 @@ export const v202401: FormSchema = {
                                                             rules: {
                                                               pattern: {
                                                                 value:
-                                                                  /^[1-9]\d*$/,
+                                                                  /^[0-9]\d*$/,
                                                                 message:
                                                                   "Must be a positive integer value",
                                                               },
@@ -936,7 +936,7 @@ export const v202401: FormSchema = {
                                                             rules: {
                                                               pattern: {
                                                                 value:
-                                                                  /^[1-9]\d*$/,
+                                                                  /^[0-9]\d*$/,
                                                                 message:
                                                                   "Must be a positive integer value",
                                                               },

--- a/src/services/api/webforms/ABP1/v202402.ts
+++ b/src/services/api/webforms/ABP1/v202402.ts
@@ -502,7 +502,7 @@ export const v202402: FormSchema = {
                                                         },
                                                         rules: {
                                                           pattern: {
-                                                            value: /^[1-9]\d*$/,
+                                                            value: /^[0-9]\d*$/,
                                                             message:
                                                               "Must be a positive integer value",
                                                           },
@@ -637,7 +637,7 @@ export const v202402: FormSchema = {
                                                             rules: {
                                                               pattern: {
                                                                 value:
-                                                                  /^[1-9]\d*$/,
+                                                                  /^[0-9]\d*$/,
                                                                 message:
                                                                   "Must be a positive integer value",
                                                               },
@@ -774,7 +774,7 @@ export const v202402: FormSchema = {
                                                             rules: {
                                                               pattern: {
                                                                 value:
-                                                                  /^[1-9]\d*$/,
+                                                                  /^[0-9]\d*$/,
                                                                 message:
                                                                   "Must be a positive integer value",
                                                               },
@@ -910,7 +910,7 @@ export const v202402: FormSchema = {
                                                             rules: {
                                                               pattern: {
                                                                 value:
-                                                                  /^[1-9]\d*$/,
+                                                                  /^[0-9]\d*$/,
                                                                 message:
                                                                   "Must be a positive integer value",
                                                               },

--- a/src/services/api/webforms/ABP5/v202401.ts
+++ b/src/services/api/webforms/ABP5/v202401.ts
@@ -245,7 +245,7 @@ function subsectionFormFields({
       rules: {
         required: "* Required",
         pattern: {
-          value: /^[1-9]\d*$/,
+          value: /^[0-9]\d*$/,
           message: "Must be a positive integer value",
         },
       },
@@ -261,7 +261,7 @@ function subsectionFormFields({
       rules: {
         required: "* Required",
         pattern: {
-          value: /^[1-9]\d*$/,
+          value: /^[0-9]\d*$/,
           message: "Must be a positive integer value",
         },
       },
@@ -277,7 +277,7 @@ function subsectionFormFields({
       rules: {
         required: "* Required",
         pattern: {
-          value: /^[1-9]\d*$/,
+          value: /^[0-9]\d*$/,
           message: "Must be a positive integer value",
         },
       },


### PR DESCRIPTION
## Purpose

Previously, when a user added `0` as a value to a numeric-only input field, validation would fail. Instead, we would like users to have the option to enter `0` as a valid value. This PR changes the validation regex to allow this.

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-28085

## Approach

The validation regex was changed from `/^[1-9]\d*$/` to `/^[0-9]\d*$/`.