### PR TITLE
fix(ld secrets manager):  Move LD SDK Key to secrets manager

### DIFF
--- a/src/services/api/serverless.yml
+++ b/src/services/api/serverless.yml
@@ -65,7 +65,7 @@ custom:
   onemacLegacyS3AccessRoleArn: ${ssm:/aws/reference/secretsmanager/${self:custom.project}/${sls:stage}/onemacLegacyS3AccessRoleArn, ssm:/aws/reference/secretsmanager/${self:custom.project}/default/onemacLegacyS3AccessRoleArn}
   dbInfo: ${ssm:/aws/reference/secretsmanager/${self:custom.project}/${sls:stage}/seatool/dbInfo, ssm:/aws/reference/secretsmanager/${self:custom.project}/default/seatool/dbInfo}
   brokerString: ${ssm:/aws/reference/secretsmanager/${self:custom.project}/${sls:stage}/brokerString, ssm:/aws/reference/secretsmanager/${self:custom.project}/default/brokerString}
-  launchdarklySDKKey: ${ssm:/${self:service}/${sls:stage}/launchdarklySDKKey, ssm:/${self:service}/default/launchdarklySDKKey}
+  launchdarklySDKKey: ${ssm:/aws/reference/secretsmanager/${self:custom.project}/${sls:stage}/launchdarklySDKKey, ssm:/aws/reference/secretsmanager/${self:custom.project}/default/launchdarklySDKKey}
 
 params:
   master:


### PR DESCRIPTION
## Purpose

This changeset accomodates the move of the launch darkly sdk key from ssm to secrets manager

#### Linked Issues to Close

None

## Approach

See diff

## Assorted Notes/Considerations/Learning

N/A