### PR TITLE
fix(OY2-27896): temporary extension faq footer

### DIFF
--- a/src/services/ui/src/features/package-actions/lib/modules/temporary-extension/legacy-page.tsx
+++ b/src/services/ui/src/features/package-actions/lib/modules/temporary-extension/legacy-page.tsx
@@ -21,6 +21,7 @@ import {
   SubmissionButtons,
   useLocationCrumbs,
   FormLoadingSpinner,
+  FAQFooter,
 } from "@/components";
 import { useParams } from "react-router-dom";
 import { TEPackageSection } from "@/features/package-actions/lib/modules/temporary-extension/legacy-components";
@@ -142,6 +143,7 @@ export const TemporaryExtension = () => {
         <ErrorBanner />
         <SubmissionButtons cancelNavigationLocation={navigationLocation} />
       </form>
+      <FAQFooter />
     </SimplePageContainer>
   );
 };


### PR DESCRIPTION
## Purpose
Added FAQ link footer for Temporary Extension form.

![Screenshot 2024-05-16 at 8 02 08 AM](https://github.com/Enterprise-CMCS/macpro-mako/assets/141361476/21a5cc95-f891-412b-8320-5fc4e4f00f75)

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-27896

## Approach

_How does this change address the issue?_

## Assorted Notes/Considerations/Learning

_List any other information that you think is important... a post-merge activity, someone to notify, what you learned, etc._
