### PR TITLE
fix (checkbox label logic): add fix to label and styled label logic

### DIFF
--- a/src/packages/shared-types/forms.ts
+++ b/src/packages/shared-types/forms.ts
@@ -76,7 +76,7 @@ type RHFTextItemType =
   | "default";
 
 export type RHFOption = {
-  label: string;
+  label?: string;
   value: string;
   styledLabel?: RHFTextField;
   dependency?: DependencyRule;

--- a/src/services/api/webforms/ABP2A/v202401.ts
+++ b/src/services/api/webforms/ABP2A/v202401.ts
@@ -92,7 +92,6 @@ export const v202401: FormSchema = {
                       "state_territory_must_have_a_process_that_meets_exemption_criteria",
                   },
                   {
-                    label: "",
                     styledLabel: [
                       {
                         text: "Once an individual is identified, the state/territory assures it will effectively inform the individual of the following:",
@@ -135,7 +134,6 @@ export const v202401: FormSchema = {
                         classname: "block py-1",
                       },
                     ],
-                    label: "",
                     value:
                       "state_territory_assures_it_will_inform_the_individual",
                   },
@@ -242,7 +240,6 @@ export const v202401: FormSchema = {
               props: {
                 options: [
                   {
-                    label: "",
                     styledLabel: [
                       {
                         text: "The state/territory assures it will document in the exempt individual's eligibility file that the individual:",

--- a/src/services/api/webforms/ABP2B/v202401.ts
+++ b/src/services/api/webforms/ABP2B/v202401.ts
@@ -36,7 +36,6 @@ export const v202401: FormSchema = {
                       "inform_exempt_and_comply_with_requirements_related_to_voluntary_enrollment",
                   },
                   {
-                    label: "",
                     styledLabel: [
                       {
                         text: "Effectively inform individuals who voluntarily enroll:",
@@ -80,7 +79,6 @@ export const v202401: FormSchema = {
                         classname: "block py-1",
                       },
                     ],
-                    label: "",
                     value:
                       "inform_individuals_of_abp_benefits_and_costs_of_different_packages",
                   },
@@ -187,7 +185,6 @@ export const v202401: FormSchema = {
               props: {
                 options: [
                   {
-                    label: "",
                     styledLabel: [
                       {
                         text: "The state/territory assures it will document in the exempt individual's eligibility file that the individual:",

--- a/src/services/ui/src/components/Inputs/checkbox.tsx
+++ b/src/services/ui/src/components/Inputs/checkbox.tsx
@@ -8,7 +8,7 @@ const Checkbox = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> &
     DependencyWrapperProps & {
       className?: string;
-      label: string;
+      label?: string;
       value?: string;
       styledLabel?: React.ReactNode;
       description?: string;

--- a/src/services/ui/src/components/Inputs/checkbox.tsx
+++ b/src/services/ui/src/components/Inputs/checkbox.tsx
@@ -19,7 +19,7 @@ const Checkbox = React.forwardRef<
     <div className="items-top flex space-x-2">
       <CheckboxPrimitive.Root
         ref={ref}
-        id={props.label ?? props.styledLabel}
+        id={(props.label || props.styledLabel) as string}
         className={cn(
           "peer h-7 w-7 my-2 shrink-0 border-black border-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:border-primary data-[state=checked]:text-primary-foreground",
           className,
@@ -35,13 +35,13 @@ const Checkbox = React.forwardRef<
       <div className="grid gap-1.5 leading-none">
         {!!(props.label || props.styledLabel) && (
           <label
-            htmlFor={props.label ?? props.styledLabel}
+            htmlFor={(props.label || props.styledLabel) as string}
             className={cn(
               "mt-2 text-md font-medium leading-normal peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
               props.optionlabelClassName,
             )}
           >
-            {props.label ?? props.styledLabel}
+            {props.label || props.styledLabel}
           </label>
         )}
         {!!props.description && (

--- a/src/services/ui/src/components/RHF/Slot.tsx
+++ b/src/services/ui/src/components/RHF/Slot.tsx
@@ -44,9 +44,9 @@ export const RHFSlot = <
         }`}
         data-testid={rest.name + "Wrapper"}
       >
-        {(label ?? styledLabel) && (
+        {(label || styledLabel) && (
           <FormLabel className={labelClassName}>
-            <RHFTextDisplay text={(styledLabel ?? label) as RHFTextField} />
+            <RHFTextDisplay text={(styledLabel || label) as RHFTextField} />
           </FormLabel>
         )}
         {descriptionAbove && description && (

--- a/src/services/ui/src/components/RHF/SlotField.tsx
+++ b/src/services/ui/src/components/RHF/SlotField.tsx
@@ -162,7 +162,9 @@ export const SlotField = ({
                   value={OPT.value}
                   checked={field.value?.includes(OPT.value)}
                   styledLabel={
-                    <RHFTextDisplay text={OPT.styledLabel ?? OPT.label} />
+                    <RHFTextDisplay
+                      text={(OPT.styledLabel || OPT.label) as string}
+                    />
                   }
                   onCheckedChange={(c) => {
                     const filtered =
@@ -207,7 +209,9 @@ export const SlotField = ({
                   />
                   {
                     <FormLabel className="font-normal mt-2" htmlFor={OPT.value}>
-                      <RHFTextDisplay text={OPT.styledLabel ?? OPT.label} />
+                      <RHFTextDisplay
+                        text={(OPT.styledLabel || OPT.label) as string}
+                      />
                     </FormLabel>
                   }
                 </div>


### PR DESCRIPTION
## Purpose
Logic was added to allow styledLabel or label for checkboxes. Before an empty string would populate, but we now added a check to fall back on either styleLabel or label if it is an empty string
