### PR TITLE
fix(email): Files section in Submission emails for all package types shows wrong file name type

### DIFF
--- a/src/services/auth/libs/users.json
+++ b/src/services/auth/libs/users.json
@@ -4,7 +4,7 @@
     "attributes": [
       {
         "Name": "email",
-        "Value": "george@example.com"
+        "Value": "aswift@fearless.tech"
       },
       {
         "Name": "given_name",

--- a/src/services/auth/libs/users.json
+++ b/src/services/auth/libs/users.json
@@ -4,7 +4,7 @@
     "attributes": [
       {
         "Name": "email",
-        "Value": "aswift@fearless.tech"
+        "Value": "george@example.com"
       },
       {
         "Name": "given_name",

--- a/src/services/email/handlers/processEmails.tsx
+++ b/src/services/email/handlers/processEmails.tsx
@@ -24,7 +24,7 @@ export const main = handler(async (record) => {
       try {
         return await SES.send(
           new SendTemplatedEmailCommand({
-            Source: process.env.emailSource ?? "aswift@fearless.tech",
+            Source: process.env.emailSource ?? "kgrue@fearless.tech",
             Destination: buildDestination(command, emailData),
             TemplateData: JSON.stringify(emailData),
             Template: command.Template,

--- a/src/services/email/handlers/processEmails.tsx
+++ b/src/services/email/handlers/processEmails.tsx
@@ -8,31 +8,39 @@ import { buildEmailData } from "../libs/data-lib";
 const SES = new SESClient({ region: process.env.region });
 
 export const main = handler(async (record) => {
-
   // get the bundle of emails associated with this action
   const emailBundle = getBundle(record, process.env.stage);
   console.log("emailBundle: ", emailBundle);
 
   // not every event has a bundle, and that's ok!
-  if (!emailBundle || !!emailBundle?.message || !emailBundle?.emailCommands) return { message: "no eventToEmailMapping found, no email sent" };
+  if (!emailBundle || !!emailBundle?.message || !emailBundle?.emailCommands)
+    return { message: "no eventToEmailMapping found, no email sent" };
 
   // data is at bundle level since often identical between emails and saves on lookups
   const emailData = await buildEmailData(emailBundle, record);
 
-  const sendResults = await Promise.allSettled(emailBundle.emailCommands.map(async (command) => {
-    try {
-      return await SES.send(new SendTemplatedEmailCommand({
-        Source: process.env.emailSource ?? "kgrue@fearless.tech",
-        Destination: buildDestination(command, emailData),
-        TemplateData: JSON.stringify(emailData),
-        Template: command.Template,
-        ConfigurationSetName: process.env.emailConfigSet,
-      }));
-    } catch (err) {
-      console.log("Failed to process theEmail.", err, JSON.stringify(command, null, 4));
-      return Promise.resolve({ message: err.message});
-    }
-  }));
+  const sendResults = await Promise.allSettled(
+    emailBundle.emailCommands.map(async (command) => {
+      try {
+        return await SES.send(
+          new SendTemplatedEmailCommand({
+            Source: process.env.emailSource ?? "aswift@fearless.tech",
+            Destination: buildDestination(command, emailData),
+            TemplateData: JSON.stringify(emailData),
+            Template: command.Template,
+            ConfigurationSetName: process.env.emailConfigSet,
+          }),
+        );
+      } catch (err) {
+        console.log(
+          "Failed to process theEmail.",
+          err,
+          JSON.stringify(command, null, 4),
+        );
+        return Promise.resolve({ message: err.message });
+      }
+    }),
+  );
   console.log("sendResults: ", sendResults);
   return sendResults;
 });

--- a/src/services/email/libs/data-lib.js
+++ b/src/services/email/libs/data-lib.js
@@ -1,6 +1,7 @@
 import { DateTime } from "luxon";
 
 import { getLookupValues } from "./lookup-lib";
+import { attachmentTitleMap } from "shared-types";
 
 const actionTypeLookup = {
   New: "Initial Waiver",
@@ -27,8 +28,14 @@ const formatAttachments = (formatType, attachmentList) => {
     return "attachment List";
   }
   if (!attachmentList || attachmentList.length === 0) return "no attachments";
-  else
-    return `${format.begin}${attachmentList.map((a) => `${a.title}: ${a.filename}`).join(format.joiner)}${format.end}`;
+  else {
+    const attachmentFormat = attachmentList.map((a) => {
+      const attachmentTitle = attachmentTitleMap[a.title] ?? a.title;
+      return `${attachmentTitle}: ${a.filename}`;
+    });
+    return `${format.begin}${attachmentFormat.join(format.joiner)}${format.end}`;
+  }
+    
 };
 
 const formatDateFromTimestamp = (timestamp) => {


### PR DESCRIPTION
## Purpose

>Mako - Files section in Submission emails for all package types shows wrong file type. It appears the file type name being displayed is a backend name version but should display the more user friendly version. This was working as intended back in April and started showing the backend file types in May.

#### Linked Issues to Close
[OY2-28880](https://qmacbis.atlassian.net/browse/OY2-28880)

## Approach
- using the attachment title map from attachements.ts so that it matches what is displayed in the app

## Email screenshots
Here are some examples of the new attachment titles:

1915(c) Waiver submitted to spa@cms.hhs.gov
<img width="1000" alt="Screenshot 2024-06-26 at 12 27 58 PM" src="https://github.com/Enterprise-CMCS/macpro-mako/assets/56361067/5405cbb7-0919-450d-a8cb-2ad94ff6a752">

CHIP SPA Submitted to spa@cms.hhs.gov
![Screenshot 2024-06-26 at 12 29 12 PM](https://github.com/Enterprise-CMCS/macpro-mako/assets/56361067/893cf276-2527-44fc-80ec-03121dd6fff6)

Medicaid SPA Submitted to spa@cms.hhs.gov
![Screenshot 2024-06-26 at 12 31 21 PM](https://github.com/Enterprise-CMCS/macpro-mako/assets/56361067/3a7dacd0-5825-44c9-816a-979026388e6a)
