### PR TITLE
fix(icon padding): fix inputs with icon padding to show inputed characters

### DIFF
--- a/react-app/src/components/Inputs/input.tsx
+++ b/react-app/src/components/Inputs/input.tsx
@@ -25,6 +25,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         <input
           className={cn(
             "flex h-9 w-full rounded-sm border border-[#212121] bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+            icon && (iconRight ? "pr-10" : "pl-10"),
             className,
           )}
           ref={ref}


### PR DESCRIPTION
## Purpose
There was an issue padma found where characters were being hidden behind the icon in an input. This issue adds padding to both sides and fixes this issue

#### Linked Issues to Close
https://qmacbis.atlassian.net/browse/OY2-30142