### PR TITLE
fix(ui): Fix TE prefilled with waiver ID

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,6 +42,7 @@ export default tseslint.config(
     rules: {
       "@typescript-eslint/no-empty-interface": "off",
       "react/react-in-jsx-scope": "off",
+      "react/jsx-no-useless-fragment": ["error", { allowExpressions: true }],
       "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": "warn",
       "@typescript-eslint/no-explicit-any": "off",

--- a/react-app/src/components/Form/content/ContentWrappers.tsx
+++ b/react-app/src/components/Form/content/ContentWrappers.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, ReactNode, useMemo } from "react";
+import { ReactElement, ReactNode } from "react";
 import { Info } from "lucide-react";
 import {
   Alert,
@@ -6,7 +6,6 @@ import {
   PackageSection,
   SectionCard,
 } from "@/components";
-import { useFormContext } from "react-hook-form";
 import { TEPackageSection } from "@/features/package-actions/lib/modules/temporary-extension/legacy-components";
 import clsx from "clsx";
 
@@ -116,17 +115,3 @@ export const PreSubmitNotice = ({
     )}
   </Alert>
 );
-
-export const ErrorBanner = () => {
-  const form = useFormContext();
-  const errorLen = useMemo(
-    () => Object.keys(form.formState.errors).length,
-    [form.formState.errors],
-  );
-
-  return errorLen !== 0 ? (
-    <Alert className="my-6" variant="destructive">
-      Missing or malformed information. Please see errors above.
-    </Alert>
-  ) : null;
-};

--- a/react-app/src/components/Layout/index.tsx
+++ b/react-app/src/components/Layout/index.tsx
@@ -191,7 +191,7 @@ const ResponsiveNav = ({ isDesktop }: ResponsiveNavProps) => {
     window.location.assign(url);
   };
 
-  if (isLoading || isError) return <></>;
+  if (isLoading || isError) return null;
 
   const setClassBasedOnNav: NavLinkProps["className"] = ({ isActive }) =>
     isActive
@@ -216,30 +216,28 @@ const ResponsiveNav = ({ isDesktop }: ResponsiveNavProps) => {
           </NavLink>
         ))}
         <div className="flex-1"></div>
-        <>
-          {data.user ? (
-            // When the user is signed in
-            <UserDropdownMenu />
-          ) : (
-            !isFaqPage && (
-              // When the user is not signed in
-              <>
-                <button
-                  className="text-white hover:text-white/70"
-                  onClick={handleLogin}
-                >
-                  Sign In
-                </button>
-                <button
-                  className="text-white hover:text-white/70"
-                  onClick={handleRegister}
-                >
-                  Register
-                </button>
-              </>
-            )
-          )}
-        </>
+        {data.user ? (
+          // When the user is signed in
+          <UserDropdownMenu />
+        ) : (
+          !isFaqPage && (
+            // When the user is not signed in
+            <>
+              <button
+                className="text-white hover:text-white/70"
+                onClick={handleLogin}
+              >
+                Sign In
+              </button>
+              <button
+                className="text-white hover:text-white/70"
+                onClick={handleRegister}
+              >
+                Register
+              </button>
+            </>
+          )
+        )}
       </>
     );
   }
@@ -261,30 +259,28 @@ const ResponsiveNav = ({ isDesktop }: ResponsiveNavProps) => {
                 </Link>
               </li>
             ))}
-            <>
-              {data.user ? (
-                // When the user is signed in
-                <UserDropdownMenu />
-              ) : (
-                !isFaqPage && (
-                  // When the user is not signed in
-                  <>
-                    <button
-                      className="text-left block py-2 pl-3 pr-4 text-white rounded"
-                      onClick={handleLogin}
-                    >
-                      Sign In
-                    </button>
-                    <button
-                      className="text-white hover:text-white/70"
-                      onClick={handleRegister}
-                    >
-                      Register
-                    </button>
-                  </>
-                )
-              )}
-            </>
+            {data.user ? (
+              // When the user is signed in
+              <UserDropdownMenu />
+            ) : (
+              !isFaqPage && (
+                // When the user is not signed in
+                <>
+                  <button
+                    className="text-left block py-2 pl-3 pr-4 text-white rounded"
+                    onClick={handleLogin}
+                  >
+                    Sign In
+                  </button>
+                  <button
+                    className="text-white hover:text-white/70"
+                    onClick={handleRegister}
+                  >
+                    Register
+                  </button>
+                </>
+              )
+            )}
           </ul>
         </div>
       )}

