### PR TITLE
bug(webform): Replace deprecated FieldGroup with FieldArray

### DIFF
--- a/lib/libs/webforms/ABP8/sections/v202401.ts
+++ b/lib/libs/webforms/ABP8/sections/v202401.ts
@@ -287,7 +287,7 @@ export function deliverySystemCharactaristics({
             },
           },
           {
-            rhf: "FieldGroup",
+            rhf: "FieldArray",
             name: "benefit-service",
             label: `Which benefit or service will be provided by a type of coverage other than the ${programLabel}?`,
             labelClassName: "font-bold",


### PR DESCRIPTION
## Purpose

ABP 8 was still using one instance of the deprecated FieldGroup. This replaces it with FieldArray.