### PR TITLE
fix(webforms): Don't allow leading or trailing whitespace in input fields

### DIFF
--- a/src/services/api/webforms/ABP1/v202401.ts
+++ b/src/services/api/webforms/ABP1/v202401.ts
@@ -16,6 +16,10 @@ export const v202401: FormSchema = {
               label: "Alternative Benefit Plan population name",
               rules: {
                 required: "* Required",
+                pattern: {
+                  value: /^\S(.*\S)?$/,
+                  message: "Must not have leading or trailing whitespace.",
+                },
               },
               props: { placeholder: "enter name" },
             },
@@ -630,6 +634,12 @@ export const v202401: FormSchema = {
                                                         rules: {
                                                           required:
                                                             "* Required",
+                                                          pattern: {
+                                                            value:
+                                                              /^\S(.*\S)?$/,
+                                                            message:
+                                                              "Must not have leading or trailing whitespace.",
+                                                          },
                                                         },
                                                       },
                                                       {
@@ -767,6 +777,12 @@ export const v202401: FormSchema = {
                                                         rules: {
                                                           required:
                                                             "* Required",
+                                                          pattern: {
+                                                            value:
+                                                              /^\S(.*\S)?$/,
+                                                            message:
+                                                              "Must not have leading or trailing whitespace.",
+                                                          },
                                                         },
                                                       },
                                                       {
@@ -903,6 +919,12 @@ export const v202401: FormSchema = {
                                                         rules: {
                                                           required:
                                                             "* Required",
+                                                          pattern: {
+                                                            value:
+                                                              /^\S(.*\S)?$/,
+                                                            message:
+                                                              "Must not have leading or trailing whitespace.",
+                                                          },
                                                         },
                                                       },
                                                       {

--- a/src/services/api/webforms/ABP1/v202402.ts
+++ b/src/services/api/webforms/ABP1/v202402.ts
@@ -16,6 +16,10 @@ export const v202402: FormSchema = {
               label: "ABP package name",
               rules: {
                 required: "* Required",
+                pattern: {
+                  value: /^\S(.*\S)?$/,
+                  message: "Must not have leading or trailing whitespace.",
+                },
               },
               props: { placeholder: "enter name" },
             },
@@ -604,6 +608,12 @@ export const v202402: FormSchema = {
                                                         rules: {
                                                           required:
                                                             "* Required",
+                                                          pattern: {
+                                                            value:
+                                                              /^\S(.*\S)?$/,
+                                                            message:
+                                                              "Must not have leading or trailing whitespace.",
+                                                          },
                                                         },
                                                       },
                                                       {
@@ -741,6 +751,12 @@ export const v202402: FormSchema = {
                                                         rules: {
                                                           required:
                                                             "* Required",
+                                                          pattern: {
+                                                            value:
+                                                              /^\S(.*\S)?$/,
+                                                            message:
+                                                              "Must not have leading or trailing whitespace.",
+                                                          },
                                                         },
                                                       },
                                                       {
@@ -877,6 +893,12 @@ export const v202402: FormSchema = {
                                                         rules: {
                                                           required:
                                                             "* Required",
+                                                          pattern: {
+                                                            value:
+                                                              /^\S(.*\S)?$/,
+                                                            message:
+                                                              "Must not have leading or trailing whitespace.",
+                                                          },
                                                         },
                                                       },
                                                       {

--- a/src/services/api/webforms/ABP2A/v202401.ts
+++ b/src/services/api/webforms/ABP2A/v202401.ts
@@ -167,6 +167,11 @@ export const v202401: FormSchema = {
                         labelClassName: "font-bold",
                         rules: {
                           required: "* Required",
+                          pattern: {
+                            value: /^\S(.*\S)?$/,
+                            message:
+                              "Must not have leading or trailing whitespace.",
+                          },
                         },
                       },
                     ],
@@ -194,6 +199,10 @@ export const v202401: FormSchema = {
                 "When did/will the state/territory inform the individuals?",
               rules: {
                 required: "* Required",
+                pattern: {
+                  value: /^\S(.*\S)?$/,
+                  message: "Must not have leading or trailing whitespace.",
+                },
               },
               descriptionClassName: "font-bold text-black",
             },
@@ -275,6 +284,11 @@ export const v202401: FormSchema = {
                         labelClassName: "font-bold",
                         rules: {
                           required: "* Required",
+                          pattern: {
+                            value: /^\S(.*\S)?$/,
+                            message:
+                              "Must not have leading or trailing whitespace.",
+                          },
                         },
                       },
                     ],
@@ -317,6 +331,11 @@ export const v202401: FormSchema = {
                         labelClassName: "font-bold",
                         rules: {
                           required: "* Required",
+                          pattern: {
+                            value: /^\S(.*\S)?$/,
+                            message:
+                              "Must not have leading or trailing whitespace.",
+                          },
                         },
                       },
                     ],

--- a/src/services/api/webforms/ABP2B/v202401.ts
+++ b/src/services/api/webforms/ABP2B/v202401.ts
@@ -116,6 +116,11 @@ export const v202401: FormSchema = {
                         labelClassName: "font-bold",
                         rules: {
                           required: "* Required",
+                          pattern: {
+                            value: /^\S(.*\S)?$/,
+                            message:
+                              "Must not have leading or trailing whitespace.",
+                          },
                         },
                       },
                     ],
@@ -143,6 +148,10 @@ export const v202401: FormSchema = {
                 "When did/will the state/territory inform the individuals?",
               rules: {
                 required: "* Required",
+                pattern: {
+                  value: /^\S(.*\S)?$/,
+                  message: "Must not have leading or trailing whitespace.",
+                },
               },
               descriptionClassName: "font-bold text-black",
             },
@@ -224,6 +233,11 @@ export const v202401: FormSchema = {
                         labelClassName: "font-bold",
                         rules: {
                           required: "* Required",
+                          pattern: {
+                            value: /^\S(.*\S)?$/,
+                            message:
+                              "Must not have leading or trailing whitespace.",
+                          },
                         },
                       },
                     ],
@@ -266,6 +280,11 @@ export const v202401: FormSchema = {
                         labelClassName: "font-bold",
                         rules: {
                           required: "* Required",
+                          pattern: {
+                            value: /^\S(.*\S)?$/,
+                            message:
+                              "Must not have leading or trailing whitespace.",
+                          },
                         },
                       },
                     ],

