### PR TITLE
fix(apb4-changes): Resolve gap between two child elements

### DIFF
--- a/src/services/api/webforms/ABP4/v202401.ts
+++ b/src/services/api/webforms/ABP4/v202401.ts
@@ -42,49 +42,55 @@ export const v202401: FormSchema = {
               },
             },
             {
-              rhf: "Checkbox",
-              name: "see-approved-attachment",
-              rules: { required: "* Required" },
-              formItemClassName:
-                "ml-[0.6rem] px-4 my-2 border-l-4 border-l-primary",
-              dependency: {
-                conditions: [
-                  {
-                    name: "abp4_cost-sharing_abp-for-individuals-income-over-100-poverty",
-                    type: "expectedValue",
-                    expectedValue: "yes",
+              rhf: "WrappedGroup",
+              name: "wrapped",
+              fields: [
+                {
+                  rhf: "Checkbox",
+                  name: "see-approved-attachment",
+                  rules: { required: "* Required" },
+                  formItemClassName:
+                    "ml-[0.6rem] px-4 border-l-4 border-l-primary pb-6",
+                  dependency: {
+                    conditions: [
+                      {
+                        name: "abp4_cost-sharing_abp-for-individuals-income-over-100-poverty",
+                        type: "expectedValue",
+                        expectedValue: "yes",
+                      },
+                    ],
+                    effect: { type: "show" },
                   },
-                ],
-                effect: { type: "show" },
-              },
-              props: {
-                options: [
-                  {
-                    label:
-                      "See approved Attachment 4.18-F or G for description.",
-                    value: "true",
+                  props: {
+                    options: [
+                      {
+                        label:
+                          "See approved Attachment 4.18-F or G for description.",
+                        value: "true",
+                      },
+                    ],
                   },
-                ],
-              },
-            },
-            {
-              rhf: "Upload",
-              name: "attachment_upload",
-              label: "Attachment 4.18-F or G",
-              labelClassName: "font-bold",
-              rules: { required: "* Required" },
-              formItemClassName:
-                "ml-[0.6rem] px-4 my-2 border-l-4 border-l-primary",
-              dependency: {
-                conditions: [
-                  {
-                    name: "abp4_cost-sharing_abp-for-individuals-income-over-100-poverty",
-                    type: "expectedValue",
-                    expectedValue: "yes",
+                },
+                {
+                  rhf: "Upload",
+                  name: "attachment_upload",
+                  label: "Attachment 4.18-F or G",
+                  labelClassName: "font-bold",
+                  rules: { required: "* Required" },
+                  formItemClassName:
+                    "ml-[0.6rem] px-4 border-l-4 border-l-primary",
+                  dependency: {
+                    conditions: [
+                      {
+                        name: "abp4_cost-sharing_abp-for-individuals-income-over-100-poverty",
+                        type: "expectedValue",
+                        expectedValue: "yes",
+                      },
+                    ],
+                    effect: { type: "show" },
                   },
-                ],
-                effect: { type: "show" },
-              },
+                },
+              ],
             },
             {
               rhf: "Textarea",


### PR DESCRIPTION
## Purpose

There was an unintended gap between the select menu and upload box, two child elements under the same parent:

<img width="804" alt="Screenshot 2024-07-23 at 10 11 43 AM" src="https://github.com/user-attachments/assets/f62f8577-6267-4a4b-86ee-8b85ed9adaf0">

This PR eliminates that gap between the two elements. The other two items listed in the ticket (a thicker border around the upload box and the height of the text area set to 76 px) have already been resolved in other tickets.

<img width="798" alt="Screenshot 2024-07-23 at 10 14 49 AM" src="https://github.com/user-attachments/assets/84462cc3-b098-4534-91c1-393d3d85225a">

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-28876

## Approach

This was resolved by leveraging the `WrappedGroup` RHF component and editing the inline Tailwind CSS properties in the ABP-4 webform file.