### PR TITLE
fix(fix parentId in RHF): add ParentID to fix rhfSlot

### DIFF
--- a/src/services/ui/src/components/RHF/SlotField.tsx
+++ b/src/services/ui/src/components/RHF/SlotField.tsx
@@ -256,7 +256,7 @@ export const OptChildren = ({
               control={control}
               name={parentId + SLOT.name}
               {...(SLOT.rules && { rules: SLOT.rules })}
-              render={RHFSlot({ ...SLOT, control })}
+              render={RHFSlot({ ...SLOT, parentId, control })}
             />
           </div>
         ))}


### PR DESCRIPTION
## Purpose
Add fix for ParentId in RHFSlot. We were missing a property that was causing radio buttons and checkboxes from receiving a concatenated parentId string.