--- a/src/services/api/webforms/ABP3/v202401.ts
+++ b/src/services/api/webforms/ABP3/v202401.ts
@@ -33,7 +33,13 @@ export const v202401: FormSchema = {
               name: "abp3_benefit-package_name_input",
               label: "Benefit package name",
               labelClassName: "font-bold",
-              rules: { required: "* Required" },
+              rules: {
+                required: "* Required",
+                pattern: {
+                  value: /^\S(.*\S)?$/,
+                  message: "Must not have leading or trailing whitespace.",
+                },
+              },
             },
           ],
         },
@@ -80,7 +86,14 @@ export const v202401: FormSchema = {
                                           rhf: "Input",
                                           label: "Plan name",
                                           name: "abp3_select-of-sect-1937-cov-opt_state-employee-coverage-plan-name_input",
-                                          rules: { required: "* Required" },
+                                          rules: {
+                                            required: "* Required",
+                                            pattern: {
+                                              value: /^\S(.*\S)?$/,
+                                              message:
+                                                "Must not have leading or trailing whitespace.",
+                                            },
+                                          },
                                         },
                                       ],
                                     },
@@ -97,7 +110,14 @@ export const v202401: FormSchema = {
                                           rhf: "Input",
                                           label: "Plan name",
                                           name: "abp3_select-of-sect-1937-cov-opt_commercial-hmo_input",
-                                          rules: { required: "* Required" },
+                                          rules: {
+                                            required: "* Required",
+                                            pattern: {
+                                              value: /^\S(.*\S)?$/,
+                                              message:
+                                                "Must not have leading or trailing whitespace.",
+                                            },
+                                          },
                                         },
                                       ],
                                     },
