### PR TITLE
fix(additionalInfo validation):  Disallow only whitespce additional information entries

### DIFF
--- a/src/services/ui/src/features/package-actions/lib/modules/respond-to-rai/spa/chip-rai.tsx
+++ b/src/services/ui/src/features/package-actions/lib/modules/respond-to-rai/spa/chip-rai.tsx
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import {
-  zAdditionalInfo,
+  zAdditionalInfoOptional,
   zAttachmentOptional,
   zAttachmentRequired,
 } from "@/utils";
@@ -13,7 +13,7 @@ import {
 import { PackageSection } from "@/components/Form/content/PackageSection";
 
 export const chipSpaRaiSchema = z.object({
-  additionalInformation: zAdditionalInfo.optional(),
+  additionalInformation: zAdditionalInfoOptional,
   attachments: z.object({
     revisedAmendedStatePlanLanguage: zAttachmentRequired({ min: 1 }),
     officialRaiResponse: zAttachmentRequired({ min: 1 }),

--- a/src/services/ui/src/features/package-actions/lib/modules/respond-to-rai/spa/med-rai.tsx
+++ b/src/services/ui/src/features/package-actions/lib/modules/respond-to-rai/spa/med-rai.tsx
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import {
-  zAdditionalInfo,
+  zAdditionalInfoOptional,
   zAttachmentOptional,
   zAttachmentRequired,
 } from "@/utils";
@@ -13,7 +13,7 @@ import {
 } from "@/components";
 
 export const medSpaRaiSchema = z.object({
-  additionalInformation: zAdditionalInfo.optional(),
+  additionalInformation: zAdditionalInfoOptional,
   attachments: z.object({
     raiResponseLetter: zAttachmentRequired({ min: 1 }),
     other: zAttachmentOptional,

--- a/src/services/ui/src/features/package-actions/lib/modules/respond-to-rai/waiver/b-waiver-rai.tsx
+++ b/src/services/ui/src/features/package-actions/lib/modules/respond-to-rai/waiver/b-waiver-rai.tsx
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import {
-  zAdditionalInfo,
+  zAdditionalInfoOptional,
   zAttachmentOptional,
   zAttachmentRequired,
 } from "@/utils";
@@ -13,7 +13,7 @@ import {
 import { PackageSection } from "@/components/Form/content/PackageSection";
 
 export const bWaiverRaiSchema = z.object({
-  additionalInformation: zAdditionalInfo.optional(),
+  additionalInformation: zAdditionalInfoOptional,
   attachments: z.object({
     raiResponseLetterWaiver: zAttachmentRequired({ min: 1 }),
     other: zAttachmentOptional,

--- a/src/services/ui/src/features/package-actions/lib/modules/withdraw-package/index.tsx
+++ b/src/services/ui/src/features/package-actions/lib/modules/withdraw-package/index.tsx
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { zAdditionalInfo, zAttachmentOptional } from "@/utils";
+import { zAdditionalInfoOptional, zAttachmentOptional } from "@/utils";
 import { FormContentHydrator } from "@/features/package-actions/lib/contentSwitch";
 import { ReactElement } from "react";
 import {
@@ -16,7 +16,7 @@ export * from "./waiver/withdraw-waiver";
 
 export const defaultWithdrawPackageSchema = z
   .object({
-    additionalInformation: zAdditionalInfo.optional(),
+    additionalInformation: zAdditionalInfoOptional,
     attachments: z.object({
       supportingDocumentation: zAttachmentOptional,
     }),
@@ -24,7 +24,8 @@ export const defaultWithdrawPackageSchema = z
   .superRefine((data, ctx) => {
     if (
       !data.attachments.supportingDocumentation?.length &&
-      data.additionalInformation === undefined
+      (data.additionalInformation === undefined ||
+        data.additionalInformation === "")
     ) {
       ctx.addIssue({
         message: "An Attachment or Additional Information is required.",

--- a/src/services/ui/src/features/package-actions/lib/modules/withdraw-package/spa/withdraw-chip-rai.tsx
+++ b/src/services/ui/src/features/package-actions/lib/modules/withdraw-package/spa/withdraw-chip-rai.tsx
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { zAdditionalInfo, zAttachmentRequired } from "@/utils";
+import { zAdditionalInfoOptional, zAttachmentRequired } from "@/utils";
 import { ReactElement } from "react";
 import {
   ActionFormDescription,
@@ -9,7 +9,7 @@ import {
 import { PackageSection } from "@/components/Form/content/PackageSection";
 
 export const chipWithdrawPackageSchema = z.object({
-  additionalInformation: zAdditionalInfo.optional(),
+  additionalInformation: zAdditionalInfoOptional,
   attachments: z.object({
     officialWithdrawalLetter: zAttachmentRequired({ min: 1 }),
   }),

--- a/src/services/ui/src/features/submission/waiver/capitated/capitated-1915-b-waiver-amendment.tsx
+++ b/src/services/ui/src/features/submission/waiver/capitated/capitated-1915-b-waiver-amendment.tsx
@@ -19,7 +19,7 @@ import * as Inputs from "@/components/Inputs";
 import { useGetUser, submit } from "@/api";
 import { Authority } from "shared-types";
 import {
-  zAdditionalInfo,
+  zAdditionalInfoOptional,
   zAmendmentOriginalWaiverNumberSchema,
   zAmendmentWaiverNumberSchema,
   zAttachmentOptional,
@@ -44,7 +44,7 @@ const formSchema = z.object({
     tribalConsultation: zAttachmentOptional,
     other: zAttachmentOptional,
   }),
-  additionalInformation: zAdditionalInfo.optional(),
+  additionalInformation: zAdditionalInfoOptional,
   seaActionType: z.string().default("Amend"),
 });
 type Waiver1915BCapitatedAmendment = z.infer<typeof formSchema>;

--- a/src/services/ui/src/features/submission/waiver/capitated/capitated-1915-b-waiver-initial.tsx
+++ b/src/services/ui/src/features/submission/waiver/capitated/capitated-1915-b-waiver-initial.tsx
@@ -18,7 +18,7 @@ import {
 import { submit } from "@/api/submissionService";
 import { Authority } from "shared-types";
 import {
-  zAdditionalInfo,
+  zAdditionalInfoOptional,
   zAttachmentOptional,
   zAttachmentRequired,
   zInitialWaiverNumberSchema,
@@ -40,7 +40,7 @@ const formSchema = z.object({
     tribalConsultation: zAttachmentOptional,
     other: zAttachmentOptional,
   }),
-  additionalInformation: zAdditionalInfo.optional(),
+  additionalInformation: zAdditionalInfoOptional,
   seaActionType: z.string().default("New"),
 });
 export type Waiver1915BCapitatedAmendment = z.infer<typeof formSchema>;

--- a/src/services/ui/src/features/submission/waiver/capitated/capitated-1915-b-waiver-renewal.tsx
+++ b/src/services/ui/src/features/submission/waiver/capitated/capitated-1915-b-waiver-renewal.tsx
@@ -19,7 +19,7 @@ import * as Inputs from "@/components/Inputs";
 import { useGetUser, submit } from "@/api";
 import { Authority } from "shared-types";
 import {
-  zAdditionalInfo,
+  zAdditionalInfoOptional,
   zRenewalOriginalWaiverNumberSchema,
   zAttachmentOptional,
   zAttachmentRequired,
@@ -46,7 +46,7 @@ const formSchema = z
       tribalConsultation: zAttachmentOptional,
       other: zAttachmentOptional,
     }),
-    additionalInformation: zAdditionalInfo.optional(),
+    additionalInformation: zAdditionalInfoOptional,
     seaActionType: z.string().default("Renew"),
   })
   .superRefine((data, ctx) => {

--- a/src/services/ui/src/features/submission/waiver/contracting/contracting-1915-b-waiver-amendment.tsx
+++ b/src/services/ui/src/features/submission/waiver/contracting/contracting-1915-b-waiver-amendment.tsx
@@ -19,7 +19,7 @@ import * as Inputs from "@/components/Inputs";
 import { useGetUser, submit } from "@/api";
 import { Authority } from "shared-types";
 import {
-  zAdditionalInfo,
+  zAdditionalInfoOptional,
   zAmendmentOriginalWaiverNumberSchema,
   zAmendmentWaiverNumberSchema,
   zAttachmentOptional,
@@ -43,7 +43,7 @@ const formSchema = z.object({
     tribalConsultation: zAttachmentOptional,
     other: zAttachmentOptional,
   }),
-  additionalInformation: zAdditionalInfo.optional(),
+  additionalInformation: zAdditionalInfoOptional,
   seaActionType: z.string().default("Amend"),
 });
 

--- a/src/services/ui/src/features/submission/waiver/contracting/contracting-1915-b-waiver-initial.tsx
+++ b/src/services/ui/src/features/submission/waiver/contracting/contracting-1915-b-waiver-initial.tsx
@@ -19,7 +19,7 @@ import * as Inputs from "@/components/Inputs";
 import { useGetUser, submit } from "@/api";
 import { Authority } from "shared-types";
 import {
-  zAdditionalInfo,
+  zAdditionalInfoOptional,
   zAttachmentOptional,
   zAttachmentRequired,
   zInitialWaiverNumberSchema,
@@ -41,7 +41,7 @@ const formSchema = z.object({
     tribalConsultation: zAttachmentOptional,
     other: zAttachmentOptional,
   }),
-  additionalInformation: zAdditionalInfo.optional(),
+  additionalInformation: zAdditionalInfoOptional,
   seaActionType: z.string().default("New"),
 });
 type Waiver1915BContractingInitial = z.infer<typeof formSchema>;

--- a/src/services/ui/src/features/submission/waiver/contracting/contracting-1915-b-waiver-renewal.tsx
+++ b/src/services/ui/src/features/submission/waiver/contracting/contracting-1915-b-waiver-renewal.tsx
@@ -19,7 +19,7 @@ import * as Inputs from "@/components/Inputs";
 import { useGetUser, submit, getItem } from "@/api";
 import { Authority } from "shared-types";
 import {
-  zAdditionalInfo,
+  zAdditionalInfoOptional,
   zRenewalOriginalWaiverNumberSchema,
   zAttachmentOptional,
   zAttachmentRequired,
@@ -45,7 +45,7 @@ const formSchema = z
       tribalConsultation: zAttachmentOptional,
       other: zAttachmentOptional,
     }),
-    additionalInformation: zAdditionalInfo.optional(),
+    additionalInformation: zAdditionalInfoOptional,
     seaActionType: z.string().default("Renew"),
   })
   .superRefine((data, ctx) => {

--- a/src/services/ui/src/utils/zod.ts
+++ b/src/services/ui/src/utils/zod.ts
@@ -34,9 +34,24 @@ export const zAttachmentRequired = ({
       message: message,
     });
 
+export const zAdditionalInfoOptional = z
+  .string()
+  .max(4000, "This field may only be up to 4000 characters.")
+  .optional()
+  .refine(
+    (value) => {
+      if (!value) return true;
+      return value === "" || value.trim().length > 0;
+    },
+    { message: "Additional Information can not be only whitespace." },
+  );
+
 export const zAdditionalInfo = z
   .string()
   .max(4000, "This field may only be up to 4000 characters.")
+  .refine((value) => value !== "", {
+    message: "Additional Information is required.",
+  })
   .refine((value) => value.trim().length > 0, {
     message: "Additional Information can not be only whitespace.",
   });


### PR DESCRIPTION
## Purpose

This changeset disallows only whitespace in additional information

#### Linked Issues to Close

Closes https://qmacbis.atlassian.net/browse/OY2-27921

## Approach

The amount of files changed is probably surprisingly high.  This got a bit tricky.  We have three use cases for additional information:
- required
- optional
- optional, if an attachment is supplied

While checking for whitespace is easy enough, there were issues when backspacing the entire entry.  Zod was treating the backspaced entry as a blank string.  Efforts to accomodate this conflicted with other use cases.  We (@13bfrancis and I) ended up making a separate additional info required schema.  This made it work.

All should behave as expected now.  

## Assorted Notes/Considerations/Learning

We think a preprocess block might be the correct way to go, to change empty strings to undefined, and rely on the zod optional/not-optional, but are of the mind to move forward with a working baseline.