### PR TITLE
fix(cw to s3 guard):  Do not stream CW to S3 in lower environments

### DIFF
--- a/lib/stacks/api.ts
+++ b/lib/stacks/api.ts
@@ -584,7 +584,7 @@ export class Api extends cdk.NestedStack {
       buckets: [logBucket],
     });
 
-    if (isDev) {
+    if (!isDev) {
       const cloudwatchToS3 = new LC.CloudWatchToS3(
         this,
         "CloudWatchToS3Construct",

--- a/lib/stacks/ui-infra.ts
+++ b/lib/stacks/ui-infra.ts
@@ -228,7 +228,7 @@ export class UiInfra extends cdk.NestedStack {
       buckets: [bucket, loggingBucket, logBucket],
     });
 
-    if (isDev) {
+    if (!isDev) {
       const cloudwatchToS3 = new LC.CloudWatchToS3(
         this,
         "CloudWatchToS3Construct",


### PR DESCRIPTION
## Purpose

This helps reduce cost where there's no return.  In lower environments we don't need to stage our cloudwatch logs in s3 for splunk ingestion.

#### Linked Issues to Close

None

## Approach

None

## Assorted Notes/Considerations/Learning

None