### PR TITLE
fix(display-waiver-action): update to display action type for waivers

### DIFF
--- a/src/services/ui/src/features/package/package-details/hooks.tsx
+++ b/src/services/ui/src/features/package/package-details/hooks.tsx
@@ -1,12 +1,13 @@
 import { isCmsUser } from "shared-utils";
 
 import { BLANK_VALUE } from "@/consts";
-import { opensearch } from "shared-types";
+import { Authority, opensearch } from "shared-types";
 import { FC, ReactNode } from "react";
 import { OneMacUser } from "@/api/useGetUser";
 
 import { formatSeatoolDate } from "shared-utils";
 import { useMemo, useState } from "react";
+import { LABELS } from "@/utils";
 
 export const ReviewTeamList: FC<opensearch.main.Document> = (props) => {
   const [expanded, setExpanded] = useState(false);
@@ -49,6 +50,13 @@ export const recordDetails = (
     label: "Authority",
     value: data?.authority,
     canView: () => true,
+  },
+  {
+    label: "Action Type",
+    value: LABELS[data.actionType as keyof typeof LABELS] || data.actionType,
+    canView: () => {
+      return [Authority["1915b"], Authority["1915c"]].includes(data.authority);
+    },
   },
   {
     label: "State",


### PR DESCRIPTION
## Purpose

Currently we are displaying the waiver action type in the dashboard, but not in the details page. The purpose of this PR is to address that.

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-27955

## Approach

Added a new field to the `hooks.tsx` file which is in charge of rendering what shows up on the package details page. 

## Working Feature Demo

Uploading Screen Recording 2024-06-03 at 2.22.29 PM.mov…