--- a/react-app/src/components/Opensearch/main/Filtering/Drawer/index.tsx
+++ b/react-app/src/components/Opensearch/main/Filtering/Drawer/index.tsx
@@ -79,12 +79,10 @@ export const OsFilterDrawer = () => {
                   />
                 )}
                 {PK.component === "boolean" && (
-                  <>
-                    <F.FilterableBoolean
+                  <F.FilterableBoolean
                       value={hook.filters[PK.field]?.value as boolean}
                       onChange={hook.onFilterChange(PK.field)}
                     />
-                  </>
                 )}
               </AccordionContent>
             </AccordionItem>

--- a/react-app/src/components/RHF/RHFTextDisplay.tsx
+++ b/react-app/src/components/RHF/RHFTextDisplay.tsx
@@ -9,69 +9,65 @@ interface RHFTextDisplayProps {
 export const RHFTextDisplay = (props: RHFTextDisplayProps) => {
   if (!Array.isArray(props.text)) return props.text;
 
-  return (
-    <>
-      {...props.text?.map((t) => {
-        if (typeof t === "string") return <>{t}</>;
-        const orderedList = t?.listType === "ordered";
+  return props.text.map((t) => {
+    if (typeof t === "string") return t;
+    const orderedList = t?.listType === "ordered";
 
-        switch (t?.type) {
-          case "br":
-            return (
-              <>
-                <br /> <span className={t.classname}>{t.text}</span>
-              </>
-            );
-          case "brWrap":
-            return (
-              <>
-                <br /> <span className={t.classname}>{t.text}</span> <br />
-              </>
-            );
-          case "bold":
-            return <b className={t.classname}>{t.text}</b>;
-          case "italic":
-            return <i className={t.classname}>{t.text}</i>;
-          case "link":
-            return (
-              <Link
-                to={t.link ?? "/"}
-                className={cn("cursor-pointer text-blue-600 ml-0", t.classname)}
-              >
-                {t.text}
-              </Link>
-            );
-          case "list":
-            return (
-              <>
-                {orderedList && (
-                  <ol>
-                    {t?.list?.map((l, j) => {
-                      return (
-                        <li key={`listItem.${j}.${l.text}`}>
-                          <RHFTextDisplay text={[l]} />
-                        </li>
-                      );
-                    })}
-                  </ol>
-                )}
-                {!orderedList && (
-                  <ul>
-                    {t?.list?.map((l, j) => {
-                      return (
-                        <li key={`listItem.${j}.${l.text}`}>
-                          <RHFTextDisplay text={[l]} />
-                        </li>
-                      );
-                    })}
-                  </ul>
-                )}
-              </>
-            );
-          default:
-            return <span className={t.classname}>{t.text}</span>;
-        }
-      })}
-    </>
-  );
+    switch (t?.type) {
+      case "br":
+        return (
+          <>
+            <br /> <span className={t.classname}>{t.text}</span>
+          </>
+        );
+      case "brWrap":
+        return (
+          <>
+            <br /> <span className={t.classname}>{t.text}</span> <br />
+          </>
+        );
+      case "bold":
+        return <b className={t.classname}>{t.text}</b>;
+      case "italic":
+        return <i className={t.classname}>{t.text}</i>;
+      case "link":
+        return (
+          <Link
+            to={t.link ?? "/"}
+            className={cn("cursor-pointer text-blue-600 ml-0", t.classname)}
+          >
+            {t.text}
+          </Link>
+        );
+      case "list":
+        return (
+          <>
+            {orderedList && (
+              <ol>
+                {t?.list?.map((l, j) => {
+                  return (
+                    <li key={`listItem.${j}.${l.text}`}>
+                      <RHFTextDisplay text={[l]} />
+                    </li>
+                  );
+                })}
+              </ol>
+            )}
+            {!orderedList && (
+              <ul>
+                {t?.list?.map((l, j) => {
+                  return (
+                    <li key={`listItem.${j}.${l.text}`}>
+                      <RHFTextDisplay text={[l]} />
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </>
+        );
+      default:
+        return <span className={t.classname}>{t.text}</span>;
+    }
+  });
 };

--- a/react-app/src/components/RHF/Section.tsx
+++ b/react-app/src/components/RHF/Section.tsx
@@ -1,4 +1,3 @@
- 
 import { Control, FieldValues } from "react-hook-form";
 import { Section } from "shared-types";
 import { FormLabel } from "../Inputs";
@@ -24,7 +23,7 @@ export const RHFSection = <TFieldValues extends FieldValues>(props: {
             <FormLabel className="font-bold">{props.section.title}</FormLabel>
           </div>
         )}
-        {props.section.form?.length ? (
+        {props.section.form?.length > 0 && (
           <div className="px-8 py-6">
             {props.section.form.map((FORM, index) => (
               <RHFFormGroup
@@ -35,8 +34,6 @@ export const RHFSection = <TFieldValues extends FieldValues>(props: {
               />
             ))}
           </div>
-        ) : (
-          <></>
         )}
       </div>
     </DependencyWrapper>

--- a/react-app/src/components/UsaBanner/index.tsx
+++ b/react-app/src/components/UsaBanner/index.tsx
@@ -25,12 +25,10 @@ export const UsaBanner = () => {
   }, []);
   const { error } = useLoaderData() as { error: string };
   return (
-    <>
-      <div className="bg-[#f0f0f0]" role="banner">
+    <div className="bg-[#f0f0f0]" role="banner">
         {/* Display for Desktop */}
         {isDesktop && (
-          <>
-            <div className="max-w-screen-xl px-4 py-1 lg:px-8 text-xs mx-auto flex gap-2 items-center">
+          <div className="max-w-screen-xl px-4 py-1 lg:px-8 text-xs mx-auto flex gap-2 items-center">
               <img
                 className="w-4 h-[11px]"
                 src={UsFlag}
@@ -48,7 +46,6 @@ export const UsaBanner = () => {
                 {isOpen && <ChevronUp className="w-4 h-4 text-[#005ea2]" />}
               </button>
             </div>
-          </>
         )}
         {/* Display for Mobile */}
         {!isDesktop && (
@@ -100,7 +97,6 @@ export const UsaBanner = () => {
           </div>
         )}
       </div>
-    </>
   );
 };
 

--- a/react-app/src/features/dashboard/Lists/renderCells/index.tsx
+++ b/react-app/src/features/dashboard/Lists/renderCells/index.tsx
@@ -28,54 +28,52 @@ export const CellDetailsLink = ({ id, authority }: CellIdLinkProps) => (
 
 export const renderCellActions = (user: CognitoUserAttributes | null) => {
   return function Cell(data: opensearch.main.Document) {
-    if (!user) return <></>;
+    if (!user) return null;
 
     const actions = getAvailableActions(user, data);
     return (
-      <>
-        <POP.Popover>
-          <POP.PopoverTrigger
-            disabled={!actions.length}
-            className="block ml-3"
-            aria-label="Available actions"
-          >
-            <EllipsisVerticalIcon
-              aria-label="record actions"
-              className={cn(
-                "w-8 ",
-                actions.length ? "text-blue-700" : "text-gray-400",
-              )}
-            />
-          </POP.PopoverTrigger>
-          <POP.PopoverContent>
-            <div className="flex flex-col">
-              {actions.map((action, idx) => (
-                <TypedLink
-                  state={{
-                    from: `${location.pathname}${location.search}`,
-                  }}
-                  path="/action/:authority/:id/:type"
-                  key={`${idx}-${action}`}
-                  params={{
-                    id: data.id,
-                    type: action,
-                    authority: data.authority,
-                  }}
-                  className={cn(
-                    "text-blue-500",
-                    "relative flex select-none items-center rounded-sm px-2 py-2 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-                  )}
-                  query={{
-                    origin: DASHBOARD_ORIGIN,
-                  }}
-                >
-                  {mapActionLabel(action)}
-                </TypedLink>
-              ))}
-            </div>
-          </POP.PopoverContent>
-        </POP.Popover>
-      </>
+      <POP.Popover>
+        <POP.PopoverTrigger
+          disabled={!actions.length}
+          className="block ml-3"
+          aria-label="Available actions"
+        >
+          <EllipsisVerticalIcon
+            aria-label="record actions"
+            className={cn(
+              "w-8 ",
+              actions.length ? "text-blue-700" : "text-gray-400",
+            )}
+          />
+        </POP.PopoverTrigger>
+        <POP.PopoverContent>
+          <div className="flex flex-col">
+            {actions.map((action, idx) => (
+              <TypedLink
+                state={{
+                  from: `${location.pathname}${location.search}`,
+                }}
+                path="/action/:authority/:id/:type"
+                key={`${idx}-${action}`}
+                params={{
+                  id: data.id,
+                  type: action,
+                  authority: data.authority,
+                }}
+                className={cn(
+                  "text-blue-500",
+                  "relative flex select-none items-center rounded-sm px-2 py-2 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+                )}
+                query={{
+                  origin: DASHBOARD_ORIGIN,
+                }}
+              >
+                {mapActionLabel(action)}
+              </TypedLink>
+            ))}
+          </div>
+        </POP.PopoverContent>
+      </POP.Popover>
     );
   };
 };

--- a/react-app/src/features/faq/content/oneMACFAQContent.tsx
+++ b/react-app/src/features/faq/content/oneMACFAQContent.tsx
@@ -219,8 +219,7 @@ export const oneMACFAQContent: FAQContent[] = [
         anchorText: "onboarding-materials",
         question: "Onboarding Materials",
         answerJSX: (
-          <>
-            <ul>
+          <ul>
               {[
                 [WelcometoOneMAC, "Welcome to OneMAC"],
                 [
@@ -243,7 +242,6 @@ export const oneMACFAQContent: FAQContent[] = [
                 </li>
               ))}
             </ul>
-          </>
         ),
       },
     ],
@@ -905,14 +903,12 @@ export const oneMACFAQContent: FAQContent[] = [
         question:
           "Why does the status of my Temporary Extension Request continue to show as 'Submitted'?",
         answerJSX: (
-          <>
-            <p>
+          <p>
               Temporary Extensions Requests will only show a status of
               ‘Submitted’ in the OneMAC system at this time. Their status does
               not update regardless of where that request is in the Submission
               Review process.
             </p>
-          </>
         ),
       },
       {

--- a/react-app/src/features/package-actions/ActionForm.tsx
+++ b/react-app/src/features/package-actions/ActionForm.tsx
@@ -1,5 +1,4 @@
 import {
-  ErrorBanner,
   Form,
   LoadingSpinner,
   userPrompt,
@@ -120,7 +119,6 @@ export const ActionForm = ({
 
           return field;
         })}
-        <ErrorBanner />
         {content.preSubmitNotice && (
           <PreSubmitNotice
             message={content.preSubmitNotice}

--- a/react-app/src/features/package-actions/ActionForm.tsx
+++ b/react-app/src/features/package-actions/ActionForm.tsx
@@ -40,7 +40,6 @@ export const ActionForm = ({
   const form = useForm<Record<string, string>>({
     resolver: setup.schema ? zodResolver(setup.schema) : undefined,
     mode: "onChange",
-    defaultValues: { id },
   });
 
   if (!item || !user) {
@@ -49,6 +48,10 @@ export const ActionForm = ({
 
   if (actionType === "temporary-extension") {
     form.setValue("seaActionType", "Extend");
+  }
+
+  if (actionType === "update-id") {
+    form.setValue("id", id);
   }
 
   const content = setup.content(item._source);

--- a/react-app/src/features/package-actions/lib/modules/temporary-extension/legacy-page.tsx
+++ b/react-app/src/features/package-actions/lib/modules/temporary-extension/legacy-page.tsx
@@ -14,7 +14,6 @@ import {
   Alert,
   AttachmentsSection,
   BreadCrumbs,
-  ErrorBanner,
   ActionFormHeaderCard,
   SimplePageContainer,
   useLocationCrumbs,
@@ -129,7 +128,6 @@ export const TemporaryExtension = () => {
           </div>
         </Alert>
         <FormLoadingSpinner />
-        <ErrorBanner />
         <SubmitAndCancelBtnSection />
       </form>
       <FAQFooter />

--- a/react-app/src/features/package/admin-changes/index.tsx
+++ b/react-app/src/features/package/admin-changes/index.tsx
@@ -133,7 +133,7 @@ export const AdminChanges = () => {
     ].includes(CL._source.actionType),
   );
 
-  if (!data?.length) return <></>;
+  if (!data?.length) return null;
 
   return (
     <DetailsSection

--- a/react-app/src/features/package/package-details/appk.tsx
+++ b/react-app/src/features/package/package-details/appk.tsx
@@ -57,9 +57,9 @@ export const AppK = () => {
       },
     );
   };
-  console.log(cache.data.appkChildren);
+
   if (!cache.data.appkChildren || cache.data.appkChildren.length === 0) {
-    return <></>;
+    return null;
   }
 
   return (
@@ -106,12 +106,10 @@ export const AppK = () => {
         cancelButtonText="Cancel"
         title="Are you sure you want to withdraw this 1915(c) Appendix K?"
         body={
-          <>
-            <p>
-              Any 1915(c) Appendix Ks associated with {removeChild} will not be
-              affected.
-            </p>
-          </>
+          <p>
+            Any 1915(c) Appendix Ks associated with {removeChild} will not be
+            affected.
+          </p>
         }
       />
     </div>

--- a/react-app/src/features/submission/waiver/capitated/capitated-1915-b-waiver-amendment.tsx
+++ b/react-app/src/features/submission/waiver/capitated/capitated-1915-b-waiver-amendment.tsx
@@ -12,6 +12,7 @@ import {
   useAlertContext,
   Route,
   FormField,
+  LoadingSpinner,
 } from "@/components";
 import * as Content from "@/components/Form/old-content";
 import * as Inputs from "@/components/Inputs";
@@ -124,6 +125,7 @@ export const Capitated1915BWaiverAmendmentPage = () => {
     <SimplePageContainer>
       <BreadCrumbs options={formCrumbsFromPath(location.pathname)} />
       <Inputs.Form {...form}>
+        {form.formState.isSubmitting && <LoadingSpinner />}
         <form
           onSubmit={form.handleSubmit(handleSubmit)}
           className="my-6 space-y-8 mx-auto justify-center flex flex-col"
@@ -262,7 +264,7 @@ export const Capitated1915BWaiverAmendmentPage = () => {
             />
           </SectionCard>
           <Content.PreSubmissionMessage />
-          <SubmitAndCancelBtnSection showAlert loadingSpinner />
+          <SubmitAndCancelBtnSection />
         </form>
       </Inputs.Form>
       <FAQFooter />

--- a/react-app/src/features/submission/waiver/capitated/capitated-1915-b-waiver-initial.tsx
+++ b/react-app/src/features/submission/waiver/capitated/capitated-1915-b-waiver-initial.tsx
@@ -13,6 +13,7 @@ import {
   formCrumbsFromPath,
   Route,
   FormField,
+  LoadingSpinner,
 } from "@/components";
 import { submit } from "@/api/submissionService";
 import { Authority } from "shared-types";
@@ -125,6 +126,7 @@ export const Capitated1915BWaiverInitialPage = () => {
     <SimplePageContainer>
       <BreadCrumbs options={formCrumbsFromPath(location.pathname)} />
       <Inputs.Form {...form}>
+        {form.formState.isSubmitting && <LoadingSpinner />}
         <form
           onSubmit={form.handleSubmit(handleSubmit)}
           className="my-6 space-y-8 mx-auto justify-center flex flex-col"
@@ -238,7 +240,7 @@ export const Capitated1915BWaiverInitialPage = () => {
             />
           </SectionCard>
           <Content.PreSubmissionMessage />
-          <SubmitAndCancelBtnSection showAlert loadingSpinner />
+          <SubmitAndCancelBtnSection />
         </form>
       </Inputs.Form>
       <FAQFooter />

--- a/react-app/src/features/submission/waiver/contracting/contracting-1915-b-waiver-amendment.tsx
+++ b/react-app/src/features/submission/waiver/contracting/contracting-1915-b-waiver-amendment.tsx
@@ -12,6 +12,7 @@ import {
   formCrumbsFromPath,
   Route,
   FormField,
+  LoadingSpinner,
 } from "@/components";
 import * as Content from "@/components/Form/old-content";
 import * as Inputs from "@/components/Inputs";
@@ -121,6 +122,7 @@ export const Contracting1915BWaiverAmendmentPage = () => {
     <SimplePageContainer>
       <BreadCrumbs options={formCrumbsFromPath(location.pathname)} />
       <Inputs.Form {...form}>
+        {form.formState.isSubmitting && <LoadingSpinner />}
         <form
           onSubmit={form.handleSubmit(handleSubmit)}
           className="my-6 space-y-8 mx-auto justify-center flex flex-col"
@@ -259,7 +261,7 @@ export const Contracting1915BWaiverAmendmentPage = () => {
             />
           </SectionCard>
           <Content.PreSubmissionMessage />
-          <SubmitAndCancelBtnSection showAlert loadingSpinner />
+          <SubmitAndCancelBtnSection />
         </form>
       </Inputs.Form>
       <FAQFooter />

--- a/react-app/src/features/submission/waiver/contracting/contracting-1915-b-waiver-initial.tsx
+++ b/react-app/src/features/submission/waiver/contracting/contracting-1915-b-waiver-initial.tsx
@@ -12,6 +12,7 @@ import {
   formCrumbsFromPath,
   Route,
   FormField,
+  LoadingSpinner,
 } from "@/components";
 import * as Content from "@/components/Form/old-content";
 import * as Inputs from "@/components/Inputs";
@@ -120,6 +121,7 @@ export const Contracting1915BWaiverInitialPage = () => {
     <SimplePageContainer>
       <BreadCrumbs options={formCrumbsFromPath(location.pathname)} />
       <Inputs.Form {...form}>
+        {form.formState.isSubmitting && <LoadingSpinner />}
         <form
           onSubmit={form.handleSubmit(handleSubmit)}
           className="my-6 space-y-8 mx-auto justify-center flex flex-col"
@@ -232,7 +234,7 @@ export const Contracting1915BWaiverInitialPage = () => {
             />
           </SectionCard>
           <Content.PreSubmissionMessage />
-          <SubmitAndCancelBtnSection showAlert loadingSpinner />
+          <SubmitAndCancelBtnSection />
         </form>
       </Inputs.Form>
       <FAQFooter />

--- a/react-app/src/features/submission/waiver/contracting/contracting-1915-b-waiver-renewal.tsx
+++ b/react-app/src/features/submission/waiver/contracting/contracting-1915-b-waiver-renewal.tsx
@@ -12,6 +12,7 @@ import {
   useAlertContext,
   Route,
   FormField,
+  LoadingSpinner,
 } from "@/components";
 import * as Content from "@/components/Form/old-content";
 import * as Inputs from "@/components/Inputs";
@@ -145,6 +146,7 @@ export const Contracting1915BWaiverRenewalPage = () => {
     <SimplePageContainer>
       <BreadCrumbs options={formCrumbsFromPath(location.pathname)} />
       <Inputs.Form {...form}>
+        {form.formState.isSubmitting && <LoadingSpinner />}
         <form
           onSubmit={form.handleSubmit(handleSubmit)}
           className="my-6 space-y-8 mx-auto justify-center flex flex-col"
@@ -285,7 +287,7 @@ export const Contracting1915BWaiverRenewalPage = () => {
             />
           </SectionCard>
           <Content.PreSubmissionMessage />
-          <SubmitAndCancelBtnSection showAlert loadingSpinner />
+          <SubmitAndCancelBtnSection />
         </form>
       </Inputs.Form>
       <FAQFooter />

--- a/react-app/src/features/submission/waiver/shared-components/SubmitAndCancelBtnSection.tsx
+++ b/react-app/src/features/submission/waiver/shared-components/SubmitAndCancelBtnSection.tsx
@@ -1,5 +1,5 @@
-import { LoadingSpinner, Button } from "@/components";
-import { Alert, userPrompt } from "@/components";
+import { Button } from "@/components";
+import { userPrompt } from "@/components";
 import { useNavigate, useParams } from "react-router-dom";
 import { useFormContext } from "react-hook-form";
 import { useMemo } from "react";
@@ -7,15 +7,11 @@ import { getFormOrigin } from "@/utils";
 import { Authority } from "shared-types";
 
 interface buttonProps {
-  loadingSpinner?: boolean;
-  showAlert?: boolean;
   confirmWithdraw?: () => void;
   enableSubmit?: boolean;
 }
 
 export const SubmitAndCancelBtnSection = ({
-  loadingSpinner,
-  showAlert,
   confirmWithdraw,
   enableSubmit,
 }: buttonProps) => {
@@ -36,46 +32,32 @@ export const SubmitAndCancelBtnSection = ({
   }, [form.formState.isValid]);
 
   return (
-    <>
-      {loadingSpinner && form.formState.isSubmitting && (
-        <div className="p-4">
-          <LoadingSpinner />
-        </div>
-      )}
-
-      {showAlert && Object.keys(form.formState.errors).length !== 0 && (
-        <Alert className="mb-6 " variant="destructive">
-          Missing or malformed information. Please see errors above.
-        </Alert>
-      )}
-
-      <section className="flex justify-end gap-2 p-4 ml-auto">
-        <Button
-          className="px-12"
-          type={confirmWithdraw ? "button" : "submit"}
-          onClick={confirmWithdraw ? confirmWithdraw : () => null}
-          disabled={disableSubmit}
-        >
-          Submit
-        </Button>
-        <Button
-          className="px-12"
-          onClick={() => {
-            userPrompt({
-              header: "Stop form submission?",
-              body: "All information you've entered on this form will be lost if you leave this page.",
-              acceptButtonText: "Yes, leave form",
-              cancelButtonText: "Return to form",
-              onAccept: acceptAction,
-              areButtonsReversed: true,
-            });
-          }}
-          variant={"outline"}
-          type="reset"
-        >
-          Cancel
-        </Button>
-      </section>
-    </>
+    <section className="flex justify-end gap-2 p-4 ml-auto">
+      <Button
+        className="px-12"
+        type={confirmWithdraw ? "button" : "submit"}
+        onClick={confirmWithdraw ? confirmWithdraw : () => null}
+        disabled={disableSubmit}
+      >
+        Submit
+      </Button>
+      <Button
+        className="px-12"
+        onClick={() => {
+          userPrompt({
+            header: "Stop form submission?",
+            body: "All information you've entered on this form will be lost if you leave this page.",
+            acceptButtonText: "Yes, leave form",
+            cancelButtonText: "Return to form",
+            onAccept: acceptAction,
+            areButtonsReversed: true,
+          });
+        }}
+        variant={"outline"}
+        type="reset"
+      >
+        Cancel
+      </Button>
+    </section>
   );
 };


### PR DESCRIPTION
## Purpose

A bug I introduced in #663. I added `id` as a default value, and that meant any record with an `id` field was populated with that value.

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-29532

## Approach

- conditionally add `id` if `actionType === 'update-id'`
- remove all instances of `Missing or malformed information. Please see errors above.`. QE said that it's an unused element of older form logic and was no longer needed.
- add new eslint rule: [no-useless-jsx-fragment rule](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-useless-fragment.md) that will error out when we use fragments with one child:
    ```tsx
      <>
       <span>
         hello world
       </span>
      </>
    ```
- adjusted code that errored out
