### PR TITLE
feat(test): Tests for Pagination

### DIFF
--- a/react-app/src/components/Pagination/Pagination.test.tsx
+++ b/react-app/src/components/Pagination/Pagination.test.tsx
@@ -95,8 +95,8 @@ describe("Pagination", () => {
     );
 
     // on UI says page 3, but code is index at 0
-    const page2Button = screen.getByRole("button", { name: "3" });
-    fireEvent.click(page2Button);
+    const page3Button = screen.getByRole("button", { name: "3" });
+    fireEvent.click(page3Button);
     expect(onPageChangeMock).toHaveBeenCalledWith(2);
   });
 
@@ -112,8 +112,6 @@ describe("Pagination", () => {
       />,
     );
 
-    // const ellipseButton = screen.("button", { name: "..." });
-    // fireEvent.click(ellipseButton);
     const selectElement = screen.getByTestId("morePagesButton");
     fireEvent.change(selectElement, { target: { value: "6" } });
     expect(onPageChangeMock).toHaveBeenCalledWith(5);

--- a/react-app/src/components/Pagination/Pagination.test.tsx
+++ b/react-app/src/components/Pagination/Pagination.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { Pagination } from ".";
+
+describe("Pagination", () => {
+  test("given more than 10000 records, max count will still read of 10000 records", () => {
+    render(
+      <Pagination
+        count={20000}
+        pageNumber={0}
+        pageSize={25}
+        onPageChange={vi.fn()}
+        onSizeChange={vi.fn()}
+      />,
+    );
+
+    const maxCount = screen.getByText(/10000/i);
+    expect(maxCount).toBeInTheDocument();
+  });
+
+  test("disables the Previous button on the first page", () => {
+    render(
+      <Pagination
+        count={100}
+        pageNumber={0}
+        pageSize={25}
+        onPageChange={vi.fn()}
+        onSizeChange={vi.fn()}
+      />,
+    );
+
+    const prevButton = screen.getByRole("button", { name: "Previous" });
+    expect(prevButton).toBeDisabled();
+  });
+
+  test("disables the Next button on the last page", () => {
+    render(
+      <Pagination
+        count={100}
+        pageNumber={3}
+        pageSize={25}
+        onPageChange={vi.fn()}
+        onSizeChange={vi.fn()}
+      />,
+    );
+
+    const nextButton = screen.getByRole("button", { name: "Next" });
+    expect(nextButton).toBeDisabled();
+  });
+
+  test("calls onPageChange when Previous button is clicked", () => {
+    const onPageChangeMock = vi.fn();
+    render(
+      <Pagination
+        count={100}
+        pageNumber={2}
+        pageSize={25}
+        onPageChange={onPageChangeMock}
+        onSizeChange={vi.fn()}
+      />,
+    );
+
+    const prevButton = screen.getByRole("button", { name: "Previous" });
+    fireEvent.click(prevButton);
+    expect(onPageChangeMock).toHaveBeenCalledWith(1);
+  });
+
+  test("calls onPageChange when Next button is clicked", () => {
+    const onPageChangeMock = vi.fn();
+    render(
+      <Pagination
+        count={100}
+        pageNumber={2}
+        pageSize={25}
+        onPageChange={onPageChangeMock}
+        onSizeChange={vi.fn()}
+      />,
+    );
+
+    const nextButton = screen.getByRole("button", { name: "Next" });
+    fireEvent.click(nextButton);
+    expect(onPageChangeMock).toHaveBeenCalledWith(3);
+  });
+
+  test("calls onPageChange when specific page is clicked", () => {
+    const onPageChangeMock = vi.fn();
+    render(
+      <Pagination
+        count={100}
+        pageNumber={1}
+        pageSize={25}
+        onPageChange={onPageChangeMock}
+        onSizeChange={vi.fn()}
+      />,
+    );
+
+    // on UI says page 3, but code is index at 0
+    const page2Button = screen.getByRole("button", { name: "3" });
+    fireEvent.click(page2Button);
+    expect(onPageChangeMock).toHaveBeenCalledWith(2);
+  });
+
+  test("calls onPageChange specifc page chosen after selecting ...", () => {
+    const onPageChangeMock = vi.fn();
+    render(
+      <Pagination
+        count={300}
+        pageNumber={0}
+        pageSize={25}
+        onPageChange={onPageChangeMock}
+        onSizeChange={vi.fn()}
+      />,
+    );
+
+    // const ellipseButton = screen.("button", { name: "..." });
+    // fireEvent.click(ellipseButton);
+    const selectElement = screen.getByTestId("morePagesButton");
+    fireEvent.change(selectElement, { target: { value: "6" } });
+    expect(onPageChangeMock).toHaveBeenCalledWith(5);
+  });
+
+  test("calls onSizeChange when page size is changed", () => {
+    const onSizeChangeMock = vi.fn();
+    render(
+      <Pagination
+        count={100}
+        pageNumber={1}
+        pageSize={25}
+        onPageChange={vi.fn()}
+        onSizeChange={onSizeChangeMock}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: 50 } });
+    expect(onSizeChangeMock).toHaveBeenCalledWith(50);
+  });
+});

--- a/react-app/src/components/Pagination/index.tsx
+++ b/react-app/src/components/Pagination/index.tsx
@@ -92,6 +92,7 @@ export const Pagination: FC<Props> = (props) => {
                       }
                       className="absolute w-auto h-auto opacity-0 cursor-pointer"
                       aria-labelledby="morePagesButton"
+                      data-testid="morePagesButton"
                       id="pagesDropdown"
                     >
                       {PAGE.map((P) => (


### PR DESCRIPTION
## Purpose
 Ticket outlines to add testing for the following:
 - Pagination
 - Accordion 
 - Alert
 
 But at the time of this PR Accordion and Alert had reported coverage of 100%, so this ticket is only adding tests for Accordion.

#### Linked Issues to Close

[OY2-29636] (https://jiraent.cms.gov/browse/OY2-29636)

## Approach

- Created a test file for this component
- Added tests to check buttons were disabled when they should be based on passed down props
- Added tests to confirm call back functions were called when expected (again based on props) 
- Lastly added small check to ensure that if more than 10,000 records are passed in, the text will only read "of 10,000 records" - specifically added based on coverage report 


## Assorted Notes/Considerations/Learning
<img width="1202" alt="Screenshot 2024-10-29 at 2 23 49 PM" src="https://github.com/user-attachments/assets/54efbf46-1b2a-4817-9dfa-91392869559e">


