### PR TITLE
skip malformed update id records

### DIFF
--- a/src/services/data/handlers/sinkMain.ts
+++ b/src/services/data/handlers/sinkMain.ts
@@ -136,9 +136,7 @@ const onemac = async (kafkaRecords: KafkaRecord[], topicPartition: string) => {
                 .transform(id)
                 .safeParse(record);
             case Action.ISSUE_RAI:
-              return opensearch.main.issueRai
-                .transform(id)
-                .safeParse(record);
+              return opensearch.main.issueRai.transform(id).safeParse(record);
             case Action.RESPOND_TO_RAI:
               return opensearch.main.respondToRai
                 .transform(id)
@@ -157,8 +155,10 @@ const onemac = async (kafkaRecords: KafkaRecord[], topicPartition: string) => {
                 .safeParse(record);
             case Action.UPDATE_ID: {
               console.log("UPDATE_ID detected...");
-              if(!record.newId){
-                console.log("Malformed update id record.  We're going to skip.")
+              if (!record.newId) {
+                console.log(
+                  "Malformed update id record.  We're going to skip.",
+                );
                 break; // we need to add a safeparse so malformed receords fail in a nominal way.
               }
               // Immediately index all prior documents


### PR DESCRIPTION
This is a fix to accomodate malformed update id records that wound up on master/dev.