### PR TITLE
fix(TE submission):  Fix an issue preventing TE submission

### DIFF
--- a/src/services/ui/src/features/package-actions/ActionForm.tsx
+++ b/src/services/ui/src/features/package-actions/ActionForm.tsx
@@ -38,22 +38,25 @@ export const ActionForm = ({ setup }: { setup: FormSetup }) => {
     mode: "onChange",
   });
 
+  if (type === "temporary-extension") {
+    form.setValue("seaActionType", "Extend");
+  }
+
   // Submission Handler
-  const handler = form.handleSubmit(
-    async (data) =>
-      await submitActionForm({
-        data,
-        id: data?.id ?? id,
-        type: type!,
-        authority: authority!,
-        user: user!,
-        alert,
-        navigate,
-        originRoute: origin,
-        statusToCheck: successCheckSwitch(type),
-        locationState: location.state,
-      }),
-  );
+  const handler = form.handleSubmit(async (data) => {
+    await submitActionForm({
+      data,
+      id: data?.id ?? id,
+      type: type!,
+      authority: authority!,
+      user: user!,
+      alert,
+      navigate,
+      originRoute: origin,
+      statusToCheck: successCheckSwitch(type),
+      locationState: location.state,
+    });
+  });
   useEffect(() => {
     content?.successBanner && alert.setContent(content.successBanner);
   }, [content]);

--- a/src/services/ui/src/features/package-actions/lib/modules/temporary-extension/legacy-page.tsx
+++ b/src/services/ui/src/features/package-actions/lib/modules/temporary-extension/legacy-page.tsx
@@ -88,6 +88,7 @@ export const TemporaryExtension = () => {
   const { handleSubmit, formMethods } = useSubmitForm();
   const { id: urlId } = useParams();
   const formId = formMethods.getValues("originalWaiverNumber");
+  formMethods.setValue("seaActionType", "Extend");
 
   const parentId = urlId ? urlId : formId;
   useDisplaySubmissionAlert(


### PR DESCRIPTION
## Purpose

Temporary Extensions were not properly being saved. This is to ensure that they get sent to the API with the correct ID. The reason this was broken before is due to the fact that we were getting the ID from the url and not from the text box for the TE ID before.

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-28223

## Approach

Pair Program with Mike Dial to debug the ID getting passed the API endpoint

P.S.... The issue with the TEs not showing up from legacy was due to a breaking change introduced May 3rd.  That's been fixed; no change needed here.