### PR TITLE
feat(unit tests): Zod and User utils

### DIFF
--- a/react-app/src/utils/user.test.ts
+++ b/react-app/src/utils/user.test.ts
@@ -4,19 +4,21 @@ import { isCmsUser, isStateUser } from "shared-utils";
 import { getUserStateCodes, isAuthorizedState } from "./user";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { type CognitoUserAttributes } from "shared-types/user";
-import {
-  testCMSCognitoUser,
-  testStateCognitoUser,
-} from "shared-utils/testData";
 
 // Mock users with different roles
 const cmsReviewerUser = {
-  ...testCMSCognitoUser.user,
   "custom:cms-roles": "onemac-micro-reviewer",
 };
-const stateSubmitterUser = {
-  ...testStateCognitoUser.user,
+
+const stateSubmitterUser: CognitoUserAttributes = {
+  sub: "12345678-1234-1234-1234-123456789012",
+  email_verified: true,
   "custom:state": "CA",
+  email: "stateuser@example.com",
+  given_name: "State",
+  family_name: "User",
+  "custom:cms-roles": "",
+  username: "stateuser",
 };
 
 // Partial mock setup
@@ -75,7 +77,9 @@ describe("isAuthorizedState", () => {
   });
 
   it("should return true if the user is authorized", async () => {
-    vi.mocked(getUser).mockResolvedValue({ user: stateSubmitterUser });
+    vi.mocked(getUser).mockResolvedValue({
+      user: stateSubmitterUser as CognitoUserAttributes,
+    });
     expect(await isAuthorizedState("CA-1234.R00.00")).toBe(true);
   });
 

--- a/react-app/src/utils/user.test.ts
+++ b/react-app/src/utils/user.test.ts
@@ -1,0 +1,96 @@
+import { STATE_CODES } from "shared-types/states";
+import { getUser } from "@/api";
+import { isCmsUser, isStateUser } from "shared-utils";
+import { getUserStateCodes, isAuthorizedState } from "./user";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { type CognitoUserAttributes } from "shared-types/user";
+import {
+  testCMSCognitoUser,
+  testStateCognitoUser,
+} from "shared-utils/testData";
+
+// Mock users with different roles
+const cmsReviewerUser = {
+  ...testCMSCognitoUser.user,
+  "custom:cms-roles": "onemac-micro-reviewer",
+};
+const stateSubmitterUser = {
+  ...testStateCognitoUser.user,
+  "custom:state": "CA",
+};
+
+// Partial mock setup
+vi.mock("./user", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(typeof actual === "object" && actual !== null ? actual : {}),
+  };
+});
+
+vi.mock("@/api", () => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock("shared-utils", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(typeof actual === "object" && actual !== null ? actual : {}),
+    isCmsUser: vi.fn(),
+    isStateUser: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getUserStateCodes", () => {
+  it("should return an empty array if the user is null", () => {
+    expect(getUserStateCodes(null)).toEqual([]);
+  });
+
+  it("should return all state codes for a CMS user", () => {
+    vi.mocked(isCmsUser).mockReturnValue(true);
+    const result = getUserStateCodes(cmsReviewerUser as CognitoUserAttributes);
+    expect(result).toEqual(STATE_CODES);
+  });
+
+  it("should return the state codes for a state user", () => {
+    vi.mocked(isCmsUser).mockReturnValue(false);
+    vi.mocked(isStateUser).mockReturnValue(true);
+    const result = getUserStateCodes(
+      stateSubmitterUser as CognitoUserAttributes,
+    );
+    expect(result).toEqual(["CA"]);
+  });
+});
+
+describe("isAuthorizedState", () => {
+  it("should return false if the user is null", async () => {
+    expect(await isAuthorizedState("CA-1234.R00.00")).toBe(false);
+  });
+
+  it("should return false if the user is not authorized", async () => {
+    expect(await isAuthorizedState("CA-1234.R00.00")).toBe(false);
+  });
+
+  it("should return true if the user is authorized", async () => {
+    vi.mocked(getUser).mockResolvedValue({ user: stateSubmitterUser });
+    expect(await isAuthorizedState("CA-1234.R00.00")).toBe(true);
+  });
+
+  it("should throw an error if no cognito attributes are found", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    vi.mocked(getUser).mockResolvedValue({ user: null });
+
+    const result = await isAuthorizedState("CA-1234.R00.00");
+
+    expect(result).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      new Error("No cognito attributes found."),
+    );
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/react-app/src/utils/zod.test.ts
+++ b/react-app/src/utils/zod.test.ts
@@ -95,7 +95,7 @@ describe("zAttachmentOptional", () => {
   });
 });
 