@@ -112,7 +132,14 @@ export const v202401: FormSchema = {
                                         {
                                           rhf: "Radio",
                                           name: "abp3_select-of-sect-1937-cov-opt_secretary-approved_radiogroup",
-                                          rules: { required: "* Required" },
+                                          rules: {
+                                            required: "* Required",
+                                            pattern: {
+                                              value: /^\S(.*\S)?$/,
+                                              message:
+                                                "Must not have leading or trailing whitespace.",
+                                            },
+                                          },
                                           props: {
                                             options: [
                                               {
@@ -225,7 +252,14 @@ export const v202401: FormSchema = {
                                           rhf: "Input",
                                           name: "abp3_select-of-sect-1937-cov-opt_state-employee-coverage-plan-name_input",
                                           label: "Plan name",
-                                          rules: { required: "* Required" },
+                                          rules: {
+                                            required: "* Required",
+                                            pattern: {
+                                              value: /^\S(.*\S)?$/,
+                                              message:
+                                                "Must not have leading or trailing whitespace.",
+                                            },
+                                          },
                                         },
                                       ],
                                     },
@@ -242,7 +276,14 @@ export const v202401: FormSchema = {
                                           rhf: "Input",
                                           name: "abp3_select-of-sect-1937-cov-opt_commercial-hmo-plan-name_input",
                                           label: "Plan name",
-                                          rules: { required: "* Required" },
+                                          rules: {
+                                            required: "* Required",
+                                            pattern: {
+                                              value: /^\S(.*\S)?$/,
+                                              message:
+                                                "Must not have leading or trailing whitespace.",
+                                            },
+                                          },
                                         },
                                       ],
                                     },
@@ -322,7 +363,13 @@ export const v202401: FormSchema = {
               rhf: "Input",
               label: "Plan name",
               name: "abp3_select-of-base-bench-plan_name_input",
-              rules: { required: "* Required" },
+              rules: {
+                required: "* Required",
+                pattern: {
+                  value: /^\S(.*\S)?$/,
+                  message: "Must not have leading or trailing whitespace.",
+                },
+              },
             },
           ],
         },

--- a/src/services/api/webforms/ABP3_1/v202401.ts
+++ b/src/services/api/webforms/ABP3_1/v202401.ts
@@ -40,6 +40,10 @@ export const v202401: FormSchema = {
               name: "abp3-1_benefit-package-details_name_input",
               rules: {
                 required: "* Required",
+                pattern: {
+                  value: /^\S(.*\S)?$/,
+                  message: "Must not have leading or trailing whitespace.",
+                },
               },
             },
           ],
@@ -91,6 +95,11 @@ export const v202401: FormSchema = {
                                       label: "Plan name",
                                       rules: {
                                         required: "* Required",
+                                        pattern: {
+                                          value: /^\S(.*\S)?$/,
+                                          message:
+                                            "Must not have leading or trailing whitespace.",
+                                        },
                                       },
                                     },
                                   ],
@@ -106,6 +115,11 @@ export const v202401: FormSchema = {
                                       label: "Plan name",
                                       rules: {
                                         required: "* Required",
+                                        pattern: {
+                                          value: /^\S(.*\S)?$/,
+                                          message:
+                                            "Must not have leading or trailing whitespace.",
+                                        },
                                       },
                                     },
                                   ],
@@ -238,6 +252,11 @@ export const v202401: FormSchema = {
                                       label: "Plan name",
                                       rules: {
                                         required: "* Required",
+                                        pattern: {
+                                          value: /^\S(.*\S)?$/,
+                                          message:
+                                            "Must not have leading or trailing whitespace.",
+                                        },
                                       },
                                     },
                                   ],
@@ -253,6 +272,11 @@ export const v202401: FormSchema = {
                                       label: "Plan name",
                                       rules: {
                                         required: "* Required",
+                                        pattern: {
+                                          value: /^\S(.*\S)?$/,
+                                          message:
+                                            "Must not have leading or trailing whitespace.",
+                                        },
                                       },
                                     },
                                   ],
@@ -291,6 +315,10 @@ export const v202401: FormSchema = {
               labelClassName: "font-bold",
               rules: {
                 required: "* Required",
+                pattern: {
+                  value: /^\S(.*\S)?$/,
+                  message: "Must not have leading or trailing whitespace.",
+                },
               },
             },
 

