### PR TITLE
fix(LD Client ID):  Move the LD Client ID to SecretsManager

### DIFF
--- a/src/services/ui/serverless.yml
+++ b/src/services/ui/serverless.yml
@@ -22,7 +22,7 @@ custom:
   region: ${opt:region, self:provider.region}
   idmInfo: ${ssm:/aws/reference/secretsmanager/${self:custom.project}/${sls:stage}/idmInfo, ""}
   googleAnalytics: ${ssm:/aws/reference/secretsmanager/${self:custom.project}/${sls:stage}/googleAnalytics, ssm:/aws/reference/secretsmanager/${self:custom.project}/default/googleAnalytics}
-  launchdarklyClientID: ${env:VITE_LAUNCHDARKLY_CLIENT_ID, ssm:/${self:service}/${sls:stage}/launchdarklyClientID, ssm:/${self:service}/default/launchdarklyClientID}
+  launchdarklyClientID: ${env:VITE_LAUNCHDARKLY_CLIENT_ID, ssm:/aws/reference/secretsmanager/${self:custom.project}/${sls:stage}/launchdarklyClientID, ssm:/aws/reference/secretsmanager/${self:custom.project}/default/launchdarklyClientID}
   serverlessTerminationProtection:
     stages:
       - master


### PR DESCRIPTION
## Purpose

This changeset moves the client id from systems manager to secrets manager, to keep consistent with our other deploy info.

#### Linked Issues to Close

None

## Approach

None

## Assorted Notes/Considerations/Learning

None