### PR TITLE
fix(email): oy2-28874 Summary section in Submission Emails

### DIFF
--- a/src/services/email/libs/data-lib.js
+++ b/src/services/email/libs/data-lib.js
@@ -116,7 +116,9 @@ export const buildEmailData = async (bundle, data) => {
           ? process.env[dataType]
           : `'${dataType} Substitute' <mako.stateuser@gmail.com>`;
         break;
-        
+      case "additionalInformation":
+        returnObject[dataType] = data[dataType] ?? "No additional information submitted";
+        break;
       default:
         returnObject[dataType] = data[dataType]
           ? data[dataType]


### PR DESCRIPTION
## Purpose

>Currently the Summary section in the submission emails for Mako displays the text “missing data” when the additional information section on the submission form is not required and the user did not enter any data.

#### Linked Issues to Close
[OY2-28874](https://qmacbis.atlassian.net/browse/OY2-28874)

## Approach
- added case in switch for additional info to catch when empty

## Screenshots


