### PR TITLE
fix(webform): Adjust noGapsOrOverlaps validation per feedback

### DIFF
--- a/react-app/src/components/RHF/tests/additionalRules.test.ts
+++ b/react-app/src/components/RHF/tests/additionalRules.test.ts
@@ -112,5 +112,53 @@ describe("Additional Rules Tests", () => {
       expect(valFunc2(undefined, testData)).toBeTruthy();
       expect(valFunc2("test", testData)).toBeTruthy();
     });
+
+    test("No gaps or overlaps", () => {
+      const rules = ruleGenerator(undefined, [
+        {
+          type: "noGapsOrOverlaps",
+          fieldName: "testField",
+          fromField: "from",
+          toField: "to",
+          options: [
+            { value: "1", label: "Option 1" },
+            { value: "2", label: "Option 2" },
+          ],
+        },
+      ]);
+
+      if (!rules) throw new Error("Failed to create rule set.");
+
+      const valFunc = (rules.validate as VO)["noGapsOrOverlaps_0"];
+      expect(valFunc).toBeTruthy();
+
+      // Test case: no gaps or overlaps
+      const noGapsOrOverlapsData = {
+        testField: [
+          { from: 1, to: 3 },
+          { from: 3, to: 5 },
+          { from: 5, to: 7 },
+        ],
+      };
+      expect(valFunc(undefined, noGapsOrOverlapsData.testField)).toBeTruthy();
+
+      // Test case: gap between 3 and 5
+      const gapData = {
+        testField: [
+          { from: 1, to: 3 },
+          { from: 5, to: 7 },
+        ],
+      };
+      expect(valFunc("test", gapData)).toBe("No gaps between ages allowed");
+
+      // Test case: overlap between 3 and 5
+      const overlapData = {
+        testField: [
+          { from: 1, to: 4 },
+          { from: 3, to: 6 },
+        ],
+      };
+      expect(valFunc("test", overlapData)).toBe("No age overlaps allowed");
+    });
   });
 });

--- a/react-app/src/components/RHF/utils/additionalRules.ts
+++ b/react-app/src/components/RHF/utils/additionalRules.ts
@@ -116,10 +116,10 @@ export const valReducer = (
 
           // Check for overlaps and gaps
           for (let i = 1; i < range.length; i++) {
-            if (range[i].from <= range[i - 1].to) {
+            if (range[i].from < range[i - 1].to) {
               return "No age overlaps allowed";
             }
-            if (range[i].from > range[i - 1].to + 1) {
+            if (range[i].from > range[i - 1].to) {
               return "No gaps between ages allowed";
             }
           }


### PR DESCRIPTION
## Purpose

This PR updates the `noGapsOrOverlaps` validation rule based on [HCD feedback](https://qmacbis.atlassian.net/browse/OY2-30287).

### Previous Behavior:

* When age range 1 was 0-2 and age range 2 was 3-4, this was **not** considered a gap.
* When age range 2 was 0-2 and age range 2 was 2-4, this **was** considered an overlap.

### New Behavior:

* **Overlap rule changed:** When age range 1 is 0-2 and age range 2 is 2-4, this is **no longer considered an overlap.**
* **Gap rule changed:** When age range 1 is 0-2 and age range 2 is 3-4, this is **now considered a gap.**

#### Linked Issues to Close

Closes [OY2-30287](https://qmacbis.atlassian.net/browse/OY2-30287)

## Approach

The change was made by adjusting the `noGapsOrOverlaps` validation rule in `additionalRules.ts`.