### PR TITLE
fix(ui):remove unnecessary warnings from forms without inputs

### DIFF
--- a/src/services/ui/src/components/Form/content/ContentWrappers.tsx
+++ b/src/services/ui/src/components/Form/content/ContentWrappers.tsx
@@ -91,19 +91,22 @@ export const ActionFormHeaderCard = ({
 
 export const PreSubmitNotice = ({
   message,
+  hasProgressLossReminder = true,
 }: {
   message: string | ReactElement;
+  hasProgressLossReminder?: boolean;
 }) => (
   <Alert variant={"infoBlock"} className="space-x-2 mb-8">
     <Info />
     {/* Wraps strings, but allows for ReactElements to declare their own wrapper */}
     {typeof message === "string" ? (
       <p>
-        {message} <ProgressLossReminder />
+        {message}
+        {hasProgressLossReminder && <ProgressLossReminder />}
       </p>
     ) : (
       <>
-        {message} <ProgressLossReminder />
+        {message} {hasProgressLossReminder && <ProgressLossReminder />}
       </>
     )}
   </Alert>

--- a/src/services/ui/src/features/package-actions/ActionForm.tsx
+++ b/src/services/ui/src/features/package-actions/ActionForm.tsx
@@ -34,7 +34,7 @@ export const ActionForm = ({ setup }: { setup: FormSetup }) => {
     [item],
   );
   const form = useForm({
-    resolver: zodResolver(setup.schema),
+    resolver: setup.schema ? zodResolver(setup.schema) : undefined,
     mode: "onChange",
   });
 
@@ -81,7 +81,7 @@ export const ActionForm = ({ setup }: { setup: FormSetup }) => {
                 return (
                   <ActionFormHeaderCard
                     title={content.title}
-                    hasRequiredField
+                    hasRequiredField={setup.schema !== null}
                     isTE={field.key === "te-content-description"}
                     key="content-description"
                   >
@@ -94,7 +94,10 @@ export const ActionForm = ({ setup }: { setup: FormSetup }) => {
             })}
           <ErrorBanner />
           {content?.preSubmitNotice && (
-            <PreSubmitNotice message={content.preSubmitNotice} />
+            <PreSubmitNotice
+              message={content.preSubmitNotice}
+              hasProgressLossReminder={setup.schema !== null}
+            />
           )}
           {content?.confirmationModal ? (
             <SubmitAndCancelBtnSection

--- a/src/services/ui/src/features/package-actions/lib/modules/toggle-rai-withdraw/index.tsx
+++ b/src/services/ui/src/features/package-actions/lib/modules/toggle-rai-withdraw/index.tsx
@@ -1,20 +1,15 @@
 import { FormContentHydrator } from "@/features/package-actions/lib/contentSwitch";
 import { ReactElement } from "react";
 import { ActionFormDescription } from "@/components";
-import { z } from "zod";
 import { CheckDocumentFunction } from "@/utils/Poller/documentPoller";
 
-// react-hook-form needs any kind of schema to prevent an undefined error
-export const defaultEnableRaiWithdrawSchema = z.object({});
 export const defaultEnableRaiWithdrawFields: ReactElement[] = [
-  <ActionFormDescription boldReminder key={"field-description"}>
+  <ActionFormDescription key="field-description">
     Once you submit this form, the most recent Formal RAI Response for this
     package will be able to be withdrawn by the state.
   </ActionFormDescription>,
 ];
-export const defaultEnableRaiWithdrawContent: FormContentHydrator = (
-  document,
-) => ({
+export const defaultEnableRaiWithdrawContent: FormContentHydrator = () => ({
   title: "Enable Formal RAI Response Withdraw Details",
   enableSubmit: true,
   successBanner: {
@@ -23,17 +18,13 @@ export const defaultEnableRaiWithdrawContent: FormContentHydrator = (
   },
 });
 
-// react-hook-form needs any kind of schema to prevent an undefined error
-export const defaultDisableRaiWithdrawSchema = z.object({});
 export const defaultDisableRaiWithdrawFields: ReactElement[] = [
-  <ActionFormDescription boldReminder key={"section-description"}>
+  <ActionFormDescription key={"section-description"}>
     The state will not be able to withdraw its RAI response. It may take up to a
     minute for this change to be applied.
   </ActionFormDescription>,
 ];
-export const defaultDisableRaiWithdrawContent: FormContentHydrator = (
-  document,
-) => ({
+export const defaultDisableRaiWithdrawContent: FormContentHydrator = () => ({
   title: "Disable Formal RAI Response Withdraw Details",
   enableSubmit: true,
   successBanner: {


### PR DESCRIPTION
## Purpose

Remove validation warnings from forms without inputs

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-28620

## Approach

The previous iteration didn't account for two things:
- empty zod object schemas were still technically schemas and could be tested against
- displaying form warnings when there weren't inputs

This PR adds a new schema type: `null`. `null` means there are no input validation rules to be tested. We can check whether `setup.schema` is `null` and hide validation warnings.

![Screenshot 2024-07-05 at 11 35 21 AM](https://github.com/Enterprise-CMCS/macpro-mako/assets/58940073/fcf59bb5-d103-4b64-a082-e7f194b52026)