### PR TITLE
chore(app): Replace `Authority` enum

### DIFF
--- a/src/packages/shared-types/authority.ts
+++ b/src/packages/shared-types/authority.ts
@@ -1,29 +1,14 @@
-// TODO: Refactor out
-export enum Authority {
-  MED_SPA = "medicaid spa",
-  CHIP_SPA = "chip spa",
-  "1915b" = "1915(b)",
-  "1915c" = "1915(c)",
-}
+export const CHIP_SPA = "CHIP SPA" as const;
+export const MEDICAD_SPA = "Medicaid SPA" as const;
+export const WAIVER_1915_B = "1915(b)" as const;
+export const WAIVER_1915_C = "1915(c)" as const;
 
-export type AuthorityUnion =
-  | "Medicaid SPA"
-  | "CHIP SPA"
-  | "1915(b)"
-  | "1915(c)";
+export const AUTHORITY = {
+  [CHIP_SPA]: "chip spa",
+  [MEDICAD_SPA]: "medicaid spa",
+  [WAIVER_1915_B]: "1915(b)",
+  [WAIVER_1915_C]: "1915(c)",
+} as const;
 
-export type AuthorityAPI = "medicaid spa" | "chip spa" | "1915(b)" | "1915(c)";
-
-export const AUTHORITY_FE_TO_API: Record<AuthorityUnion, AuthorityAPI> = {
-  "CHIP SPA": "chip spa",
-  "Medicaid SPA": "medicaid spa",
-  "1915(b)": "1915(b)",
-  "1915(c)": "1915(c)",
-};
-
-export const AUTHORITY_API_TO_FE: Record<AuthorityAPI, AuthorityUnion> = {
-  "1915(b)": "1915(b)",
-  "1915(c)": "1915(c)",
-  "chip spa": "CHIP SPA",
-  "medicaid spa": "Medicaid SPA",
-};
+export type Authority = keyof typeof AUTHORITY;
+export type SeatoolAuthority = (typeof AUTHORITY)[keyof typeof AUTHORITY];

--- a/src/packages/shared-types/opensearch/main/transforms/seatool.ts
+++ b/src/packages/shared-types/opensearch/main/transforms/seatool.ts
@@ -8,7 +8,7 @@ import {
   SEATOOL_SPW_STATUS,
 } from "../../..";
 
-import { Authority, SEATOOL_AUTHORITIES } from "shared-types";
+import { SEATOOL_AUTHORITIES } from "shared-types";
 
 type Flavor = "SPA" | "WAIVER" | "MEDICAID" | "CHIP";
 
