### PR TITLE
fix(ui): add `Intl.Collator("en").compare` to sort CPOC names alphabetically

### DIFF
--- a/src/services/ui/src/components/Opensearch/main/Filtering/Drawer/hooks.ts
+++ b/src/services/ui/src/components/Opensearch/main/Filtering/Drawer/hooks.ts
@@ -157,10 +157,12 @@ export const useFilterDrawer = () => {
       (STATE, [KEY, AGG]) => {
         return {
           ...STATE,
-          [KEY]: AGG.buckets.map((BUCK) => ({
-            label: `${labelMap[BUCK.key] || BUCK.key}`,
-            value: BUCK.key,
-          })),
+          [KEY]: AGG.buckets
+            .map((BUCK) => ({
+              label: `${labelMap[BUCK.key] || BUCK.key}`,
+              value: BUCK.key,
+            }))
+            .sort((a, b) => Intl.Collator("en").compare(a.value, b.value)),
         };
       },
       {} as Record<opensearch.main.Field, { label: string; value: string }[]>,


### PR DESCRIPTION
## Purpose

CPOC names of various cases weren't sorted according to their alphabetical order

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-26746

## Approach

- check the commit message for more information

