### PR TITLE
feat(webforms): Multiselect

### DIFF
--- a/src/packages/shared-types/forms.ts
+++ b/src/packages/shared-types/forms.ts
@@ -7,6 +7,7 @@ import {
 import {
   CalendarProps,
   InputProps,
+  MultiselectProps,
   RadioProps,
   SelectProps,
   SwitchProps,
@@ -94,6 +95,7 @@ export type RHFComponentMap = {
   Textarea: TextareaProps;
   Switch: SwitchProps;
   Select: SelectProps & { sort?: "ascending" | "descending" };
+  Multiselect: MultiselectProps;
   Radio: RadioProps & {
     options: RHFOption[];
   };

--- a/src/packages/shared-types/inputs.ts
+++ b/src/packages/shared-types/inputs.ts
@@ -10,14 +10,6 @@ export type CalendarProps = React.ComponentProps<typeof DayPicker> & {
   defaultMonth?: Date;
 };
 
-export interface MultiselectOption {
-  readonly value: string;
-  readonly label: string;
-  readonly color?: string;
-  readonly isFixed?: boolean;
-  readonly isDisabled?: boolean;
-}
-
 export type DatePickerProps = {
   date: Date | undefined;
   onChange: (date: Date | undefined) => void;
@@ -40,6 +32,14 @@ export type SelectProps = React.ComponentPropsWithoutRef<
   options: { label: string; value: any }[];
   className?: string;
 };
+
+export interface MultiselectOption {
+  readonly value: string;
+  readonly label: string;
+  readonly color?: string;
+  readonly isFixed?: boolean;
+  readonly isDisabled?: boolean;
+}
 
 export type MultiselectProps = {
   className?: string;

--- a/src/packages/shared-types/inputs.ts
+++ b/src/packages/shared-types/inputs.ts
@@ -44,6 +44,7 @@ export interface MultiselectOption {
 export type MultiselectProps = {
   className?: string;
   options: MultiselectOption[];
+  value?: string[];
 };
 
 export type SwitchProps = React.ComponentPropsWithoutRef<

--- a/src/packages/shared-types/inputs.ts
+++ b/src/packages/shared-types/inputs.ts
@@ -45,6 +45,7 @@ export type MultiselectProps = {
   className?: string;
   options: MultiselectOption[];
   value?: string[];
+  onChange?: (selectedValues: string[]) => void;
 };
 
 export type SwitchProps = React.ComponentPropsWithoutRef<

--- a/src/packages/shared-types/inputs.ts
+++ b/src/packages/shared-types/inputs.ts
@@ -10,6 +10,14 @@ export type CalendarProps = React.ComponentProps<typeof DayPicker> & {
   defaultMonth?: Date;
 };
 
+export interface MultiselectOption {
+  readonly value: string;
+  readonly label: string;
+  readonly color?: string;
+  readonly isFixed?: boolean;
+  readonly isDisabled?: boolean;
+}
+
 export type DatePickerProps = {
   date: Date | undefined;
   onChange: (date: Date | undefined) => void;
@@ -31,6 +39,11 @@ export type SelectProps = React.ComponentPropsWithoutRef<
 > & {
   options: { label: string; value: any }[];
   className?: string;
+};
+
+export type MultiselectProps = {
+  className?: string;
+  options: MultiselectOption[];
 };
 
 export type SwitchProps = React.ComponentPropsWithoutRef<

--- a/src/services/ui/src/components/Inputs/index.tsx
+++ b/src/services/ui/src/components/Inputs/index.tsx
@@ -5,6 +5,7 @@ export * from "./date-picker";
 export * from "./form";
 export * from "./upload";
 export * from "./input";
+export * from "./multiselect";
 export * from "./label";
 export * from "./radio-group";
 export * from "./select";

--- a/src/services/ui/src/components/Inputs/multiselect.tsx
+++ b/src/services/ui/src/components/Inputs/multiselect.tsx
@@ -1,0 +1,20 @@
+import { type FC } from "react";
+import Select from "react-select";
+import { MultiselectOption } from "shared-types";
+
+export const Multiselect: FC<{
+  options: MultiselectOption[];
+  value: string[];
+  onChange: (values: string[]) => void;
+}> = (props) => {
+  return (
+    <Select<any, any>
+      isMulti={true}
+      value={props.value?.map((str) => ({ value: str, label: str }))}
+      onChange={(val) => props.onChange(val.map((s: any) => s.value) || [])}
+      options={props.options}
+      closeMenuOnSelect={false}
+      placeholder
+    />
+  );
+};

--- a/src/services/ui/src/components/Inputs/multiselect.tsx
+++ b/src/services/ui/src/components/Inputs/multiselect.tsx
@@ -1,22 +1,20 @@
 import { type FC } from "react";
 import Select from "react-select";
 import { MultiselectOption } from "shared-types";
-import { cn } from "@/utils";
 
 export const Multiselect: FC<{
   options: MultiselectOption[];
   value: string[];
   onChange: (values: string[]) => void;
-  className?: string;
-}> = (className, props) => {
+}> = (props) => {
   return (
     <Select<any, any>
       isMulti={true}
-      value={props.value?.map((str: string) => ({ value: str, label: str }))}
+      value={props.value?.map((str) => ({ value: str, label: str }))}
       onChange={(val) => props.onChange(val.map((s: any) => s.value) || [])}
       options={props.options}
       closeMenuOnSelect={false}
-      className={cn("rounded-sm border border-black", className)}
+      placeholder
     />
   );
 };

--- a/src/services/ui/src/components/Inputs/multiselect.tsx
+++ b/src/services/ui/src/components/Inputs/multiselect.tsx
@@ -1,6 +1,17 @@
 import { type FC } from "react";
-import Select from "react-select";
+import Select, { StylesConfig } from "react-select";
 import { MultiselectOption } from "shared-types";
+
+const customStyles: StylesConfig = {
+  control: (provided) => ({
+    ...provided,
+    border: "1px solid black",
+    boxShadow: "none",
+    "&:hover": {
+      border: "1px solid black",
+    },
+  }),
+};
 
 export const Multiselect: FC<{
   options: MultiselectOption[];
@@ -15,6 +26,7 @@ export const Multiselect: FC<{
       options={props.options}
       closeMenuOnSelect={false}
       placeholder
+      styles={customStyles}
     />
   );
 };

--- a/src/services/ui/src/components/Inputs/multiselect.tsx
+++ b/src/services/ui/src/components/Inputs/multiselect.tsx
@@ -13,15 +13,10 @@ const customStyles: StylesConfig = {
   }),
 };
 
-export const Multiselect: FC<MultiselectProps> = ({
-  options,
-  value,
-  ...props
-}) => {
+export const Multiselect: FC<MultiselectProps> = ({ options, ...props }) => {
   return (
     <Select<any, any>
       isMulti={true}
-      value={value?.map((str) => ({ value: str, label: str }))}
       options={options}
       closeMenuOnSelect={false}
       placeholder

--- a/src/services/ui/src/components/Inputs/multiselect.tsx
+++ b/src/services/ui/src/components/Inputs/multiselect.tsx
@@ -1,20 +1,22 @@
 import { type FC } from "react";
 import Select from "react-select";
 import { MultiselectOption } from "shared-types";
+import { cn } from "@/utils";
 
 export const Multiselect: FC<{
   options: MultiselectOption[];
   value: string[];
   onChange: (values: string[]) => void;
-}> = (props) => {
+  className?: string;
+}> = (className, props) => {
   return (
     <Select<any, any>
       isMulti={true}
-      value={props.value?.map((str) => ({ value: str, label: str }))}
+      value={props.value?.map((str: string) => ({ value: str, label: str }))}
       onChange={(val) => props.onChange(val.map((s: any) => s.value) || [])}
       options={props.options}
       closeMenuOnSelect={false}
-      placeholder
+      className={cn("rounded-sm border border-black", className)}
     />
   );
 };

--- a/src/services/ui/src/components/Inputs/multiselect.tsx
+++ b/src/services/ui/src/components/Inputs/multiselect.tsx
@@ -1,6 +1,6 @@
 import { type FC } from "react";
 import Select, { StylesConfig } from "react-select";
-import { MultiselectOption } from "shared-types";
+import { MultiselectProps } from "shared-types";
 
 const customStyles: StylesConfig = {
   control: (provided) => ({
@@ -13,20 +13,20 @@ const customStyles: StylesConfig = {
   }),
 };
 
-export const Multiselect: FC<{
-  options: MultiselectOption[];
-  value: string[];
-  onChange: (values: string[]) => void;
-}> = (props) => {
+export const Multiselect: FC<MultiselectProps> = ({
+  options,
+  value,
+  ...props
+}) => {
   return (
     <Select<any, any>
       isMulti={true}
-      value={props.value?.map((str) => ({ value: str, label: str }))}
-      onChange={(val) => props.onChange(val.map((s: any) => s.value) || [])}
-      options={props.options}
+      value={value?.map((str) => ({ value: str, label: str }))}
+      options={options}
       closeMenuOnSelect={false}
       placeholder
       styles={customStyles}
+      {...props}
     />
   );
 };

--- a/src/services/ui/src/components/RHF/SlotField.tsx
+++ b/src/services/ui/src/components/RHF/SlotField.tsx
@@ -123,14 +123,7 @@ export const SlotField = ({
       const options = props?.options as MultiselectOption[];
       const value = field.value as string[];
 
-      return (
-        <Multiselect
-          options={options}
-          value={value}
-          onChange={(values) => field.onChange(values)}
-          {...props}
-        />
-      );
+      return <Multiselect options={options} value={value} {...props} />;
     }
     case "DatePicker":
       return (

--- a/src/services/ui/src/components/RHF/SlotField.tsx
+++ b/src/services/ui/src/components/RHF/SlotField.tsx
@@ -128,6 +128,7 @@ export const SlotField = ({
           options={options}
           value={value}
           onChange={(values) => field.onChange(values)}
+          {...props}
         />
       );
     }

--- a/src/services/ui/src/components/RHF/SlotField.tsx
+++ b/src/services/ui/src/components/RHF/SlotField.tsx
@@ -1,4 +1,9 @@
-import { RHFComponentMap, RHFOption, RHFSlotProps } from "shared-types";
+import {
+  RHFComponentMap,
+  RHFOption,
+  RHFSlotProps,
+  MultiselectOption,
+} from "shared-types";
 import { CalendarIcon } from "lucide-react";
 import { format } from "date-fns";
 import { cn } from "@/utils";
@@ -19,6 +24,7 @@ import {
   FormField,
   FormLabel,
   Input,
+  Multiselect,
   RadioGroup,
   RadioGroupItem,
   Select,
@@ -111,6 +117,18 @@ export const SlotField = ({
             ))}
           </SelectContent>
         </Select>
+      );
+    }
+    case "Multiselect": {
+      const options = props?.options as MultiselectOption[];
+      const value = field.value as string[];
+
+      return (
+        <Multiselect
+          options={options}
+          value={value}
+          onChange={(values) => field.onChange(values)}
+        />
       );
     }
     case "DatePicker":

--- a/src/services/ui/src/components/RHF/SlotField.tsx
+++ b/src/services/ui/src/components/RHF/SlotField.tsx
@@ -123,7 +123,14 @@ export const SlotField = ({
       const options = props?.options as MultiselectOption[];
       const value = field.value as string[];
 
-      return <Multiselect options={options} value={value} {...props} />;
+      return (
+        <Multiselect
+          options={options}
+          value={value}
+          onChange={(selectedValues) => field.onChange(selectedValues)}
+          {...props}
+        />
+      );
     }
     case "DatePicker":
       return (

--- a/src/services/ui/src/components/RHF/tests/SlotField.test.tsx
+++ b/src/services/ui/src/components/RHF/tests/SlotField.test.tsx
@@ -89,7 +89,7 @@ describe("Slot Input Field Tests", () => {
     expect(selectBox).toBeTruthy();
   });
 
-  describe.only("Multiselect", () => {
+  describe("Multiselect", () => {
     test("renders Multiselect", () => {
       const { getByRole } = render(
         <TestWrapper

--- a/src/services/ui/src/components/RHF/tests/SlotField.test.tsx
+++ b/src/services/ui/src/components/RHF/tests/SlotField.test.tsx
@@ -1,10 +1,5 @@
 import { describe, test, expect } from "vitest";
-import {
-  render,
-  prettyDOM,
-  fireEvent,
-  getByLabelText,
-} from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 import { RHFSlot } from "../.";
 import { Form, FormField } from "../../Inputs";
 import { Control, useForm } from "react-hook-form";
@@ -92,6 +87,71 @@ describe("Slot Input Field Tests", () => {
     );
     const selectBox = rend.getByRole("combobox");
     expect(selectBox).toBeTruthy();
+  });
+
+  describe.only("Multiselect", () => {
+    test("renders Multiselect", () => {
+      const { getByRole } = render(
+        <TestWrapper
+          {...testValues}
+          rhf="Multiselect"
+          props={{
+            options: [
+              { label: "test 1", value: "test-1" },
+              { label: "test 2", value: "test-2" },
+            ],
+          }}
+        />,
+      );
+
+      expect(getByRole("combobox")).toBeInTheDocument();
+    });
+
+    test("renders options correctly", () => {
+      const { getByText, getByRole } = render(
+        <TestWrapper
+          {...testValues}
+          rhf="Multiselect"
+          props={{
+            options: [
+              { label: "test 1", value: "test-1" },
+              { label: "test 2", value: "test-2" },
+            ],
+          }}
+        />,
+      );
+
+      fireEvent.mouseDown(getByRole("combobox"));
+      expect(getByText("test 1")).toBeInTheDocument();
+      expect(getByText("test 2")).toBeInTheDocument();
+    });
+
+    test("allows multiple selections", () => {
+      const { getByText, getByRole, container } = render(
+        <TestWrapper
+          {...testValues}
+          rhf="Multiselect"
+          props={{
+            options: [
+              { label: "test 1", value: "test-1" },
+              { label: "test 2", value: "test-2" },
+            ],
+          }}
+        />,
+      );
+
+      fireEvent.mouseDown(getByRole("combobox"));
+      fireEvent.click(getByText("test 1"));
+      fireEvent.mouseDown(getByRole("combobox"));
+      fireEvent.click(getByText("test 2"));
+
+      const selectedOptions = container.querySelectorAll(
+        ".css-1p3m7a8-multiValue",
+      );
+      expect(selectedOptions).toHaveLength(2);
+      expect(selectedOptions[0]).toHaveTextContent("test-1");
+      expect(selectedOptions[1]).toHaveTextContent("test-2");
+    });
   });
 
   test("renders RadioGroup", () => {

--- a/src/services/ui/src/components/RHF/tests/SlotField.test.tsx
+++ b/src/services/ui/src/components/RHF/tests/SlotField.test.tsx
@@ -149,8 +149,8 @@ describe("Slot Input Field Tests", () => {
         ".css-1p3m7a8-multiValue",
       );
       expect(selectedOptions).toHaveLength(2);
-      expect(selectedOptions[0]).toHaveTextContent("test-1");
-      expect(selectedOptions[1]).toHaveTextContent("test-2");
+      expect(selectedOptions[0]).toHaveTextContent("test 1");
+      expect(selectedOptions[1]).toHaveTextContent("test 2");
     });
   });
 

--- a/src/services/ui/src/components/RHF/utils/initializer.ts
+++ b/src/services/ui/src/components/RHF/utils/initializer.ts
@@ -47,6 +47,7 @@ export const slotInitializer =
         break;
       case "Input":
       case "Select":
+      case "Multiselect":
       case "Radio":
       case "Textarea":
       default:


### PR DESCRIPTION
## Purpose

This adds the Multiselect component from the Dashboard to an RHF component that can be used in webforms.

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-28491

## Approach

I wrapped the `react-select` component into its own component that can be used with RHF and our webforms. This should make it available for use in upcoming webforms.