-describe("zAttachemtnRequired", () => {
+describe("zAttachmentRequired", () => {
   const schema = zAttachmentRequired({ min: 1, max: 3 });
 
   it("validates an array within file count bounds", () => {

--- a/react-app/src/utils/zod.test.ts
+++ b/react-app/src/utils/zod.test.ts
@@ -1,16 +1,37 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
-import { zSpaIdSchema, zAttachmentOptional, zAttachmentRequired } from "./zod";
+import {
+  zAdditionalInfo,
+  zAdditionalInfoOptional,
+  zAmendmentOriginalWaiverNumberSchema,
+  zAmendmentWaiverNumberSchema,
+  zAppkWaiverNumberSchema,
+  zAttachmentOptional,
+  zAttachmentRequired,
+  zExtensionOriginalWaiverNumberSchema,
+  zExtensionWaiverNumberSchema,
+  zInitialWaiverNumberSchema,
+  zRenewalOriginalWaiverNumberSchema,
+  zRenewalWaiverNumberSchema,
+  zSpaIdSchema,
+  zUpdateIdSchema,
+  zodAlwaysRefine,
+} from "./zod";
 import { isAuthorizedState } from "@/utils";
-import { itemExists } from "@/api";
+import { canBeRenewedOrAmended, idIsApproved, itemExists } from "@/api";
 
 // Mock async functions
 vi.mock("@/utils", () => ({
+  canBeRenewedOrAmended: vi.fn(),
+  idIsApproved: vi.fn(),
   isAuthorizedState: vi.fn(),
   itemExists: vi.fn(),
 }));
 
 // Setup for mock return values
 beforeEach(() => {
+  vi.mocked(canBeRenewedOrAmended).mockResolvedValue(true);
+  vi.mocked(idIsApproved).mockResolvedValue(true);
+  vi.mocked(isAuthorizedState).mockResolvedValue(true);
   vi.mocked(isAuthorizedState).mockResolvedValue(true);
   vi.mocked(itemExists).mockResolvedValue(false);
 });
@@ -55,6 +76,25 @@ describe("zSpaIdSchema", () => {
   });
 });
 
+describe("zAttachmentOptional", () => {
+  it("validates an empty array", async () => {
+    const result = await zAttachmentOptional.safeParseAsync([]);
+    expect(result.success).toBe(true);
+  });
+
+  it("validates an array of files", async () => {
+    const result = await zAttachmentOptional.safeParseAsync([
+      new File(["content"], "file.txt"),
+    ]);
+    expect(result.success).toBe(true);
+  });
+
+  it("passes when no files are provided", () => {
+    const result = zAttachmentOptional.safeParse(undefined);
+    expect(result.success).toBe(true);
+  });
+});
+
 describe("zAttachemtnRequired", () => {
   const schema = zAttachmentRequired({ min: 1, max: 3 });
 
@@ -86,21 +126,547 @@ describe("zAttachemtnRequired", () => {
   });
 });
 
-describe("zAttachmentOptional", () => {
-  it("validates an empty array", async () => {
-    const result = await zAttachmentOptional.safeParseAsync([]);
+describe("zAdditionalInfoOptional", () => {
+  it("allows valid strings within length limit", () => {
+    const result = zAdditionalInfoOptional.safeParse("This is a valid string");
     expect(result.success).toBe(true);
   });
 
-  it("validates an array of files", async () => {
-    const result = await zAttachmentOptional.safeParseAsync([
-      new File(["content"], "file.txt"),
-    ]);
+  it("allows empty strings", () => {
+    const result = zAdditionalInfoOptional.safeParse("");
     expect(result.success).toBe(true);
   });
 
-  it("passes when no files are provided", () => {
-    const result = zAttachmentOptional.safeParse(undefined);
+  it("fails if string is only whitespace", () => {
+    const result = zAdditionalInfoOptional.safeParse("   ");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "Additional Information can not be only whitespace.",
+    );
+  });
+
+  it("fails if string is too long", () => {
+    const longString = "A".repeat(4001);
+    const result = zAdditionalInfoOptional.safeParse(longString);
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "This field may only be up to 4000 characters.",
+    );
+  });
+
+  it("fails if string is too long and only whitespace", () => {
+    const longString = " ".repeat(4001);
+    const result = zAdditionalInfoOptional.safeParse(longString);
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "This field may only be up to 4000 characters.",
+    );
+  });
+});
+
+describe("zAdditionalInfo", () => {
+  it("validates a non-empty string", () => {
+    const result = zAdditionalInfo.safeParse("This is a valid string");
     expect(result.success).toBe(true);
+  });
+
+  it("fails on empty string", () => {
+    const result = zAdditionalInfo.safeParse("");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "Additional Information is required.",
+    );
+  });
+
+  it("fails on whitespace string", () => {
+    const result = zAdditionalInfo.safeParse("   ");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "Additional Information can not be only whitespace.",
+    );
+  });
+
+  it("fails on string that is too long", () => {
+    const longString = "A".repeat(4001);
+    const result = zAdditionalInfo.safeParse(longString);
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "This field may only be up to 4000 characters.",
+    );
+  });
+
+  it("validates a string exactly 4000 characters long", () => {
+    const maxString = "A".repeat(4000);
+    const result = zAdditionalInfo.safeParse(maxString);
+    expect(result.success).toBe(true);
+  });
+
+  it("fails on string that is too long and only whitespace", () => {
+    const longString = " ".repeat(4001);
+    const result = zAdditionalInfo.safeParse(longString);
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "This field may only be up to 4000 characters.",
+    );
+  });
+
+  it("fails on null value", () => {
+    const result = zAdditionalInfo.safeParse(null);
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "Expected string, received null",
+    );
+  });
+});
+
+describe("zInitialWaiverNumberSchema", () => {
+  it("validates a correct waiver number", async () => {
+    const result = await zInitialWaiverNumberSchema.safeParseAsync(
+      "MD-1234.R00.00",
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("fails with unauthorized state", async () => {
+    vi.mocked(isAuthorizedState).mockResolvedValue(false);
+    const result = await zInitialWaiverNumberSchema.safeParseAsync(
+      "MD-1234.R00.00",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "You can only submit for a state you have access to. If you need to add another state, visit your IDM user profile to request access.",
+    );
+  });
+
+  it("fails on empty string", async () => {
+    const result = await zInitialWaiverNumberSchema.safeParseAsync("");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe("Required");
+  });
+
+  it("fails with an existing waiver number", async () => {
+    vi.mocked(itemExists).mockResolvedValue(true);
+    const result = await zInitialWaiverNumberSchema.safeParseAsync(
+      "MD-1234.R00.00",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "According to our records, this 1915(b) Waiver Number already exists. Please check the 1915(b) Waiver Number and try entering it again.",
+    );
+  });
+
+  it("fails with an invalid waiver number format", async () => {
+    const result = await zInitialWaiverNumberSchema.safeParseAsync("MD-1234");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "The Initial Waiver Number must be in the format of SS-####.R00.00 or SS-#####.R00.00",
+    );
+  });
+});
+
+describe("zRenewalWaiverNumberSchema", () => {
+  it("validates a correct renewal waiver number format", async () => {
+    const result = await zRenewalWaiverNumberSchema.safeParseAsync(
+      "MD-12345.R01.00",
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("fails with an invalid waiver number format", async () => {
+    const result = await zRenewalWaiverNumberSchema.safeParseAsync("MD-1234");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "Renewal Number must be in the format of SS-####.R##.00 or SS-#####.R##.00 For renewals, the “R##” starts with '01' and ascends.",
+    );
+  });
+
+  it("fails if user does not have access to the state", async () => {
+    vi.mocked(isAuthorizedState).mockResolvedValue(false);
+    const result = await zRenewalWaiverNumberSchema.safeParseAsync(
+      "MD-12345.R01.00",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "You can only submit for a state you have access to. If you need to add another state, visit your IDM user profile to request access.",
+    );
+  });
+
+  it("fails if waiver number already exists", async () => {
+    vi.mocked(itemExists).mockResolvedValue(true);
+    const result = await zRenewalWaiverNumberSchema.safeParseAsync(
+      "MD-12345.R01.00",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "According to our records, this 1915(b) Waiver Renewal Number already exists. Please check the 1915(b) Waiver Renewal Number and try entering it again.",
+    );
+  });
+});
+
+describe("zAmendmentWaiverNumberSchema", () => {
+  it("validates a correct amendment waiver number format", async () => {
+    const result = await zAmendmentWaiverNumberSchema.safeParseAsync(
+      "MD-12345.R01.01",
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("fails if the user does not have access to the state", async () => {
+    vi.mocked(isAuthorizedState).mockResolvedValue(false);
+    const result = await zAmendmentWaiverNumberSchema.safeParseAsync(
+      "MD-12345.R01.01",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "You can only submit for a state you have access to. If you need to add another state, visit your IDM user profile to request access.",
+    );
+  });
+
+  it("fails if the waiver number is not in the correct format", async () => {
+    const result = await zAmendmentWaiverNumberSchema.safeParseAsync(
+      "MD-12345.R01.00",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "The 1915(b) Waiver Amendment Number must be in the format of SS-####.R##.## or SS-#####.R##.##. For amendments, the last two digits start with '01' and ascends.",
+    );
+  });
+
+  it("fails if the waiver number exists", async () => {
+    vi.mocked(itemExists).mockResolvedValue(true);
+    const result = await zAmendmentWaiverNumberSchema.safeParseAsync(
+      "MD-12345.R01.01",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "According to our records, this 1915(b) Waiver Amendment Number already exists. Please check the 1915(b) Waiver Amendment Number and try entering it again.",
+    );
+  });
+});
+
+describe("zAmendmentOriginalWaiverNumberSchema", () => {
+  it("fails if the user does not have access to the state", async () => {
+    vi.mocked(isAuthorizedState).mockResolvedValue(false);
+    const result = await zAmendmentOriginalWaiverNumberSchema.safeParseAsync(
+      "MD-12345.R01.01",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "You can only submit for a state you have access to. If you need to add another state, visit your IDM user profile to request access.",
+    );
+  });
+
+  it("validates a correct amendment original waiver number format", async () => {
+    vi.mocked(itemExists).mockResolvedValue(true);
+    const result = await zAmendmentOriginalWaiverNumberSchema.safeParseAsync(
+      "MD-12345.R01.01",
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("fails if the waiver number is not in the correct format", async () => {
+    const result = await zAmendmentOriginalWaiverNumberSchema.safeParseAsync(
+      "MD-12345.R01.AA",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "The approved 1915(b) Initial or Renewal Number must be in the format of SS-####.R##.## or SS-#####.R##.##.",
+    );
+  });
+
+  it("fails if the waiver number does not yet exist", async () => {
+    vi.mocked(itemExists).mockResolvedValue(false);
+    const result = await zAmendmentOriginalWaiverNumberSchema.safeParseAsync(
+      "MD-12345.R01.01",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "According to our records, this 1915(b) Waiver Number does not yet exist. Please check the 1915(b) Initial or Renewal Waiver Number and try entering it again.",
+    );
+  });
+
+  it("fails if the waiver number is not approved", async () => {
+    vi.mocked(itemExists).mockResolvedValue(true);
+    vi.mocked(idIsApproved).mockResolvedValue(false);
+    const result = await zAmendmentOriginalWaiverNumberSchema.safeParseAsync(
+      "MD-12345.R01.01",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "According to our records, this 1915(b) Waiver Number is not approved. You must supply an approved 1915(b) Initial or Renewal Waiver Number.",
+    );
+  });
+});
+
+describe("zRenewalOriginalWaiverNumberSchema", () => {
+  it("fails if the user does not have access to the state", async () => {
+    vi.mocked(isAuthorizedState).mockResolvedValue(false);
+    const result = await zRenewalOriginalWaiverNumberSchema.safeParseAsync(
+      "MD-12345.R01.01",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "You can only submit for a state you have access to. If you need to add another state, visit your IDM user profile to request access.",
+    );
+  });
+
+  it("validates a correct renewal waiver number format", async () => {
+    vi.mocked(itemExists).mockResolvedValue(true);
+    const result = await zRenewalOriginalWaiverNumberSchema.safeParseAsync(
+      "MD-12345.R01.01",
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("fails if the waiver number is not in the correct format", async () => {
+    const result = await zRenewalOriginalWaiverNumberSchema.safeParseAsync(
+      "MD-12345.R01.AA",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "The approved 1915(b) Initial or Renewal Waiver Number must be in the format of SS-####.R##.## or SS-#####.R##.##.",
+    );
+  });
+
+  it("fails if the waiver number does not yet exist", async () => {
+    vi.mocked(itemExists).mockResolvedValue(false);
+    const result = await zRenewalOriginalWaiverNumberSchema.safeParseAsync(
+      "MD-12345.R01.01",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "According to our records, this 1915(b) Waiver Number does not yet exist. Please check the 1915(b) Initial or Renewal Waiver Number and try entering it again.",
+    );
+  });
+
+  it("fails if the waiver number does not match records", async () => {
+    vi.mocked(itemExists).mockResolvedValue(true);
+    vi.mocked(canBeRenewedOrAmended).mockResolvedValue(false);
+    const result = await zRenewalOriginalWaiverNumberSchema.safeParseAsync(
+      "MD-12345.R01.01",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "The 1915(b) Waiver Number entered does not seem to match our records. Please enter an approved 1915(b) Initial or Renewal Waiver Number, using a dash after the two character state abbreviation.",
+    );
+  });
+
+  it("fails if the waiver number is not approved", async () => {
+    vi.mocked(itemExists).mockResolvedValue(true);
+    vi.mocked(idIsApproved).mockResolvedValue(false);
+    const result = await zRenewalOriginalWaiverNumberSchema.safeParseAsync(
+      "MD-12345.R01.01",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "According to our records, this 1915(b) Waiver Number is not approved. You must supply an approved 1915(b) Initial or Renewal Waiver Number.",
+    );
+  });
+});
+
+describe("zAppkWaiverNumberSchema", () => {
+  it("validates a correct waiver number format", async () => {
+    const result = await zAppkWaiverNumberSchema.safeParseAsync("1234.R00.01");
+    expect(result.success).toBe(true);
+  });
+
+  it("fails if the waiver amendment number is not in the correct format", async () => {
+    const result = await zAppkWaiverNumberSchema.safeParseAsync("WRONG-FORMAT");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "The Waiver Amendment Number must be in the format of ####.R##.## or #####.R##.##. For amendments, the last two digits start with '01' and ascends.",
+    );
+  });
+
+  it("fails if the waiver amendment number ends in 00", async () => {
+    const result = await zAppkWaiverNumberSchema.safeParseAsync("1234.R00.00");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "The Waiver Amendment Number must be in the format of ####.R##.## or #####.R##.##. For amendments, the last two digits start with '01' and ascends.",
+    );
+  });
+});
+
+describe("zExtensionWaiverNumberSchema", () => {
+  it("validates a correct waiver number format", async () => {
+    const result = await zExtensionWaiverNumberSchema.safeParseAsync(
+      "MD-1234.R00.TE00",
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("fails if the user does not have access to the state", async () => {
+    vi.mocked(isAuthorizedState).mockResolvedValue(false);
+    const result = await zExtensionWaiverNumberSchema.safeParseAsync(
+      "MD-1234.R00.TE00",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "You can only submit for a state you have access to. If you need to add another state, visit your IDM user profile to request access.",
+    );
+  });
+
+  it("fails if the waiver number is not in the correct format", async () => {
+    const result = await zExtensionWaiverNumberSchema.safeParseAsync(
+      "MD-1234.R00.TE",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "The Temporary Extension Request Number must be in the format of SS-####.R##.TE## or SS-#####.R##.TE##",
+    );
+  });
+
+  it("fails if the waiver number already exists", async () => {
+    vi.mocked(itemExists).mockResolvedValue(true);
+    const result = await zExtensionWaiverNumberSchema.safeParseAsync(
+      "MD-1234.R00.TE00",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "According to our records, this Temporary Extension Request Number already exists. Please check the Temporary Extension Request Number and try entering it again.",
+    );
+  });
+});
+
+describe("zExtensionOriginalWaiverNumberSchema", () => {
+  it("validates a correct waiver number format", async () => {
+    vi.mocked(itemExists).mockResolvedValue(true);
+    const result = await zExtensionOriginalWaiverNumberSchema.safeParseAsync(
+      "MD-1234.R00.00",
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("fails if the user does not have access to the state", async () => {
+    vi.mocked(isAuthorizedState).mockResolvedValue(false);
+    const result = await zExtensionOriginalWaiverNumberSchema.safeParseAsync(
+      "MD-1234.R00.00",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "You can only submit for a state you have access to. If you need to add another state, visit your IDM user profile to request access.",
+    );
+  });
+
+  it("fails if the waiver number is not in the correct format", async () => {
+    const result = await zExtensionOriginalWaiverNumberSchema.safeParseAsync(
+      "MD-1234.R00.TE00",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "The Approved Initial or Renewal Waiver Number must be in the format of SS-####.R##.00 or SS-#####.R##.00.",
+    );
+  });
+
+  it("fails if the waiver number does not yet exist", async () => {
+    vi.mocked(itemExists).mockResolvedValue(false);
+    const result = await zExtensionOriginalWaiverNumberSchema.safeParseAsync(
+      "MD-1234.R00.00",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "According to our records, this Approved Initial or Renewal Waiver Number does not yet exist. Please check the Approved Initial or Renewal Waiver Number and try entering it again.",
+    );
+  });
+
+  it("fails if the waiver number is not approved", async () => {
+    vi.mocked(itemExists).mockResolvedValue(true);
+    vi.mocked(idIsApproved).mockResolvedValue(false);
+    const result = await zExtensionOriginalWaiverNumberSchema.safeParseAsync(
+      "MD-1234.R00.00",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "According to our records, this Approved Initial or Renewal Waiver Number is not approved. You must supply an approved Initial or Renewal Waiver Number.",
+    );
+  });
+});
+
+describe("zUpdateIdSchema", () => {
+  it("validates a correct ID format", async () => {
+    const result = await zUpdateIdSchema.safeParseAsync("MD-21-1234");
+    expect(result.success).toBe(true);
+  });
+
+  it("fails if the ID already exists", async () => {
+    vi.mocked(itemExists).mockResolvedValue(true);
+    const result = await zUpdateIdSchema.safeParseAsync("MD-21-1234");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "According to our records, this ID already exists. Please check the ID and try entering it again.",
+    );
+  });
+
+  it("fails if the ID contains whitespace", async () => {
+    const result = await zUpdateIdSchema.safeParseAsync("wrong format");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "The new ID can only contain uppercase letters, numbers, dots, and dashes without any whitespace, no leading or trailing dashes or dots, no consecutive dots or dashes.",
+    );
+  });
+
+  it("fails if the ID contains leading dots", async () => {
+    const result = await zUpdateIdSchema.safeParseAsync(".MD-21-1234");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "The new ID can only contain uppercase letters, numbers, dots, and dashes without any whitespace, no leading or trailing dashes or dots, no consecutive dots or dashes.",
+    );
+  });
+
+  it("fails if the ID contains trailing dots", async () => {
+    const result = await zUpdateIdSchema.safeParseAsync("MD-21-1234.");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "The new ID can only contain uppercase letters, numbers, dots, and dashes without any whitespace, no leading or trailing dashes or dots, no consecutive dots or dashes.",
+    );
+  });
+
+  it("fails if the ID contains leading dashes", async () => {
+    const result = await zUpdateIdSchema.safeParseAsync("-MD-21-1234");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "The new ID can only contain uppercase letters, numbers, dots, and dashes without any whitespace, no leading or trailing dashes or dots, no consecutive dots or dashes.",
+    );
+  });
+
+  it("fails if the ID contains trailing dashes", async () => {
+    const result = await zUpdateIdSchema.safeParseAsync("MD-21-1234-");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "The new ID can only contain uppercase letters, numbers, dots, and dashes without any whitespace, no leading or trailing dashes or dots, no consecutive dots or dashes.",
+    );
+  });
+
+  it("fails if the ID contains consecutive dots", async () => {
+    const result = await zUpdateIdSchema.safeParseAsync("MD-21..1234");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "The new ID can only contain uppercase letters, numbers, dots, and dashes without any whitespace, no leading or trailing dashes or dots, no consecutive dots or dashes.",
+    );
+  });
+
+  it("fails if the ID contains consecutive dashes", async () => {
+    const result = await zUpdateIdSchema.safeParseAsync("MD-21--1234");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "The new ID can only contain uppercase letters, numbers, dots, and dashes without any whitespace, no leading or trailing dashes or dots, no consecutive dots or dashes.",
+    );
+  });
+});
+
+describe("zodAlwaysRefine", () => {
+  it("validates a correct value", async () => {
+    const schema = zodAlwaysRefine(zExtensionWaiverNumberSchema);
+    const result = await schema.safeParseAsync("MD-1234.R00.TE00");
+    expect(result.success).toBe(true);
+  });
+
+  it("fails if the value is not correct", async () => {
+    const schema = zodAlwaysRefine(zExtensionWaiverNumberSchema);
+    const result = await schema.safeParseAsync("MD-1234.R00.TE");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "The Temporary Extension Request Number must be in the format of SS-####.R##.TE## or SS-#####.R##.TE##",
+    );
   });
 });

--- a/react-app/src/utils/zod.test.ts
+++ b/react-app/src/utils/zod.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { zSpaIdSchema, zAttachmentOptional, zAttachmentRequired } from "./zod";
+import { isAuthorizedState } from "@/utils";
+import { itemExists } from "@/api";
+
+// Mock async functions
+vi.mock("@/utils", () => ({
+  isAuthorizedState: vi.fn(),
+  itemExists: vi.fn(),
+}));
+
+// Setup for mock return values
+beforeEach(() => {
+  vi.mocked(isAuthorizedState).mockResolvedValue(true);
+  vi.mocked(itemExists).mockResolvedValue(false);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("zSpaIdSchema", () => {
+  it("validates a correct ID format", async () => {
+    const result = await zSpaIdSchema.safeParseAsync("MD-21-1234");
+    expect(result.success).toBe(true);
+  });
+
+  it("validates a corred ID format with a suffix", async () => {
+    const result = await zSpaIdSchema.safeParseAsync("MD-21-1234-ABCD");
+    expect(result.success).toBe(true);
+  });
+
+  it("fails when the ID is empty", async () => {
+    const result = await zSpaIdSchema.safeParseAsync("");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe("Required");
+  });
+
+  it("fails when state is unauthorized", async () => {
+    vi.mocked(isAuthorizedState).mockResolvedValue(false);
+    const result = await zSpaIdSchema.safeParseAsync("MD-21-1234");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "You can only submit for a state you have access to. If you need to add another state, visit your IDM user profile to request access.",
+    );
+  });
+
+  it("fails when ID already exists", async () => {
+    vi.mocked(itemExists).mockResolvedValue(true);
+    const result = await zSpaIdSchema.safeParseAsync("MD-21-1234");
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe(
+      "According to our records, this SPA ID already exists. Please check the SPA ID and try entering it again.",
+    );
+  });
+});
+
+describe("zAttachemtnRequired", () => {
+  const schema = zAttachmentRequired({ min: 1, max: 3 });
+
+  it("validates an array within file count bounds", () => {
+    const files = [
+      new File(["content"], "file1.txt"),
+      new File(["content"], "file2.txt"),
+    ];
+    const result = schema.safeParse(files);
+    expect(result.success).toBe(true);
+  });
+
+  it("fails if file count is below minimum", () => {
+    const result = schema.safeParse([]);
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe("Required");
+  });
+
+  it("fails if file count is above maximum", () => {
+    const files = [
+      new File(["content"], "file1.txt"),
+      new File(["content"], "file2.txt"),
+      new File(["content"], "file3.txt"),
+      new File(["content"], "file4.txt"),
+    ];
+    const result = schema.safeParse(files);
+    expect(result.success).toBe(false);
+    expect(result.error.errors[0].message).toBe("Required");
+  });
+});
+
+describe("zAttachmentOptional", () => {
+  it("validates an empty array", async () => {
+    const result = await zAttachmentOptional.safeParseAsync([]);
+    expect(result.success).toBe(true);
+  });
+
+  it("validates an array of files", async () => {
+    const result = await zAttachmentOptional.safeParseAsync([
+      new File(["content"], "file.txt"),
+    ]);
+    expect(result.success).toBe(true);
+  });
+
+  it("passes when no files are provided", () => {
+    const result = zAttachmentOptional.safeParse(undefined);
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Purpose

This PR adds unit test coverage for the Zod (`zod.ts`) and User (`user.ts`) utilities.

#### Linked Issues to Close

https://jiraent.cms.gov/browse/OY2-29714

## Approach

Creates new test files and provides test coverage for each utility. Brings unit test coverage of each to 100%.