@@ -158,7 +158,7 @@ export const transform = (id: string) => {
         !leadAnalystName && !finalDispositionStatuses.includes(seatoolStatus),
       leadAnalystName,
       authorityId: authorityId || null,
-      authority: getAuthority(authorityId, id) as Authority | null,
+      authority: getAuthority(authorityId, id),
       types:
         data.STATE_PLAN_SERVICETYPES?.filter(
           (type): type is NonNullable<typeof type> => type != null,

--- a/src/packages/shared-utils/package-actions/rules.ts
+++ b/src/packages/shared-utils/package-actions/rules.ts
@@ -1,7 +1,6 @@
 import {
   Action,
   ActionRule,
-  Authority,
   SEATOOL_STATUS,
   finalDispositionStatuses,
 } from "shared-types";
@@ -22,7 +21,7 @@ const arIssueRai: ActionRule = {
       // The latest RAI is complete
       (checker.hasCompletedRai &&
         // The package is a chip (chips can have more than 1 rai)
-        checker.authorityIs([Authority.CHIP_SPA]) &&
+        checker.authorityIs(["CHIP SPA"]) &&
         // The package does not have RAI Response Withdraw enabled
         !checker.hasEnabledRaiWithdraw)) &&
     isCmsWriteUser(user) &&
@@ -101,10 +100,8 @@ const arCompleteIntake: ActionRule = {
 
 const arRemoveAppkChild: ActionRule = {
   action: Action.REMOVE_APPK_CHILD,
-  check: (checker, user) =>
-    isStateUser(user) && !!checker.isAppkChild
-}
-
+  check: (checker, user) => isStateUser(user) && !!checker.isAppkChild,
+};
 
 export default [
   arIssueRai,

--- a/src/packages/shared-utils/package-check.ts
+++ b/src/packages/shared-utils/package-check.ts
@@ -1,8 +1,9 @@
 import {
   opensearch,
-  Authority,
   SEATOOL_STATUS,
   ActionType,
+  Authority,
+  SeatoolAuthority,
 } from "shared-types";
 
 const secondClockStatuses = [
@@ -11,13 +12,8 @@ const secondClockStatuses = [
   SEATOOL_STATUS.PENDING_CONCURRENCE,
 ];
 
-const checkAuthority = (
-  authority: Authority | null,
-  validAuthorities: Authority[],
-) =>
-  !authority
-    ? false
-    : validAuthorities.includes(authority.toLowerCase() as Authority);
+const checkAuthority = (authority: string, validAuthorities: Authority[]) =>
+  validAuthorities.some((validAuthority) => validAuthority === authority);
 
 const checkStatus = (seatoolStatus: string, authorized: string | string[]) =>
   typeof authorized === "string"
@@ -37,15 +33,11 @@ export const PackageCheck = ({
   appkParentId,
   appkParent,
   initialIntakeNeeded,
-  leadAnalystName
-   
+  leadAnalystName,
 }: opensearch.main.Document) => {
   const planChecks = {
-    isSpa: checkAuthority(authority, [Authority.MED_SPA, Authority.CHIP_SPA]),
-    isWaiver: checkAuthority(authority, [
-      Authority["1915b"],
-      Authority["1915c"],
-    ]),
+    isSpa: checkAuthority(authority, ["Medicaid SPA", "CHIP SPA"]),
+    isWaiver: checkAuthority(authority, ["1915(b)", "1915(c)"]),
     isAppk: appkParent,
     isAppkChild: appkParentId,
     /** Keep excess methods to a minimum with `is` **/
@@ -61,7 +53,7 @@ export const PackageCheck = ({
     ]),
     /** Is in a second clock status and RAI has been received **/
     isInSecondClock:
-      !planChecks.authorityIs([Authority.CHIP_SPA]) &&
+      !planChecks.authorityIs(["CHIP SPA"]) &&
       checkStatus(seatoolStatus, secondClockStatuses) &&
       raiRequestedDate &&
       raiReceivedDate &&

--- a/src/packages/shared-utils/tests/package-check.test.ts
+++ b/src/packages/shared-utils/tests/package-check.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { testItemResult, testCMSCognitoUser } from "./testData";
+import { testItemResult } from "./testData";
 import { PackageCheck } from "../package-check";
-import { ActionType, Authority, SEATOOL_STATUS } from "shared-types";
+import {
+  ActionType,
+  AUTHORITY,
+  CHIP_SPA,
+  MEDICAD_SPA,
+  SEATOOL_STATUS,
+  WAIVER_1915_B,
+} from "shared-types";
 
 // Build Mock Package data:
 //   - make it basic, like a new submission
@@ -13,38 +20,38 @@ describe("PackageCheck", () => {
     it("checks if isSpa", () => {
       let packageCheck = PackageCheck({
         ...testItemResult._source,
-        authority: Authority.MED_SPA,
+        authority: MEDICAD_SPA,
       });
       expect(packageCheck.isSpa).toBe(true);
       packageCheck = PackageCheck({
         ...testItemResult._source,
-        authority: Authority.CHIP_SPA,
+        authority: CHIP_SPA,
       });
       expect(packageCheck.isSpa).toBe(true);
       packageCheck = PackageCheck({
         ...testItemResult._source,
-        authority: Authority["1915b"],
+        authority: WAIVER_1915_B,
       });
       expect(packageCheck.isSpa).toBe(false);
     });
     it("checks if isWaiver", () => {
       let packageCheck = PackageCheck({
         ...testItemResult._source,
-        authority: Authority["1915b"],
+        authority: WAIVER_1915_B,
       });
       expect(packageCheck.isWaiver).toBe(true);
       packageCheck = PackageCheck({
         ...testItemResult._source,
-        authority: Authority.CHIP_SPA,
+        authority: CHIP_SPA,
       });
       expect(packageCheck.isWaiver).toBe(false);
     });
     it("checks against input", () => {
       let packageCheck = PackageCheck({
         ...testItemResult._source,
-        authority: Authority["1915b"],
+        authority: WAIVER_1915_B,
       });
-      expect(packageCheck.authorityIs([Authority["1915b"]])).toBe(true);
+      expect(packageCheck.authorityIs(["1915(b)"])).toBe(true);
     });
   });
 
@@ -64,7 +71,7 @@ describe("PackageCheck", () => {
     it("checks if isInSecondClock", () => {
       let packageCheck = PackageCheck({
         ...testItemResult._source,
-        authority: Authority.CHIP_SPA, // Chip Spas don't have 2nd clock
+        authority: CHIP_SPA, // Chip Spas don't have 2nd clock
         seatoolStatus: SEATOOL_STATUS.PENDING,
         raiRequestedDate: "exists",
         raiReceivedDate: "exists",
@@ -72,7 +79,7 @@ describe("PackageCheck", () => {
       expect(packageCheck.isInSecondClock).toBe(false);
       packageCheck = PackageCheck({
         ...testItemResult._source,
-        authority: Authority.MED_SPA,
+        authority: MEDICAD_SPA,
         seatoolStatus: SEATOOL_STATUS.PENDING,
         raiRequestedDate: "exists",
         raiReceivedDate: "exists",

--- a/src/packages/shared-utils/tests/rules.test.ts
+++ b/src/packages/shared-utils/tests/rules.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import rules from "../package-actions/rules";
-import { Action, Authority, SEATOOL_STATUS } from "shared-types";
+import { Action, CHIP_SPA, MEDICAD_SPA, SEATOOL_STATUS } from "shared-types";
 import {
   testItemResult,
   testCMSCognitoUser,
@@ -54,7 +54,7 @@ describe("Action Rules", () => {
     it("is unavailable if the package has completed the latest RAI and is a Medicaid SPA", () => {
       const packageChecker = PackageCheck({
         ...testItemResult._source,
-        authority: Authority.MED_SPA,
+        authority: MEDICAD_SPA,
         raiRequestedDate: "yesterday, lol",
         raiReceivedDate: "today, foo",
       });
@@ -63,7 +63,7 @@ describe("Action Rules", () => {
     it("is unavailable if the package has completed the latest RAI and has RAI Withdraw enabled", () => {
       const packageChecker = PackageCheck({
         ...testItemResult._source,
-        authority: Authority.CHIP_SPA,
+        authority: CHIP_SPA,
         raiRequestedDate: "yesterday, lol",
         raiReceivedDate: "today, foo",
         raiWithdrawEnabled: true,

--- a/src/packages/shared-utils/tests/testData.ts
+++ b/src/packages/shared-utils/tests/testData.ts
@@ -1,5 +1,5 @@
 import { OneMacUser } from "ui/src/api";
-import { Authority, opensearch } from "../../shared-types";
+import { opensearch } from "../../shared-types";
 
 export const testStateCognitoUser: OneMacUser = {
   isCms: false,
@@ -99,7 +99,7 @@ export const testItemResult: opensearch.main.ItemResult = {
     flavor: "MEDICAID",
     authorityId: 125,
     initialIntakeNeeded: true,
-    authority: "Medicaid SPA" as Authority,
+    authority: "Medicaid SPA",
     approvedEffectiveDate: null,
     typeId: null,
     seatoolStatus: "Pending",

--- a/src/services/api/handlers/submit.ts
+++ b/src/services/api/handlers/submit.ts
@@ -9,7 +9,7 @@ import {
 
 import {
   Action,
-  Authority,
+  AUTHORITY,
   SEATOOL_AUTHORITIES,
   onemacSchema,
 } from "shared-types";
@@ -54,10 +54,10 @@ export const submit = async (event: APIGatewayEvent) => {
   }
 
   const activeSubmissionTypes = [
-    Authority.CHIP_SPA,
-    Authority.MED_SPA,
-    Authority["1915b"],
-    Authority["1915c"], // We accept amendments, renewals, and extensions for Cs
+    AUTHORITY["CHIP SPA"],
+    AUTHORITY["Medicaid SPA"],
+    AUTHORITY["1915(b)"],
+    AUTHORITY["1915(c)"], // We accept amendments, renewals, and extensions for Cs
   ];
   if (!activeSubmissionTypes.includes(body.authority)) {
     return response({
@@ -76,7 +76,7 @@ export const submit = async (event: APIGatewayEvent) => {
 
   // I think we need to break this file up.  A switch maybe
   if (
-    [Authority["1915b"], Authority["1915c"]].includes(body.authority) &&
+    [AUTHORITY["1915(b)"], AUTHORITY["1915(c)"]].includes(body.authority) &&
     body.seaActionType === "Extend"
   ) {
     console.log("Received a new temporary extension sumbission");
@@ -164,9 +164,10 @@ export const submit = async (event: APIGatewayEvent) => {
     // Resolve the the Plan_Type_ID
     const authorityId = findAuthorityIdByName(body.authority);
     // Resolve the actionTypeID, if applicable
-    const actionTypeSelect = [Authority["1915b"], Authority.CHIP_SPA].includes(
-      body.authority,
-    )
+    const actionTypeSelect = [
+      AUTHORITY["1915(b)"],
+      AUTHORITY["CHIP SPA"],
+    ].includes(body.authority)
       ? `
         SELECT @ActionTypeID = Action_ID FROM SEA.dbo.Action_Types
         WHERE Plan_Type_ID = '${authorityId}'

--- a/src/services/data/handlers/sinkMain.ts
+++ b/src/services/data/handlers/sinkMain.ts
@@ -1,6 +1,6 @@
 import { Handler } from "aws-lambda";
 import * as os from "./../../../libs/opensearch-lib";
-import { Action, Authority, KafkaRecord, opensearch } from "shared-types";
+import { Action, AUTHORITY, KafkaRecord, opensearch } from "shared-types";
 import { KafkaEvent } from "shared-types";
 import {
   ErrorType,
@@ -198,7 +198,7 @@ const onemac = async (kafkaRecords: KafkaRecord[], topicPartition: string) => {
               // Handle the appk children when an appk parent id is updated
               // I'd like a better way to identify an appk parent.
               if (
-                item._source.authority === Authority["1915c"] &&
+                item._source.authority === AUTHORITY["1915(c)"] &&
                 !item._source.appkParentId
               ) {
                 console.log("AppK Parent ID update detected...");

--- a/src/services/ui/src/api/submissionService.ts
+++ b/src/services/ui/src/api/submissionService.ts
@@ -4,8 +4,8 @@ import {
   ReactQueryApiError,
   Action,
   AttachmentKey,
-  AUTHORITY_FE_TO_API,
-  AuthorityAPI,
+  AUTHORITY,
+  SeatoolAuthority,
 } from "shared-types";
 import { buildActionUrl, SubmissionServiceEndpoint } from "@/utils";
 import { OneMacUser } from "@/api";
@@ -16,7 +16,7 @@ export type SubmissionServiceParameters<T> = {
   data: T;
   endpoint: SubmissionServiceEndpoint;
   user: OneMacUser | undefined;
-  authority: AuthorityAPI;
+  authority: SeatoolAuthority;
 };
 type SubmissionServiceResponse = {
   body: {
@@ -59,7 +59,7 @@ export const buildSubmissionPayload = <T extends Record<string, unknown>>(
   data: T,
   user: OneMacUser | undefined,
   endpoint: SubmissionServiceEndpoint,
-  authority: AuthorityAPI,
+  authority: SeatoolAuthority,
   attachments?: UploadRecipe[],
 ) => {
   const userDetails = {
@@ -78,7 +78,7 @@ export const buildSubmissionPayload = <T extends Record<string, unknown>>(
         ...data,
         ...userDetails,
         ...baseProperties,
-        authority: AUTHORITY_FE_TO_API["1915(c)"],
+        authority: AUTHORITY["1915(c)"],
         proposedEffectiveDate: seaToolFriendlyTimestamp(
           data.proposedEffectiveDate as Date,
         ),
@@ -89,7 +89,7 @@ export const buildSubmissionPayload = <T extends Record<string, unknown>>(
         ...data,
         ...baseProperties,
         ...userDetails,
-        authority: AUTHORITY_FE_TO_API["1915(c)"],
+        authority: AUTHORITY["1915(c)"],
       };
     case "/submit":
       return {

--- a/src/services/ui/src/components/Form/content/PackageSection.tsx
+++ b/src/services/ui/src/components/Form/content/PackageSection.tsx
@@ -1,30 +1,27 @@
+import { useParams } from "react-router-dom";
 import { Authority } from "shared-types";
-import { useParams } from "@/components";
 
 export const PackageSection = () => {
-  const { id, authority } = useParams("/action/:authority/:id/:type");
-  const lcAuthority = authority.toLowerCase();
-  // We should pass in the already lowercased Authority, right?  todo
+  const { id, authority } = useParams<{ id: string; authority: Authority }>();
+
   return (
     <section className="flex flex-col mb-8 space-y-8">
       <div>
         <p>
-          {[Authority.CHIP_SPA, Authority.MED_SPA].includes(
-            authority.toLowerCase() as Authority,
-          ) && "Package ID"}
-          {[Authority["1915b"], Authority["1915c"]].includes(
-            authority.toLowerCase() as Authority,
-          ) && "Waiver Number"}
+          {(authority === "CHIP SPA" || authority === "Medicaid SPA") &&
+            "Package ID"}
+          {(authority === "1915(b)" || authority === "1915(c)") &&
+            "Waiver Number"}
         </p>
         <p className="text-xl">{id}</p>
       </div>
       <div>
         <p>Authority</p>
         <p className="text-xl">
-          {lcAuthority === Authority["1915b"] && "1915(b) Waiver"}
-          {lcAuthority === Authority["1915c"] && "1915(c) Waiver"}
-          {lcAuthority === Authority["CHIP_SPA"] && "CHIP SPA"}
-          {lcAuthority === Authority["MED_SPA"] && "Medicaid SPA"}
+          {authority === "1915(b)" && "1915(b) Waiver"}
+          {authority === "1915(c)" && "1915(c) Waiver"}
+          {authority === "CHIP SPA" && "CHIP SPA"}
+          {authority === "Medicaid SPA" && "Medicaid SPA"}
         </p>
       </div>
     </section>

--- a/src/services/ui/src/features/dashboard/Lists/spas/consts.tsx
+++ b/src/services/ui/src/features/dashboard/Lists/spas/consts.tsx
@@ -1,6 +1,6 @@
 import { removeUnderscoresAndCapitalize } from "@/utils";
 import { OsTableColumn } from "@/components";
-import { CMS_READ_ONLY_ROLES, UserRoles } from "shared-types";
+import { Authority, CMS_READ_ONLY_ROLES, UserRoles } from "shared-types";
 import { useGetUser } from "@/api";
 import {
   CellDetailsLink,
@@ -36,7 +36,7 @@ export const useSpaTableColumns = (): OsTableColumn[] => {
       locked: true,
       transform: (data) => data.id,
       cell: ({ id, authority }) => (
-        <CellDetailsLink id={id} authority={authority} />
+        <CellDetailsLink id={id} authority={authority as Authority} />
       ),
     },
     {

--- a/src/services/ui/src/features/dashboard/Lists/waivers/consts.tsx
+++ b/src/services/ui/src/features/dashboard/Lists/waivers/consts.tsx
@@ -1,7 +1,7 @@
 import { removeUnderscoresAndCapitalize, LABELS } from "@/utils";
 import { OsTableColumn } from "@/components";
 import { BLANK_VALUE } from "@/consts";
-import { CMS_READ_ONLY_ROLES, UserRoles } from "shared-types";
+import { Authority, CMS_READ_ONLY_ROLES, UserRoles } from "shared-types";
 import { useGetUser } from "@/api";
 import {
   CellDetailsLink,
@@ -36,7 +36,7 @@ export const useWaiverTableColumns = (): OsTableColumn[] => {
       locked: true,
       transform: (data) => data.id,
       cell: ({ id, authority }) => (
-        <CellDetailsLink id={id} authority={authority} />
+        <CellDetailsLink id={id} authority={authority as Authority} />
       ),
     },
     {

--- a/src/services/ui/src/features/package-actions/lib/contentSwitch.ts
+++ b/src/services/ui/src/features/package-actions/lib/contentSwitch.ts
@@ -1,5 +1,5 @@
 import { BannerContent, SubmissionAlert } from "@/components";
-import { Action, AuthorityUnion, opensearch } from "shared-types";
+import { Action, Authority, opensearch } from "shared-types";
 import {
   defaultIssueRaiContent,
   defaultTempExtContent,
@@ -24,7 +24,7 @@ type FormContent = {
 /** Form content sometimes requires data values for templating, so forms
  * hydrate the content with these functions. */
 export type FormContentHydrator = (d: opensearch.main.Document) => FormContent;
-type FormContentGroup = Record<AuthorityUnion, FormContentHydrator | undefined>;
+type FormContentGroup = Record<Authority, FormContentHydrator | undefined>;
 
 const issueRaiFor: FormContentGroup = {
   "CHIP SPA": defaultIssueRaiContent,
@@ -89,10 +89,7 @@ const completeIntakeFor: FormContentGroup = {
   "1915(c)": defaultCompleteIntakeContent,
 };
 
-export const getContentFor = (
-  a: Action,
-  p: AuthorityUnion,
-): FormContentHydrator => {
+export const getContentFor = (a: Action, p: Authority): FormContentHydrator => {
   const actionContentMap: Record<string, FormContentGroup> = {
     "issue-rai": issueRaiFor,
     "respond-to-rai": respondToRaiFor,

--- a/src/services/ui/src/features/package-actions/lib/fieldsSwitch.ts
+++ b/src/services/ui/src/features/package-actions/lib/fieldsSwitch.ts
@@ -1,4 +1,4 @@
-import { Action, AuthorityUnion } from "shared-types";
+import { Action, Authority } from "shared-types";
 import { ReactElement } from "react";
 import {
   bWaiverRaiFields,
@@ -15,7 +15,7 @@ import {
   medSpaRaiFields,
 } from "@/features/package-actions/lib/modules";
 
-type FieldsGroup = Record<AuthorityUnion, ReactElement[] | undefined>;
+type FieldsGroup = Record<Authority, ReactElement[] | undefined>;
 
 const issueRaiFor: FieldsGroup = {
   "CHIP SPA": defaultIssueRaiFields,
@@ -80,7 +80,7 @@ const completeIntakeFor: FieldsGroup = {
   "1915(c)": defaultCompleteIntakeFields,
 };
 
-export const getFieldsFor = (a: Action, p: AuthorityUnion): ReactElement[] => {
+export const getFieldsFor = (a: Action, p: Authority): ReactElement[] => {
   const fieldsGroupMap: Record<string, FieldsGroup> = {
     "issue-rai": issueRaiFor,
     "respond-to-rai": respondToRaiFor,

--- a/src/services/ui/src/features/package-actions/lib/index.ts
+++ b/src/services/ui/src/features/package-actions/lib/index.ts
@@ -1,4 +1,4 @@
-import { Action, AUTHORITY_FE_TO_API, AuthorityUnion } from "shared-types";
+import { Action, AUTHORITY, Authority } from "shared-types";
 import { getSchemaFor } from "@/features/package-actions/lib/schemaSwitch";
 import { getFieldsFor } from "@/features/package-actions/lib/fieldsSwitch";
 import { OneMacUser, submit } from "@/api";
@@ -20,7 +20,7 @@ export type FormSetup = {
 };
 /** Builds a form setup using an Action x Authority 2-dimensional
  * lookup. */
-export const getSetupFor = (a: Action, p: AuthorityUnion): FormSetup => ({
+export const getSetupFor = (a: Action, p: Authority): FormSetup => ({
   schema: getSchemaFor(a, p),
   fields: getFieldsFor(a, p),
   content: getContentFor(a, p),
@@ -42,7 +42,7 @@ export const submitActionForm = async ({
   id: string;
   type: Action;
   user: OneMacUser;
-  authority: AuthorityUnion;
+  authority: Authority;
   originRoute: ReturnType<typeof useOriginPath>;
   alert: ReturnType<typeof useAlertContext>;
   navigate: ReturnType<typeof useNavigate>;
@@ -58,7 +58,7 @@ export const submitActionForm = async ({
         ? buildActionUrl(type) // "/action/{type}"
         : "/submit",
       user,
-      authority: AUTHORITY_FE_TO_API[authority],
+      authority: AUTHORITY[authority],
     });
     alert.setBannerStyle("success");
     alert.setBannerShow(true);

--- a/src/services/ui/src/features/package-actions/lib/modules/temporary-extension/legacy-page.tsx
+++ b/src/services/ui/src/features/package-actions/lib/modules/temporary-extension/legacy-page.tsx
@@ -5,7 +5,7 @@
 import { unflatten } from "flat";
 import { defaultTempExtSchema } from ".";
 import { getUser, submit } from "@/api";
-import { AuthorityAPI } from "shared-types";
+import { Authority, SeatoolAuthority } from "shared-types";
 import { FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
@@ -45,8 +45,8 @@ export const onValidSubmission: ActionFunction = async ({ request }) => {
       data,
       endpoint: "/submit",
       user,
-      // REFACTOR: either check if data.authority is AuthorityAPI or type it out correctly
-      authority: data.authority as AuthorityAPI,
+      // REFACTOR: either check if data.authority is SeatoolAuthority or type it out correctly
+      authority: data.authority as SeatoolAuthority,
     });
 
     await documentPoller(data.id, (data) => !!data).startPollingData();
@@ -79,7 +79,7 @@ export const TempExtensionWrapper = () => {
 };
 
 export const TemporaryExtension = () => {
-  const { id, authority } = useParams<{ id: string; authority: string }>();
+  const { id, authority } = useParams<{ id: string; authority: Authority }>();
 
   const navigationLocation = useMemo(
     () =>

--- a/src/services/ui/src/features/package-actions/lib/modules/withdraw-package/index.tsx
+++ b/src/services/ui/src/features/package-actions/lib/modules/withdraw-package/index.tsx
@@ -8,7 +8,7 @@ import {
   AttachmentsSection,
 } from "@/components";
 import { CheckDocumentFunction } from "@/utils/Poller/documentPoller";
-import { Authority, SEATOOL_STATUS } from "shared-types";
+import { AUTHORITY, SEATOOL_STATUS } from "shared-types";
 
 export * from "./spa/withdraw-chip-rai";
 export * from "./waiver/withdraw-waiver";
@@ -66,7 +66,7 @@ export const defaultWithdrawPackageFields: ReactElement[] = [
 export const defaultWithdrawPackageContent: FormContentHydrator = (
   document,
 ) => ({
-  title: `Withdraw ${document.authority} ${document.authority === Authority["1915c"] ? "Appendix K" : ""}`,
+  title: `Withdraw ${document.authority} ${document.authority === AUTHORITY["1915(c)"] ? "Appendix K" : ""}`,
   preSubmitNotice:
     "Once complete, you will not be able to resubmit this package. CMS will be notified and will use this content to review your request. If CMS needs any additional information, they will follow up by email.",
   confirmationModal: {

--- a/src/services/ui/src/features/package-actions/lib/schemaSwitch.ts
+++ b/src/services/ui/src/features/package-actions/lib/schemaSwitch.ts
@@ -1,4 +1,4 @@
-import { Action, AuthorityUnion } from "shared-types";
+import { Action, Authority } from "shared-types";
 import { ZodEffects, ZodObject, ZodRawShape, ZodType } from "zod";
 import {
   bWaiverRaiSchema,
@@ -14,7 +14,7 @@ import {
 } from "@/features/package-actions/lib/modules";
 
 type Schema = ZodObject<ZodRawShape> | ZodEffects<ZodType>;
-type SchemaGroup = Record<AuthorityUnion, Schema | undefined | null>;
+type SchemaGroup = Record<Authority, Schema | undefined | null>;
 
 const issueRaiFor: SchemaGroup = {
   "CHIP SPA": defaultIssueRaiSchema,
@@ -79,7 +79,7 @@ const completeIntakeFor: SchemaGroup = {
   "1915(c)": defaultCompleteIntakeSchema,
 };
 
-export const getSchemaFor = (a: Action, p: AuthorityUnion): Schema | null => {
+export const getSchemaFor = (a: Action, p: Authority): Schema | null => {
   const actionSchemaMap: Record<string, SchemaGroup> = {
     "issue-rai": issueRaiFor,
     "respond-to-rai": respondToRaiFor,

--- a/src/services/ui/src/features/package/index.tsx
+++ b/src/services/ui/src/features/package/index.tsx
@@ -11,7 +11,7 @@ import { PackageDetails } from "./package-details";
 import { PackageStatusCard } from "./package-status";
 import { PackageActionsCard } from "./package-actions";
 import { useDetailsSidebarLinks } from "./hooks";
-import { Authority, AuthorityUnion } from "shared-types";
+import { AUTHORITY, Authority } from "shared-types";
 import { Navigate, useParams } from "react-router-dom";
 import { detailsAndActionsCrumbs } from "@/utils";
 
@@ -38,8 +38,8 @@ export const DetailsContent: FC<{ id: string }> = ({ id }) => {
   const title =
     (() => {
       switch (data._source.authority) {
-        case Authority["1915b"]:
-        case Authority["1915c"]:
+        case AUTHORITY["1915(b)"]:
+        case AUTHORITY["1915(c)"]:
         case undefined: // Some TEs have no authority
           if (data._source.appkParent)
             return "Appendix K Amendment Package Details";
@@ -72,7 +72,7 @@ export const DetailsContent: FC<{ id: string }> = ({ id }) => {
 export const Details = () => {
   const { id, authority } = useParams<{
     id: string;
-    authority: AuthorityUnion;
+    authority: Authority;
   }>();
 
   if (id === undefined || authority === undefined) {

--- a/src/services/ui/src/features/package/package-details/appk.tsx
+++ b/src/services/ui/src/features/package/package-details/appk.tsx
@@ -1,5 +1,5 @@
 import { ConfirmationModal, LoadingSpinner } from "@/components";
-import { SEATOOL_STATUS } from "shared-types";
+import { SEATOOL_STATUS, SeatoolAuthority } from "shared-types";
 import { useState } from "react";
 import * as T from "@/components/Table";
 import { Button } from "@/components/Inputs";
@@ -25,7 +25,7 @@ export const AppK = () => {
       {
         data: { id, appkParentId: cache.data.id },
         user,
-        authority: cache.data.authority,
+        authority: cache.data.authority as SeatoolAuthority,
         endpoint: "/action/remove-appk-child",
       },
       {

--- a/src/services/ui/src/features/package/package-details/hooks.tsx
+++ b/src/services/ui/src/features/package/package-details/hooks.tsx
@@ -1,7 +1,7 @@
 import { isCmsUser } from "shared-utils";
 
 import { BLANK_VALUE } from "@/consts";
-import { Authority, opensearch } from "shared-types";
+import { AUTHORITY, opensearch } from "shared-types";
 import { FC, ReactNode } from "react";
 import { OneMacUser } from "@/api/useGetUser";
 
@@ -56,7 +56,9 @@ export const recordDetails = (
     label: "Action Type",
     value: LABELS[data.actionType as keyof typeof LABELS] || data.actionType,
     canView: () => {
-      return [Authority["1915b"], Authority["1915c"]].includes(data.authority);
+      return [AUTHORITY["1915(b)"], AUTHORITY["1915(c)"]].some(
+        (waiver) => waiver === data.authority,
+      );
     },
   },
   {

--- a/src/services/ui/src/features/submission/app-k/index.tsx
+++ b/src/services/ui/src/features/submission/app-k/index.tsx
@@ -8,7 +8,6 @@ import { FORM, SchemaForm } from "./consts";
 import { SlotStateSelect, WaiverIdFieldArray } from "./slots";
 import { SubmissionServiceParameters, submit } from "@/api/submissionService";
 import { useGetUser } from "@/api/useGetUser";
-import { Authority } from "shared-types";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@/components/Routing";
 import { useEffect, useState } from "react";
@@ -39,7 +38,7 @@ export const AppKSubmissionForm = () => {
     await submission.mutateAsync(
       {
         data: draft,
-        authority: Authority["1915c"],
+        authority: "1915(c)",
         endpoint: "/appk",
         user,
       },
@@ -55,8 +54,7 @@ export const AppKSubmissionForm = () => {
           await documentPoller(
             `${draft.state}-${draft.waiverIds[0]}`,
             (checks) =>
-              checks.authorityIs([Authority["1915c"]]) &&
-              checks.actionIs("Amend"),
+              checks.authorityIs(["1915(c)"]) && checks.actionIs("Amend"),
           ).startPollingData();
           setIsDataPolling(false);
 

--- a/src/services/ui/src/features/submission/waiver/capitated/capitated-1915-b-waiver-amendment.tsx
+++ b/src/services/ui/src/features/submission/waiver/capitated/capitated-1915-b-waiver-amendment.tsx
@@ -17,7 +17,6 @@ import {
 import * as Content from "@/components/Form/old-content";
 import * as Inputs from "@/components/Inputs";
 import { useGetUser, submit } from "@/api";
-import { Authority } from "shared-types";
 import {
   zAdditionalInfoOptional,
   zAmendmentOriginalWaiverNumberSchema,
@@ -89,7 +88,7 @@ export const Capitated1915BWaiverAmendmentPage = () => {
         data: formData,
         endpoint: "/submit",
         user,
-        authority: Authority["1915b"],
+        authority: "1915(b)",
       });
       alert.setContent({
         header: "Package submitted",

--- a/src/services/ui/src/features/submission/waiver/capitated/capitated-1915-b-waiver-initial.tsx
+++ b/src/services/ui/src/features/submission/waiver/capitated/capitated-1915-b-waiver-initial.tsx
@@ -16,7 +16,6 @@ import {
   FormField,
 } from "@/components";
 import { submit } from "@/api/submissionService";
-import { Authority } from "shared-types";
 import {
   zAdditionalInfoOptional,
   zAttachmentOptional,
@@ -88,7 +87,7 @@ export const Capitated1915BWaiverInitialPage = () => {
         data: formData,
         endpoint: "/submit",
         user,
-        authority: Authority["1915b"],
+        authority: "1915(b)",
       });
       alert.setContent({
         header: "Package submitted",

--- a/src/services/ui/src/features/submission/waiver/capitated/capitated-1915-b-waiver-renewal.tsx
+++ b/src/services/ui/src/features/submission/waiver/capitated/capitated-1915-b-waiver-renewal.tsx
@@ -17,7 +17,6 @@ import {
 import * as Content from "@/components/Form/old-content";
 import * as Inputs from "@/components/Inputs";
 import { useGetUser, submit } from "@/api";
-import { Authority } from "shared-types";
 import {
   zAdditionalInfoOptional,
   zRenewalOriginalWaiverNumberSchema,
@@ -117,7 +116,7 @@ export const Capitated1915BWaiverRenewalPage = () => {
         data: formData,
         endpoint: "/submit",
         user,
-        authority: Authority["1915b"],
+        authority: "1915(b)",
       });
       alert.setContent({
         header: "Package submitted",

--- a/src/services/ui/src/features/submission/waiver/contracting/contracting-1915-b-waiver-amendment.tsx
+++ b/src/services/ui/src/features/submission/waiver/contracting/contracting-1915-b-waiver-amendment.tsx
@@ -17,7 +17,6 @@ import {
 import * as Content from "@/components/Form/old-content";
 import * as Inputs from "@/components/Inputs";
 import { useGetUser, submit } from "@/api";
-import { Authority } from "shared-types";
 import {
   zAdditionalInfoOptional,
   zAmendmentOriginalWaiverNumberSchema,
@@ -86,7 +85,7 @@ export const Contracting1915BWaiverAmendmentPage = () => {
         data: formData,
         endpoint: "/submit",
         user,
-        authority: Authority["1915b"],
+        authority: "1915(b)",
       });
       alert.setContent({
         header: "Package submitted",

--- a/src/services/ui/src/features/submission/waiver/contracting/contracting-1915-b-waiver-initial.tsx
+++ b/src/services/ui/src/features/submission/waiver/contracting/contracting-1915-b-waiver-initial.tsx
@@ -17,7 +17,6 @@ import {
 import * as Content from "@/components/Form/old-content";
 import * as Inputs from "@/components/Inputs";
 import { useGetUser, submit } from "@/api";
-import { Authority } from "shared-types";
 import {
   zAdditionalInfoOptional,
   zAttachmentOptional,
@@ -83,7 +82,7 @@ export const Contracting1915BWaiverInitialPage = () => {
         data: formData,
         endpoint: "/submit",
         user,
-        authority: Authority["1915b"],
+        authority: "1915(b)",
       });
       alert.setContent({
         header: "Package submitted",

--- a/src/services/ui/src/features/submission/waiver/contracting/contracting-1915-b-waiver-renewal.tsx
+++ b/src/services/ui/src/features/submission/waiver/contracting/contracting-1915-b-waiver-renewal.tsx
@@ -17,7 +17,6 @@ import {
 import * as Content from "@/components/Form/old-content";
 import * as Inputs from "@/components/Inputs";
 import { useGetUser, submit } from "@/api";
-import { Authority } from "shared-types";
 import {
   zAdditionalInfoOptional,
   zRenewalOriginalWaiverNumberSchema,
@@ -110,7 +109,7 @@ export const Contracting1915BWaiverRenewalPage = () => {
         data: formData,
         endpoint: "/submit",
         user,
-        authority: Authority["1915b"],
+        authority: "1915(b)",
       });
       alert.setContent({
         header: "Package submitted",

--- a/src/services/ui/src/utils/crumbs.ts
+++ b/src/services/ui/src/utils/crumbs.ts
@@ -1,15 +1,15 @@
 import { BreadCrumbConfig, Route } from "@/components";
 import { mapActionLabel, mapSubmissionCrumb } from "@/utils";
-import { Action, AuthorityUnion } from "shared-types";
+import { Action, Authority } from "shared-types";
 
 type DetailsAndActionsBreadCrumbsArgs = {
   id: string;
-  authority: AuthorityUnion;
+  authority: Authority;
   actionType?: Action;
 };
 
 export const getDashboardTabForAuthority = (
-  authority: AuthorityUnion,
+  authority: Authority,
 ): "spas" | "waivers" => {
   switch (authority) {
     case "CHIP SPA":
@@ -38,9 +38,7 @@ export const detailsAndActionsCrumbs = ({
     : defaultBreadCrumbs;
 };
 
-export const dashboardCrumb = (
-  authority?: AuthorityUnion,
-): BreadCrumbConfig => {
+export const dashboardCrumb = (authority?: Authority): BreadCrumbConfig => {
   return {
     displayText: "Dashboard",
     order: 1,
@@ -53,7 +51,7 @@ export const dashboardCrumb = (
 
 export const detailsCrumb = (
   id: string,
-  authority: AuthorityUnion,
+  authority: Authority,
 ): BreadCrumbConfig => ({
   displayText: id,
   order: 2,


### PR DESCRIPTION
## Purpose

Replace `Authority` enum with a union. Unions allow us to compare values without importing any values into a file

## Approach

- create a `AUTHORITY` constant and create unions from its keys and values
- replace `Authority` everywhere with either strings or with the new `AUTHORITY` constant (which we should eventually phase out as well)
- improve logic in some files due to new union powers