--- a/src/services/api/webforms/ABP5/v202401.ts
+++ b/src/services/api/webforms/ABP5/v202401.ts
@@ -125,7 +125,13 @@ function subsectionFormFields({
           label: "Benefit provided",
           labelClassName: "font-bold",
           name: `${formName}_${sectionName}_benefit-provided_input`,
-          rules: { required: "* Required" },
+          rules: {
+            required: "* Required",
+            pattern: {
+              value: /^\S(.*\S)?$/,
+              message: "Must not have leading or trailing whitespace.",
+            },
+          },
           props: {
             className: "w-[300px]",
           },
@@ -148,7 +154,13 @@ function subsectionFormFields({
       labelClassName: "font-bold",
       name: `${formName}_${sectionName}_source-other-info_input`,
       formItemClassName: "ml-[0.6rem] px-4 border-l-4 border-l-primary",
-      rules: { required: "* Required" },
+      rules: {
+        required: "* Required",
+        pattern: {
+          value: /^\S(.*\S)?$/,
+          message: "Must not have leading or trailing whitespace.",
+        },
+      },
       dependency: {
         conditions: [
           {
@@ -167,7 +179,13 @@ function subsectionFormFields({
       labelClassName: "font-bold",
       name: `${formName}_${sectionName}_secretary-other-info_input`,
       formItemClassName: "ml-[0.6rem] px-4 border-l-4 border-l-primary",
-      rules: { required: "* Required" },
+      rules: {
+        required: "* Required",
+        pattern: {
+          value: /^\S(.*\S)?$/,
+          message: "Must not have leading or trailing whitespace.",
+        },
+      },
       dependency: {
         conditions: [
           {
@@ -196,7 +214,13 @@ function subsectionFormFields({
       labelClassName: "font-bold",
       name: `${formName}_${sectionName}_authorization-other-info_input`,
       formItemClassName: "ml-[0.6rem] px-4 border-l-4 border-l-primary",
-      rules: { required: "* Required" },
+      rules: {
+        required: "* Required",
+        pattern: {
+          value: /^\S(.*\S)?$/,
+          message: "Must not have leading or trailing whitespace.",
+        },
+      },
       dependency: {
         conditions: [
           {
@@ -225,7 +249,13 @@ function subsectionFormFields({
       labelClassName: "font-bold",
       name: `${formName}_${sectionName}_provider-qual-other-info_input`,
       formItemClassName: "ml-[0.6rem] px-4 border-l-4 border-l-primary",
-      rules: { required: "* Required" },
+      rules: {
+        required: "* Required",
+        pattern: {
+          value: /^\S(.*\S)?$/,
+          message: "Must not have leading or trailing whitespace.",
+        },
+      },
       dependency: {
         conditions: [
           {
@@ -342,7 +372,14 @@ function subsection({
                                     label: "Benefit duplicated",
                                     labelClassName: "font-bold",
                                     name: `${formName}_${sectionName}_benefit-duped_input`,
-                                    rules: { required: "* Required" },
+                                    rules: {
+                                      required: "* Required",
+                                      pattern: {
+                                        value: /^\S(.*\S)?$/,
+                                        message:
+                                          "Must not have leading or trailing whitespace.",
+                                      },
+                                    },
                                   },
                                 ],
                               },
@@ -359,7 +396,14 @@ function subsection({
                                     label: "Benefit substituted",
                                     labelClassName: "font-bold",
                                     name: `${formName}_${sectionName}_benefit-subbed_input`,
-                                    rules: { required: "* Required" },
+                                    rules: {
+                                      required: "* Required",
+                                      pattern: {
+                                        value: /^\S(.*\S)?$/,
+                                        message:
+                                          "Must not have leading or trailing whitespace.",
+                                      },
+                                    },
                                   },
                                 ],
                               },
@@ -453,7 +497,13 @@ export const v202401: FormSchema = {
               label: "Name of selected base benchmark plan",
               labelClassName: "font-bold",
               name: `${formName}_benefits-included_plan-name_input`,
-              rules: { required: "* Required" },
+              rules: {
+                required: "* Required",
+                pattern: {
+                  value: /^\S(.*\S)?$/,
+                  message: "Must not have leading or trailing whitespace.",
+                },
+              },
             },
             {
               rhf: "Input",
@@ -461,7 +511,13 @@ export const v202401: FormSchema = {
                 "Name of selected Section 1937 coverage option if other than Secretary-approved. Otherwise, enter “Secretary-approved.”",
               labelClassName: "font-bold",
               name: `${formName}_benefits-included_section-1937-name_input`,
-              rules: { required: "* Required" },
+              rules: {
+                required: "* Required",
+                pattern: {
+                  value: /^\S(.*\S)?$/,
+                  message: "Must not have leading or trailing whitespace.",
+                },
+              },
             },
           ],
         },
@@ -616,7 +672,13 @@ export const v202401: FormSchema = {
                 "Coverage that exceeds the minimum requirements or other information",
               labelClassName: "font-bold",
               name: `${formName}_prescrip-drugs_other-info_input`,
-              rules: { required: "* Required" },
+              rules: {
+                required: "* Required",
+                pattern: {
+                  value: /^\S(.*\S)?$/,
+                  message: "Must not have leading or trailing whitespace.",
+                },
+              },
             },
             {
               rhf: "Radio",
@@ -638,7 +700,14 @@ export const v202401: FormSchema = {
                             label: "Benefit duplicated",
                             labelClassName: "font-bold",
                             name: `${formName}_prescrip-drugs_benefit-duped_input`,
-                            rules: { required: "* Required" },
+                            rules: {
+                              required: "* Required",
+                              pattern: {
+                                value: /^\S(.*\S)?$/,
+                                message:
+                                  "Must not have leading or trailing whitespace.",
+                              },
+                            },
                           },
                         ],
                       },
@@ -655,7 +724,14 @@ export const v202401: FormSchema = {
                             label: "Benefit substituted",
                             labelClassName: "font-bold",
                             name: `${formName}_prescrip-drugs_benefit-subbed_input`,
-                            rules: { required: "* Required" },
+                            rules: {
+                              required: "* Required",
+                              pattern: {
+                                value: /^\S(.*\S)?$/,
+                                message:
+                                  "Must not have leading or trailing whitespace.",
+                              },
+                            },
                           },
                         ],
                       },
@@ -773,7 +849,14 @@ export const v202401: FormSchema = {
                                 label:
                                   "Base benchmark benefit that was substituted",
                                 labelClassName: "font-bold",
-                                rules: { required: "* Required" },
+                                rules: {
+                                  required: "* Required",
+                                  pattern: {
+                                    value: /^\S(.*\S)?$/,
+                                    message:
+                                      "Must not have leading or trailing whitespace.",
+                                  },
+                                },
                                 name: `${formName}_opt-items_benchmark-subbed_input`,
                               },
                               {

--- a/src/services/ui/src/components/Inputs/input.tsx
+++ b/src/services/ui/src/components/Inputs/input.tsx
@@ -15,7 +15,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           className={cn(
             "flex h-9 w-full rounded-sm border border-black bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
             icon && "pl-6",
-            className
+            className,
           )}
           ref={ref}
           id={props.name}
@@ -23,7 +23,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         />
       </div>
     );
-  }
+  },
 );
 
 Input.displayName = "Input";

--- a/src/services/ui/src/components/RHF/utils/validator.ts
+++ b/src/services/ui/src/components/RHF/utils/validator.ts
@@ -19,7 +19,7 @@ import {
 export const validateInput = (inputValue: any, rules?: RegisterOptions) => {
   const isEmpty =
     isUndefined(inputValue) ||
-    inputValue.trim() === "" ||
+    inputValue === "" ||
     (Array.isArray(inputValue) && !inputValue.length);
 
   if (isEmpty && rules?.required) {

--- a/src/services/ui/src/components/RHF/utils/validator.ts
+++ b/src/services/ui/src/components/RHF/utils/validator.ts
@@ -19,7 +19,7 @@ import {
 export const validateInput = (inputValue: any, rules?: RegisterOptions) => {
   const isEmpty =
     isUndefined(inputValue) ||
-    inputValue === "" ||
+    inputValue.trim() === "" ||
     (Array.isArray(inputValue) && !inputValue.length);
 
   if (isEmpty && rules?.required) {


### PR DESCRIPTION
## Purpose

Previously, a user could enter a single space into an input field and the validator would consider it valid. To avoid this, we will use regex on the input fields to prevent a user from entering text with leading or trailing whitespace.

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-27908