### PR TITLE
feat(app): Upload Subsequent Documentation

### DIFF
--- a/lib/lambda/submit/submissionPayloads/index.ts
+++ b/lib/lambda/submit/submissionPayloads/index.ts
@@ -1,5 +1,6 @@
 import { newChipSubmission } from "./new-chip-submission";
 import { newMedicaidSubmission } from "./new-medicaid-submission";
+import { uploadSubsequentDocuments } from "./upload-subsequent-documents";
 import { capitatedAmendment } from "./capitated-amendment";
 import { capitatedInitial } from "./capitated-initial";
 import { capitatedRenewal } from "./capitated-renewal";
@@ -26,4 +27,5 @@ export const submissionPayloads = {
   "withdraw-rai": withdrawRai,
   "toggle-withdraw-rai": toggleWithdrawRai,
   "respond-to-rai": respondToRai,
+  "upload-subsequent-documents": uploadSubsequentDocuments,
 };

--- a/lib/lambda/submit/submissionPayloads/upload-subsequent-documents.ts
+++ b/lib/lambda/submit/submissionPayloads/upload-subsequent-documents.ts
@@ -1,0 +1,38 @@
+import { APIGatewayEvent } from "aws-lambda";
+import { getAuthDetails, lookupUserAttributes } from "lib/libs/api/auth/user";
+import { itemExists } from "lib/libs/api/package";
+import { events } from "lib/packages/shared-types";
+
+export const uploadSubsequentDocuments = async (event: APIGatewayEvent) => {
+  if (event.body === null) return;
+
+  const parsedResult = events[
+    "upload-subsequent-documents"
+  ].baseSchema.safeParse(JSON.parse(event.body));
+
+  if (parsedResult.success === false) {
+    throw parsedResult.error;
+  }
+
+  if ((await itemExists({ id: parsedResult.data.id })) === false) {
+    throw "Item Doesn't Exist";
+  }
+
+  const authDetails = getAuthDetails(event);
+  const userAttr = await lookupUserAttributes(
+    authDetails.userId,
+    authDetails.poolId,
+  );
+
+  const submitterEmail = userAttr.email;
+  const submitterName = `${userAttr.given_name} ${userAttr.family_name}`;
+
+  const transformedData = events["new-chip-submission"].schema.parse({
+    ...parsedResult.data,
+    submitterName,
+    submitterEmail,
+    timestamp: Date.now(),
+  });
+
+  return transformedData;
+};

--- a/lib/lambda/submit/submissionPayloads/upload-subsequent-documents.ts
+++ b/lib/lambda/submit/submissionPayloads/upload-subsequent-documents.ts
@@ -27,7 +27,7 @@ export const uploadSubsequentDocuments = async (event: APIGatewayEvent) => {
   const submitterEmail = userAttr.email;
   const submitterName = `${userAttr.given_name} ${userAttr.family_name}`;
 
-  const transformedData = events["new-chip-submission"].schema.parse({
+  const transformedData = events["upload-subsequent-documents"].schema.parse({
     ...parsedResult.data,
     submitterName,
     submitterEmail,

--- a/lib/packages/shared-types/actions.ts
+++ b/lib/packages/shared-types/actions.ts
@@ -12,6 +12,7 @@ export enum Action {
   UPDATE_ID = "update-id",
   LEGACY_ADMIN_CHANGE = "legacy-admin-change",
   LEGACY_WITHDRAW_RAI_REQUEST = "legacy-withdraw-rai-request",
+  UPLOAD_SUBSEQUENT_DOCUMENTS = "upload-subsequent-documents",
 }
 
 export type ActionRule = {

--- a/lib/packages/shared-types/events/capitated-amendment.ts
+++ b/lib/packages/shared-types/events/capitated-amendment.ts
@@ -5,7 +5,6 @@ import {
 } from "../attachments";
 
 export const baseSchema = z.object({
-  // zAmendmentWaiverNumberSchema
   event: z.literal("capitated-amendment").default("capitated-amendment"),
   authority: z.string().default("1915(b)"),
   id: z

--- a/lib/packages/shared-types/events/capitated-initial.ts
+++ b/lib/packages/shared-types/events/capitated-initial.ts
@@ -5,7 +5,6 @@ import {
 } from "../attachments";
 
 export const baseSchema = z.object({
-  // zAmendmentWaiverNumberSchema
   event: z.literal("capitated-initial").default("capitated-initial"),
   authority: z.string().default("1915(b)"),
   id: z

--- a/lib/packages/shared-types/events/contracting-amendment.ts
+++ b/lib/packages/shared-types/events/contracting-amendment.ts
@@ -5,7 +5,6 @@ import {
 } from "../attachments";
 
 export const baseSchema = z.object({
-  // zAmendmentWaiverNumberSchema
   event: z.literal("contracting-amendment").default("contracting-amendment"),
   authority: z.string().default("1915(b)"),
   id: z

--- a/lib/packages/shared-types/events/contracting-initial.ts
+++ b/lib/packages/shared-types/events/contracting-initial.ts
@@ -5,7 +5,6 @@ import {
 } from "../attachments";
 
 export const baseSchema = z.object({
-  // zAmendmentWaiverNumberSchema
   event: z.literal("contracting-initial").default("contracting-initial"),
   authority: z.string().default("1915(b)"),
   id: z

--- a/lib/packages/shared-types/events/contracting-renewal.ts
+++ b/lib/packages/shared-types/events/contracting-renewal.ts
@@ -5,7 +5,6 @@ import {
 } from "../attachments";
 
 export const baseSchema = z.object({
-  // zAmendmentWaiverNumberSchema
   event: z.literal("contracting-renewal").default("contracting-renewal"),
   authority: z.string().default("1915(b)"),
   id: z

--- a/lib/packages/shared-types/events/index.ts
+++ b/lib/packages/shared-types/events/index.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import * as newMedicaidSubmission from "./new-medicaid-submission";
+import * as uploadSubsequentDocuments from "./upload-subsequent-documents";
 import * as newChipSubmission from "./new-chip-submission";
 import * as capitatedAmendment from "./capitated-amendment";
 import * as capitatedIntial from "./capitated-initial";
@@ -37,6 +38,7 @@ export const events = {
   "withdraw-rai": withdrawRai,
   "toggle-withdraw-rai": toggleWithdrawRai,
   "respond-to-rai": respondToRai,
+  "upload-subsequent-documents": uploadSubsequentDocuments,
 };
 
 export type BaseSchemas = z.infer<typeof newMedicaidSubmission.baseSchema>;

--- a/lib/packages/shared-types/events/upload-subsequent-documents.ts
+++ b/lib/packages/shared-types/events/upload-subsequent-documents.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { attachmentSchema } from "../attachments";
+import { attachmentArraySchemaOptional } from "../attachments";
 
 export const baseSchema = z.object({
   event: z
@@ -9,7 +9,7 @@ export const baseSchema = z.object({
   attachments: z.record(
     z.string(),
     z.object({
-      files: attachmentSchema,
+      files: attachmentArraySchemaOptional(),
       label: z.string(),
     }),
   ),

--- a/lib/packages/shared-types/events/upload-subsequent-documents.ts
+++ b/lib/packages/shared-types/events/upload-subsequent-documents.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { attachmentSchema } from "../attachments";
+
+export const baseSchema = z.object({
+  event: z
+    .literal("upload-subsequent-documents")
+    .default("upload-subsequent-documents"),
+  additionalInformation: z.string().max(4000).default(null),
+  attachments: z.array(attachmentSchema),
+  id: z.string(),
+});
+
+export const schema = baseSchema.extend({
+  origin: z.literal("mako").default("mako"),
+  submitterName: z.string(),
+  submitterEmail: z.string().email(),
+  timestamp: z.number(),
+});

--- a/lib/packages/shared-types/events/upload-subsequent-documents.ts
+++ b/lib/packages/shared-types/events/upload-subsequent-documents.ts
@@ -6,7 +6,13 @@ export const baseSchema = z.object({
     .literal("upload-subsequent-documents")
     .default("upload-subsequent-documents"),
   additionalInformation: z.string().max(4000).default(null),
-  attachments: z.array(attachmentSchema),
+  attachments: z.record(
+    z.string(),
+    z.object({
+      files: attachmentSchema,
+      label: z.string(),
+    }),
+  ),
   id: z.string(),
 });
 

--- a/lib/packages/shared-types/events/withdraw-rai.ts
+++ b/lib/packages/shared-types/events/withdraw-rai.ts
@@ -15,10 +15,8 @@ export const baseSchema = z.object({
     (value) => (typeof value === "string" ? value.trimStart() : value),
     z
       .string()
+      .min(1, { message: "Additional Information is required." })
       .max(4000)
-      .refine((value) => value !== "", {
-        message: "Additional Information is required.",
-      })
       .refine((value) => value.trim().length > 0, {
         message: "Additional Information can not be only whitespace.",
       }),

--- a/lib/packages/shared-types/opensearch/changelog/index.ts
+++ b/lib/packages/shared-types/opensearch/changelog/index.ts
@@ -67,5 +67,5 @@ export const transforms = {
   "withdraw-rai": withdrawRai,
   "toggle-withdraw-rai": toggleWithdrawRai,
   "respond-to-rai": respondToRai,
-  "upload-subsequent-transforms": uploadSubsequentDocuments,
+  "upload-subsequent-documents": uploadSubsequentDocuments,
 };

--- a/lib/packages/shared-types/opensearch/changelog/index.ts
+++ b/lib/packages/shared-types/opensearch/changelog/index.ts
@@ -22,6 +22,7 @@ import {
   withdrawRai,
   toggleWithdrawRai,
   respondToRai,
+  uploadSubsequentDocuments,
 } from "./transforms";
 
 // legacy
@@ -38,11 +39,6 @@ export type Document = z.infer<capitatedAmendment.Schema> &
   z.infer<temporaryExtension.Schema> &
   z.infer<legacyEvent.Schema> &
   z.infer<legacyAdminChange.Schema>;
-
-// & {
-//   appkParentId: string;
-//   appkParent: boolean;
-// };
 
 export type Response = Res<Document>;
 export type ItemResult = Hit<Document> & {
@@ -71,4 +67,5 @@ export const transforms = {
   "withdraw-rai": withdrawRai,
   "toggle-withdraw-rai": toggleWithdrawRai,
   "respond-to-rai": respondToRai,
+  "upload-subsequent-transforms": uploadSubsequentDocuments,
 };

--- a/lib/packages/shared-types/opensearch/changelog/transforms/index.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/index.ts
@@ -13,3 +13,4 @@ export * as withdrawPackage from "./withdraw-package";
 export * as withdrawRai from "./withdraw-rai";
 export * as toggleWithdrawRai from "./toggle-withdraw-rai";
 export * as respondToRai from "./respond-to-rai";
+export * as uploadSubsequentDocuments from "./upload-subsequent-documents";

--- a/lib/packages/shared-types/opensearch/changelog/transforms/upload-subsequent-documents.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/upload-subsequent-documents.ts
@@ -1,0 +1,34 @@
+import { events } from "shared-types";
+export const transform = (offset: number) => {
+  return events["upload-subsequent-documents"].schema.transform((data) => {
+    const attachments = Object.entries(data.attachments).flatMap(
+      ([, attachment]) => {
+        // Check if 'attachment' exists and has a non-empty 'files' array
+        if (
+          attachment &&
+          Array.isArray(attachment.files) &&
+          attachment.files.length > 0
+        ) {
+          // Map each file in 'files' array to the desired shape
+          return attachment.files.map((file) => ({
+            filename: file.filename,
+            title: attachment.label,
+            bucket: file.bucket,
+            key: file.key,
+            uploadDate: file.uploadDate,
+          }));
+        }
+        // If there are no files or the files array is empty, return an empty array
+        return [];
+      },
+    );
+    return {
+      ...data,
+      attachments,
+      packageId: data.id,
+      id: `${data.id}-${offset}`,
+    };
+  });
+};
+
+export type Schema = ReturnType<typeof transform>;

--- a/lib/packages/shared-types/opensearch/main/transforms/seatool.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/seatool.ts
@@ -178,6 +178,7 @@ export const transform = (id: string) => {
       statusDate: getDateStringOrNullFromEpoc(data.STATE_PLAN.STATUS_DATE),
       cmsStatus: cmsStatus || SEATOOL_STATUS.UNKNOWN,
       seatoolStatus,
+      locked: false,
       submissionDate: getDateStringOrNullFromEpoc(
         data.STATE_PLAN.SUBMISSION_DATE,
       ),

--- a/lib/packages/shared-utils/package-actions/rules.ts
+++ b/lib/packages/shared-utils/package-actions/rules.ts
@@ -15,7 +15,7 @@ const arRespondToRai: ActionRule = {
     // safety; prevent bad status from causing overwrite
     (!checker.hasRaiResponse || checker.hasRaiWithdrawal) &&
     isStateUser(user) &&
-    !checker.isLocked
+    !checker.isLocked,
 };
 
 const arTempExtension: ActionRule = {
@@ -62,6 +62,7 @@ const arWithdrawRaiResponse: ActionRule = {
     isStateUser(user) &&
     !checker.isLocked,
 };
+
 const arWithdrawPackage: ActionRule = {
   action: Action.WITHDRAW_PACKAGE,
   check: (checker, user) =>
@@ -70,6 +71,7 @@ const arWithdrawPackage: ActionRule = {
     isStateUser(user) &&
     !checker.isLocked,
 };
+
 const arUpdateId: ActionRule = {
   action: Action.UPDATE_ID,
   check: (checker, user) =>
@@ -83,6 +85,27 @@ const arRemoveAppkChild: ActionRule = {
   check: (checker, user) => isStateUser(user) && !!checker.isAppkChild && false,
 };
 
+const arUploadSubsequentDocuments: ActionRule = {
+  action: Action.UPLOAD_SUBSEQUENT_DOCUMENTS,
+  check: (checker, user) => {
+    if (checker.hasStatus(SEATOOL_STATUS.PENDING)) {
+      if (isStateUser(user)) {
+        if (
+          checker.hasStatus(SEATOOL_STATUS.PENDING_CONCURRENCE) ||
+          checker.hasStatus(SEATOOL_STATUS.PENDING_APPROVAL) ||
+          checker.hasLatestRai
+        ) {
+          return false;
+        }
+
+        return true;
+      }
+    }
+
+    return false;
+  },
+};
+
 export default [
   arRespondToRai,
   arEnableWithdrawRaiResponse,
@@ -92,4 +115,5 @@ export default [
   arTempExtension,
   arUpdateId,
   arRemoveAppkChild,
+  arUploadSubsequentDocuments,
 ];

--- a/react-app/src/components/ActionForm/ActionForm.test.tsx
+++ b/react-app/src/components/ActionForm/ActionForm.test.tsx
@@ -96,6 +96,31 @@ describe("ActionForm", () => {
     );
   });
 
+  test("renders `attachments.title`", () => {
+    const { queryByText } = renderForm(
+      <ActionForm
+        title="Action Form Title"
+        schema={z.object({
+          attachments: z.object({
+            other: z.object({
+              label: z.string().default("Other"),
+              files: attachmentArraySchemaOptional(),
+            }),
+          }),
+        })}
+        fields={() => null}
+        documentPollerArgs={{
+          property: () => "id",
+          documentChecker: () => true,
+        }}
+        attachments={{ title: "this is an attachments title" }}
+        breadcrumbText="Example Breadcrumb"
+      />,
+    );
+
+    expect(queryByText("this is an attachments title")).not.toBeInTheDocument();
+  });
+
   test("doesn't render form if user access is denied", () => {
     const { queryByText } = renderForm(
       <ActionForm
@@ -171,6 +196,33 @@ describe("ActionForm", () => {
     expect(
       queryByText(/hello world special instructions./),
     ).toBeInTheDocument();
+  });
+
+  test("renders `attachments.callout`", () => {
+    const { queryByText } = renderForm(
+      <ActionForm
+        title="Action Form Title"
+        schema={z.object({
+          attachments: z.object({
+            other: z.object({
+              files: attachmentArraySchemaOptional(),
+              label: z.string().default("Other"),
+            }),
+          }),
+        })}
+        fields={() => null}
+        documentPollerArgs={{
+          property: () => "id",
+          documentChecker: () => true,
+        }}
+        attachments={{
+          callout: "this is a callout",
+        }}
+        breadcrumbText="Example Breadcrumb"
+      />,
+    );
+
+    expect(queryByText(/this is a callout/)).toBeInTheDocument();
   });
 
   test("renders custom `promptOnLeavingForm` when clicking Cancel", async () => {

--- a/react-app/src/components/ActionForm/ActionFormAttachments.tsx
+++ b/react-app/src/components/ActionForm/ActionFormAttachments.tsx
@@ -9,30 +9,18 @@ import {
   RequiredIndicator,
   Upload,
 } from "@/components";
-import { Link } from "react-router-dom";
-import { FAQ_TAB } from "@/router";
 
-const DEFAULT_ATTACHMENTS_INSTRUCTIONS =
-  "Maximum file size of 80 MB per attachment. You can add multiple files per attachment type.";
-
-const AttachmentInstructions = ({ fileValidation }) => {
-  const { maxLength, minLength } = fileValidation;
-
-  if (maxLength?.value === 1 && minLength?.value === 1) {
-    return <p>One attachment is required</p>;
-  }
-
-  if (minLength?.value) {
-    return <p>At least one attachment is required</p>;
-  }
-
-  return null;
-};
+import { Fragment } from "react/jsx-runtime";
+import {
+  AttachmentFAQInstructions,
+  AttachmentFileFormatInstructions,
+  AttachmentInstructions,
+} from "./actionForm.components";
 
 export type AttachmentsOptions = {
   title?: string;
   requiredIndicatorForTitle?: boolean;
-  instructions?: React.ReactNode;
+  instructions?: JSX.Element[];
   callout?: string;
   faqLink?: string;
 };
@@ -46,10 +34,15 @@ export const ActionFormAttachments = ({
   title = "Attachments",
   faqLink,
   requiredIndicatorForTitle,
-  instructions = DEFAULT_ATTACHMENTS_INSTRUCTIONS,
+  instructions,
   callout,
 }: ActionFormAttachmentsProps) => {
   const form = useFormContext();
+
+  const attachmentInstructions = instructions ?? [
+    <AttachmentFileFormatInstructions />,
+    <AttachmentFAQInstructions faqLink={faqLink} />,
+  ];
 
   return (
     <SectionCard
@@ -60,35 +53,18 @@ export const ActionFormAttachments = ({
       }
     >
       <div className="text-gray-700 font-light">
-        {callout && <p className="font-medium mb-8">{callout}</p>}
-
-        <p data-testid="attachments-instructions">
-          {instructions} Read the description for each of the attachment types
-          on the{" "}
-          <Link
-            to={faqLink || "/faq"}
-            target={FAQ_TAB}
-            rel="noopener noreferrer"
-            className="text-blue-900 underline"
-          >
-            FAQ Page
-          </Link>
-          .
-        </p>
-        <br />
-        <p>
-          We accept the following file formats:{" "}
-          <strong>.doc, .docx, .pdf, .jpg, .xlsx, and more. </strong>{" "}
-          <Link
-            to={"/faq/acceptable-file-formats"}
-            target={FAQ_TAB}
-            rel="noopener noreferrer"
-            className="text-blue-900 underline"
-          >
-            See the full list
-          </Link>
-          .
-        </p>
+        {callout && (
+          <>
+            <p className="font-medium">{callout}</p>
+            <br />
+          </>
+        )}
+        {attachmentInstructions.map((instruction, i) => (
+          <Fragment key={i}>
+            {instruction}
+            {i < attachmentInstructions.length - 1 && <br />}
+          </Fragment>
+        ))}
       </div>
       <section className="space-y-8" data-testid="attachments-section">
         {attachmentsFromSchema.map(([key, value]) => (

--- a/react-app/src/components/ActionForm/ActionFormAttachments.tsx
+++ b/react-app/src/components/ActionForm/ActionFormAttachments.tsx
@@ -55,7 +55,7 @@ export const ActionFormAttachments = ({
           {instructions} Read the description for each of the attachment types
           on the{" "}
           <Link
-            to={faqLink}
+            to={faqLink || "/faq"}
             target={FAQ_TAB}
             rel="noopener noreferrer"
             className="text-blue-900 underline"

--- a/react-app/src/components/ActionForm/ActionFormAttachments.tsx
+++ b/react-app/src/components/ActionForm/ActionFormAttachments.tsx
@@ -29,25 +29,36 @@ const AttachmentInstructions = ({ fileValidation }) => {
   return null;
 };
 
-type ActionFormAttachmentsProps = {
-  attachmentsFromSchema: [string, z.ZodObject<z.ZodRawShape, "strip">][];
+export type AttachmentsOptions = {
   title?: string;
+  requiredIndicatorForTitle?: boolean;
   instructions?: React.ReactNode;
   callout?: string;
-  faqLink: string;
+  faqLink?: string;
 };
+
+type ActionFormAttachmentsProps = {
+  attachmentsFromSchema: [string, z.ZodObject<z.ZodRawShape, "strip">][];
+} & AttachmentsOptions;
 
 export const ActionFormAttachments = ({
   attachmentsFromSchema,
   title = "Attachments",
+  faqLink,
+  requiredIndicatorForTitle,
   instructions = DEFAULT_ATTACHMENTS_INSTRUCTIONS,
   callout,
-  faqLink,
 }: ActionFormAttachmentsProps) => {
   const form = useFormContext();
 
   return (
-    <SectionCard title={title}>
+    <SectionCard
+      title={
+        <>
+          {title} {requiredIndicatorForTitle && <RequiredIndicator />}
+        </>
+      }
+    >
       <div className="text-gray-700 font-light">
         {callout && <p className="font-medium mb-8">{callout}</p>}
 

--- a/react-app/src/components/ActionForm/actionForm.components.tsx
+++ b/react-app/src/components/ActionForm/actionForm.components.tsx
@@ -1,0 +1,66 @@
+import { FAQ_TAB } from "@/router";
+import { Link } from "react-router-dom";
+import { z } from "zod";
+
+export const AttachmentFileFormatInstructions = () => (
+  <p>
+    We accept the following file formats:{" "}
+    <strong>.doc, .docx, .pdf, .jpg, .xlsx, and more. </strong>{" "}
+    <Link
+      to={"/faq/acceptable-file-formats"}
+      target={FAQ_TAB}
+      rel="noopener noreferrer"
+      className="text-blue-900 underline"
+    >
+      See the full list
+    </Link>
+    .
+  </p>
+);
+
+export const AttachmentFAQInstructions = ({
+  faqLink,
+}: {
+  faqLink?: string;
+}) => (
+  <p data-testid="attachments-instructions">
+    Maximum file size of 80 MB per attachment. You can add multiple files per
+    attachment type. Read the description for each of the attachment types on
+    the{" "}
+    <Link
+      to={faqLink || "/faq"}
+      target={FAQ_TAB}
+      rel="noopener noreferrer"
+      className="text-blue-900 underline"
+    >
+      FAQ Page
+    </Link>
+    .
+  </p>
+);
+
+const isZodArrayDef = (def: unknown): def is z.ZodArrayDef =>
+  def &&
+  typeof def === "object" &&
+  "typeName" in def &&
+  def.typeName === "ZodArray";
+
+export const AttachmentInstructions = ({
+  fileValidation,
+}: {
+  fileValidation: z.ZodArray<any>;
+}) => {
+  if (isZodArrayDef(fileValidation)) {
+    const { maxLength, minLength } = fileValidation;
+
+    if (maxLength?.value === 1 && minLength?.value === 1) {
+      return <p>One attachment is required</p>;
+    }
+
+    if (minLength?.value) {
+      return <p>At least one attachment is required</p>;
+    }
+  }
+
+  return null;
+};

--- a/react-app/src/components/ActionForm/index.tsx
+++ b/react-app/src/components/ActionForm/index.tsx
@@ -40,10 +40,14 @@ import {
 } from "@/utils/Poller/documentPoller";
 import { API } from "aws-amplify";
 import { Authority, CognitoUserAttributes } from "shared-types";
-import { ActionFormAttachments } from "./ActionFormAttachments";
+import {
+  ActionFormAttachments,
+  AttachmentsOptions,
+} from "./ActionFormAttachments";
 import { getAttachments } from "./actionForm.utilities";
 import { isStateUser } from "shared-utils";
 import { useGetUser } from "@/api";
+
 type EnforceSchemaProps<Shape extends z.ZodRawShape> = z.ZodObject<
   Shape & {
     attachments?: z.ZodObject<{
@@ -75,12 +79,7 @@ type ActionFormProps<Schema extends SchemaWithEnforcableProps> = {
   bannerPostSubmission?: Omit<Banner, "pathnameToDisplayOn">;
   promptPreSubmission?: Omit<UserPrompt, "onAccept">;
   promptOnLeavingForm?: Omit<UserPrompt, "onAccept">;
-  attachments?: {
-    title?: string;
-    callout?: string;
-    instructions?: React.ReactNode;
-    faqLink: string;
-  };
+  attachments?: AttachmentsOptions;
   additionalInformation?:
     | {
         required: boolean;

--- a/react-app/src/components/ActionForm/index.tsx
+++ b/react-app/src/components/ActionForm/index.tsx
@@ -150,15 +150,7 @@ export const ActionForm = <Schema extends SchemaWithEnforcableProps>({
   const navigate = useNavigate();
   const { data: userObj } = useGetUser();
 
-  const breadcrumbs = optionCrumbsFromPath(pathname, authority);
-
-  if (id) {
-    breadcrumbs.push({
-      displayText: id,
-      to: `/details/${authority}/${id}`,
-      order: breadcrumbs.length,
-    });
-  }
+  const breadcrumbs = optionCrumbsFromPath(pathname, authority, id);
 
   const form = useForm<z.TypeOf<Schema>>({
     resolver: zodResolver(schema),

--- a/react-app/src/components/ActionForm/index.tsx
+++ b/react-app/src/components/ActionForm/index.tsx
@@ -197,10 +197,8 @@ export const ActionForm = <Schema extends SchemaWithEnforcableProps>({
 
   const attachmentsFromSchema = useMemo(() => getAttachments(schema), [schema]);
 
-  const hasProgressLossReminder = useMemo(
-    () => Fields({ ...form }) !== null || attachmentsFromSchema.length > 0,
-    [attachmentsFromSchema, Fields, form],
-  );
+  const hasProgressLossReminder =
+    Fields({ ...form }) !== null || attachmentsFromSchema.length > 0;
 
   const areRequiredFields = requiredFields && hasProgressLossReminder;
 

--- a/react-app/src/components/BreadCrumb/create-breadcrumbs.ts
+++ b/react-app/src/components/BreadCrumb/create-breadcrumbs.ts
@@ -57,8 +57,9 @@ const newSubmissionPageRouteMapper: Record<
 export const optionCrumbsFromPath = (
   path: string,
   authority?: Authority,
-): BreadCrumbConfig[] =>
-  [dashboardCrumb(authority)].concat(
+  id?: string,
+): BreadCrumbConfig[] => {
+  const breadcrumbs = [dashboardCrumb(authority)].concat(
     path.split("/").reduce<BreadCrumbConfig[]>((acc, subPath, index) => {
       if (subPath in newSubmissionPageRouteMapper) {
         return acc.concat({
@@ -70,3 +71,14 @@ export const optionCrumbsFromPath = (
       return acc;
     }, []),
   );
+
+  if (id) {
+    return breadcrumbs.concat({
+      displayText: id,
+      to: `/details/${authority}/${id}`,
+      order: breadcrumbs.length,
+    });
+  }
+
+  return breadcrumbs;
+};

--- a/react-app/src/features/forms/new-submission/Medicaid.tsx
+++ b/react-app/src/features/forms/new-submission/Medicaid.tsx
@@ -13,6 +13,7 @@ import {
 import { ActionForm } from "@/components/ActionForm";
 import { formSchemas } from "@/formSchemas";
 import { FAQ_TAB } from "@/router";
+import { AttachmentFileFormatInstructions } from "@/components/ActionForm/actionForm.components";
 
 export const MedicaidForm = () => (
   <ActionForm
@@ -80,9 +81,23 @@ export const MedicaidForm = () => (
     )}
     defaultValues={{ id: "" }}
     attachments={{
-      faqLink: "/faq/medicaid-spa-attachments",
-      instructions:
-        "Maximum file size of 80 MB per attachment. You can add multiple files per attachment type except for the CMS Form 179.",
+      instructions: [
+        <p data-testid="attachments-instructions">
+          Maximum file size of 80 MB per attachment. You can add multiple files
+          per attachment type except for the CMS Form 179. Read the description
+          for each of the attachment types on the{" "}
+          <Link
+            to="/faq/medicaid-spa-attachments"
+            target={FAQ_TAB}
+            rel="noopener noreferrer"
+            className="text-blue-900 underline"
+          >
+            FAQ Page
+          </Link>
+          .
+        </p>,
+        <AttachmentFileFormatInstructions />,
+      ],
     }}
     documentPollerArgs={{
       property: "id",

--- a/react-app/src/features/forms/post-submission/post-submission-forms.tsx
+++ b/react-app/src/features/forms/post-submission/post-submission-forms.tsx
@@ -16,6 +16,7 @@ import {
   DisableWithdrawRaiForm,
   EnableWithdrawRaiForm,
 } from "./toggle-withdraw-rai";
+import { UploadSubsequentDocuments } from "./upload-subsequent-documents";
 
 // the keys will relate to this part of the route /actions/{key of postSubmissionForms}/authority/id
 export const postSubmissionForms: Record<
@@ -51,6 +52,12 @@ export const postSubmissionForms: Record<
     ["1915(c)"]: DisableWithdrawRaiForm,
     ["Medicaid SPA"]: DisableWithdrawRaiForm,
     ["CHIP SPA"]: DisableWithdrawRaiForm,
+  },
+  "upload-subsequent-documents": {
+    ["1915(b)"]: UploadSubsequentDocuments,
+    ["1915(c)"]: UploadSubsequentDocuments,
+    ["Medicaid SPA"]: UploadSubsequentDocuments,
+    ["CHIP SPA"]: UploadSubsequentDocuments,
   },
 };
 

--- a/react-app/src/features/forms/post-submission/upload-subsequent-documents/index.tsx
+++ b/react-app/src/features/forms/post-submission/upload-subsequent-documents/index.tsx
@@ -4,6 +4,10 @@ import {
   PackageSection,
   SchemaWithEnforcableProps,
 } from "@/components";
+import {
+  AttachmentFAQInstructions,
+  AttachmentFileFormatInstructions,
+} from "@/components/ActionForm/actionForm.components";
 import { formSchemas } from "@/formSchemas";
 import { Navigate, useParams } from "react-router-dom";
 import { z } from "zod";
@@ -100,6 +104,11 @@ export const UploadSubsequentDocuments = () => {
       attachments={{
         title: "Subsequent Medicaid SPA Documents",
         requiredIndicatorForTitle: true,
+        instructions: [
+          <AttachmentFAQInstructions />,
+          <AttachmentFileFormatInstructions />,
+          <p>At least one attachment is required to submit.</p>,
+        ],
       }}
       documentPollerArgs={{
         property: "id",

--- a/react-app/src/features/forms/post-submission/upload-subsequent-documents/index.tsx
+++ b/react-app/src/features/forms/post-submission/upload-subsequent-documents/index.tsx
@@ -1,0 +1,7 @@
+import { useParams } from "react-router-dom";
+
+export const UploadSubsequentDocuments = () => {
+  const { authority, id } = useParams();
+
+  return null;
+};

--- a/react-app/src/features/forms/post-submission/upload-subsequent-documents/index.tsx
+++ b/react-app/src/features/forms/post-submission/upload-subsequent-documents/index.tsx
@@ -1,7 +1,115 @@
-import { useParams } from "react-router-dom";
+import { useGetItem } from "@/api";
+import {
+  ActionForm,
+  PackageSection,
+  SchemaWithEnforcableProps,
+} from "@/components";
+import { formSchemas } from "@/formSchemas";
+import { Navigate, useParams } from "react-router-dom";
+import { z } from "zod";
+
+const pickAttachmentsAndAdditionalInfo = (
+  schema: SchemaWithEnforcableProps,
+  submissionId: string,
+) => {
+  if (schema instanceof z.ZodEffects) {
+    return pickAttachmentsAndAdditionalInfo(schema.innerType(), submissionId);
+  }
+
+  if (schema instanceof z.ZodObject) {
+    const shape = schema._def.shape();
+
+    const optionalAttachmentsShape = Object.fromEntries(
+      Object.entries(shape.attachments.shape).map(([key, value]) => [
+        key,
+        z.object({
+          files: value._def.shape().files.optional(),
+          label: value._def.shape().label,
+        }),
+      ]),
+    );
+
+    return z
+      .object({
+        id: z.string().default(submissionId),
+        event: z
+          .literal("upload-subsequent-documents")
+          .default("upload-subsequent-documents"),
+        attachments: z.object(optionalAttachmentsShape),
+        additionalInformation: z
+          .string()
+          .min(1, { message: "Additional Information is required." })
+          .max(4000)
+          .refine((value) => value.trim().length > 0, {
+            message: "Additional Information can not be only whitespace.",
+          }),
+      })
+      .refine(
+        (data) =>
+          data.attachments &&
+          Object.values(data.attachments).some(
+            (attachment) =>
+              attachment && attachment.files && attachment.files.length > 0,
+          ),
+        {
+          message: "At least one attachment must have files.",
+          path: ["attachments"],
+        },
+      );
+  }
+
+  throw new Error("No attachments property found in schema");
+};
 
 export const UploadSubsequentDocuments = () => {
   const { authority, id } = useParams();
+  const { data: submission } = useGetItem(id);
 
-  return null;
+  if (submission === undefined) {
+    return <Navigate to="/dashboard" />;
+  }
+
+  const originalSubmissionEvent = (submission._source.changelog ?? []).reduce<
+    string | null
+  >((acc, { _source }) => (_source.event ? _source.event : acc), null);
+
+  const schema: SchemaWithEnforcableProps | undefined =
+    formSchemas[originalSubmissionEvent];
+
+  if (schema === undefined) {
+    return <Navigate to="/dashboard" />;
+  }
+
+  const pickedSchema = pickAttachmentsAndAdditionalInfo(schema, submission._id);
+
+  return (
+    <ActionForm
+      title={`Upload Subsequent ${authority} Documentation`}
+      schema={pickedSchema}
+      breadcrumbText="New Subsequent Documentation"
+      fields={PackageSection}
+      promptPreSubmission={{
+        header: "Submit additional documents?",
+        body: "These documents will be added to the package and reviewed by CMS.",
+        acceptButtonText: "Yes, Submit",
+      }}
+      bannerPostSubmission={{
+        header: "Documents submitted",
+        body: "CMS reviewers will follow up by email if additional information is needed",
+      }}
+      attachments={{
+        title: "Subsequent Medicaid SPA Documents",
+        requiredIndicatorForTitle: true,
+      }}
+      documentPollerArgs={{
+        property: "id",
+        documentChecker: (check) => check.recordExists,
+      }}
+      additionalInformation={{
+        required: true,
+        title: "Reason for subsequent documents",
+        label: "Explain why additional documents are being submitted",
+      }}
+    />
+  );
 };

--- a/react-app/src/features/package-actions/renderSlots.tsx
+++ b/react-app/src/features/package-actions/renderSlots.tsx
@@ -2,6 +2,7 @@ import {
   FormDescription,
   FormItem,
   FormLabel,
+  FormMessage,
   RequiredIndicator,
   Textarea,
   Upload,
@@ -85,6 +86,7 @@ export const SlotAdditionalInfo = <
           className="h-[200px] resize-none"
           id="additional-info"
         />
+        <FormMessage />
         <FormDescription>
           <span
             tabIndex={0}

--- a/react-app/src/features/package/package-activity/index.tsx
+++ b/react-app/src/features/package/package-activity/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from "react";
+import { useMemo } from "react";
 import { opensearch } from "shared-types";
 import { format } from "date-fns";
 import {
@@ -12,11 +12,15 @@ import * as Table from "@/components";
 import { BLANK_VALUE } from "@/consts";
 import { usePackageActivities, useAttachmentService } from "./hook";
 
-const AttachmentDetails: FC<{
+const AttachmentDetails = ({
+  id,
+  attachments,
+  hook,
+}: {
   id: string;
   attachments: opensearch.changelog.Document["attachments"];
   hook: ReturnType<typeof useAttachmentService>;
-}> = ({ id, attachments, hook }) => {
+}) => {
   return (
     <Table.TableBody>
       {attachments &&
@@ -42,48 +46,14 @@ const AttachmentDetails: FC<{
   );
 };
 
-// export const PA_AppkParentRemovedChild: FC<opensearch.changelog.Document> = (
-//   props,
-// ) => {
-//   return (
-//     <div className="flex gap-1">
-//       <Link
-//         to={`/details/${props.authority}/${props.appkChildId}`}
-//         className="hover:underline font-semibold text-blue-600"
-//       >
-//         {props.appkChildId}
-//       </Link>
-//       <p>was removed</p>
-//     </div>
-//   );
-// };
+const Submission = (props: opensearch.changelog.Document) => {
+  const attachmentService = useAttachmentService(props);
 
-// export const PA_AppkChildRemovedFromParent: FC<
-//   opensearch.changelog.Document
-// > = (props) => {
-//   return (
-//     <div className="flex gap-1">
-//       <p>Removed from:</p>
-//       <Link
-//         to={`/details/${props.authority}/${props.appkParentId}`}
-//         className="hover:underline font-semibold text-blue-600"
-//       >
-//         {props.appkParentId}
-//       </Link>
-//     </div>
-//   );
-// };
-
-export const PA_InitialSubmission: FC<opensearch.changelog.Document> = (
-  props,
-) => {
-  const hook = useAttachmentService(props);
   return (
     <div className="flex flex-col gap-6">
       <div>
         <h2 className="font-bold text-lg mb-2">Attachments</h2>
-        {!props.attachments?.length && <p>No information submitted</p>}
-        {!!props.attachments?.length && (
+        {props.attachments.length ? (
           <Table.Table>
             <Table.TableHeader>
               <Table.TableRow>
@@ -96,21 +66,24 @@ export const PA_InitialSubmission: FC<opensearch.changelog.Document> = (
             <AttachmentDetails
               attachments={props.attachments}
               id={props.id}
-              hook={hook}
+              hook={attachmentService}
             />
           </Table.Table>
+        ) : (
+          <p>No information submitted</p>
         )}
       </div>
 
-      {props.attachments && props.attachments?.length > 1 && (
+      {props.attachments.length > 1 && (
         <Table.Button
           variant="outline"
           className="w-max"
-          disabled={!props.attachments?.length}
-          loading={hook.loading}
+          disabled={props.attachments.length === 0}
+          loading={attachmentService.loading}
           onClick={() => {
-            if (!props.attachments?.length) return;
-            hook.onZip(props.attachments);
+            if (props.attachments.length !== 0) {
+              attachmentService.onZip(props.attachments);
+            }
           }}
         >
           Download documents
@@ -127,164 +100,9 @@ export const PA_InitialSubmission: FC<opensearch.changelog.Document> = (
   );
 };
 
-export const PA_ResponseSubmitted: FC<opensearch.changelog.Document> = (
-  props,
-) => {
-  const hook = useAttachmentService(props);
-
-  return (
-    <div className="flex flex-col gap-6">
-      <div>
-        <h2 className="font-bold text-lg mb-2">Attachments</h2>
-        {!props.attachments?.length && <p>No information submitted</p>}
-        {!!props.attachments?.length && (
-          <Table.Table>
-            <Table.TableHeader>
-              <Table.TableRow>
-                <Table.TableHead className="w-[300px]">
-                  Document Type
-                </Table.TableHead>
-                <Table.TableHead>Attached File</Table.TableHead>
-              </Table.TableRow>
-            </Table.TableHeader>
-            <AttachmentDetails
-              attachments={props.attachments}
-              id={props.id}
-              hook={hook}
-            />
-          </Table.Table>
-        )}
-      </div>
-
-      {props.attachments && props.attachments?.length > 1 && (
-        <Table.Button
-          variant="outline"
-          className="w-max"
-          disabled={!props.attachments?.length}
-          loading={hook.loading}
-          onClick={() => {
-            if (!props.attachments?.length) return;
-            hook.onZip(props.attachments);
-          }}
-        >
-          Download documents
-        </Table.Button>
-      )}
-
-      <div>
-        <h2 className="font-bold text-lg mb-2">Additional Information</h2>
-        <p>{props.additionalInformation || "No information submitted"}</p>
-      </div>
-    </div>
-  );
-};
-
-export const PA_ResponseWithdrawn: FC<opensearch.changelog.Document> = (
-  props,
-) => {
-  const hook = useAttachmentService(props);
-
-  return (
-    <div className="flex flex-col gap-6">
-      <div>
-        <h2 className="font-bold text-lg mb-2">Attachments</h2>
-        {!props.attachments?.length && <p>No information submitted</p>}
-        {!!props.attachments?.length && (
-          <Table.Table>
-            <Table.TableHeader>
-              <Table.TableRow>
-                <Table.TableHead className="w-[300px]">
-                  Document Type
-                </Table.TableHead>
-                <Table.TableHead>Attached File</Table.TableHead>
-              </Table.TableRow>
-            </Table.TableHeader>
-            <AttachmentDetails
-              attachments={props.attachments}
-              id={props.id}
-              hook={hook}
-            />
-          </Table.Table>
-        )}
-      </div>
-
-      {props.attachments && props.attachments?.length > 1 && (
-        <Table.Button
-          variant="outline"
-          className="w-max"
-          disabled={!props.attachments?.length}
-          loading={hook.loading}
-          onClick={() => {
-            if (!props.attachments?.length) return;
-            hook.onZip(props.attachments);
-          }}
-        >
-          Download documents
-        </Table.Button>
-      )}
-
-      <div>
-        <h2 className="font-bold text-lg mb-2">Additional Information</h2>
-        <p>{props.additionalInformation || "No information submitted"}</p>
-      </div>
-    </div>
-  );
-};
-
-// export const PA_RaiIssued: FC<opensearch.changelog.Document> = (props) => {
-//   const hook = useAttachmentService(props);
-
-//   return (
-//     <div className="flex flex-col gap-6">
-//       <div>
-//         <h2 className="font-bold text-lg mb-2">Attachments</h2>
-//         {!props.attachments?.length && <p>No information submitted</p>}
-//         {!!props.attachments?.length && (
-//           <Table.Table>
-//             <Table.TableHeader>
-//               <Table.TableRow>
-//                 <Table.TableHead className="w-[300px]">
-//                   Document Type
-//                 </Table.TableHead>
-//                 <Table.TableHead>Attached File</Table.TableHead>
-//               </Table.TableRow>
-//             </Table.TableHeader>
-//             <AttachmentDetails
-//               attachments={props.attachments}
-//               id={props.id}
-//               hook={hook}
-//             />
-//           </Table.Table>
-//         )}
-//       </div>
-
-//       {props.attachments && props.attachments?.length > 1 && (
-//         <Table.Button
-//           variant="outline"
-//           className="w-max"
-//           disabled={!props.attachments?.length}
-//           loading={hook.loading}
-//           onClick={() => {
-//             if (!props.attachments?.length) return;
-//             hook.onZip(props.attachments);
-//           }}
-//         >
-//           Download documents
-//         </Table.Button>
-//       )}
-
-//       <div>
-//         <h2 className="font-bold text-lg mb-2">Additional Information</h2>
-//         <p>{props.additionalInformation || "No information submitted"}</p>
-//       </div>
-//     </div>
-//   );
-// };
-
-// Control Map
-export const PackageActivity: FC<opensearch.changelog.Document> = (props) => {
-  const [LABEL, CONTENT] = useMemo(() => {
-    switch (props.event as string) {
+const PackageActivity = (props: opensearch.changelog.Document) => {
+  const label = useMemo(() => {
+    switch (props.event) {
       case "capitated-amendment":
       case "capitated-initial":
       case "capitated-renewal":
@@ -294,48 +112,33 @@ export const PackageActivity: FC<opensearch.changelog.Document> = (props) => {
       case "new-chip-submission":
       case "new-medicaid-submission":
       case "temporary-extension":
-        return ["Initial package submitted", PA_InitialSubmission];
+        return "Initial package submitted";
 
-      // case "withdraw-rai":
-      //   return ["RAI response withdrawn", PA_ResponseWithdrawn];
       case "withdraw-package":
-        return ["Package withdrawn", PA_ResponseWithdrawn];
+        return "Package withdrawn";
       case "withdraw-rai":
-        return ["RAI response withdrawn", PA_ResponseWithdrawn];
-      // case "withdraw-package":
-      //   return ["Package withdrawn", PA_ResponseWithdrawn];
-      // case "issue-rai":
-      //   return ["RAI issued", PA_RaiIssued];
+        return "RAI response withdrawn";
+
       case "respond-to-rai":
-        return ["RAI response submitted", PA_ResponseSubmitted];
-      // case "remove-appk-child": {
-      //   if (props.appkChildId) {
-      //     return [
-      //       `Package removed: ${props.appkChildId}`,
-      //       PA_AppkParentRemovedChild,
-      //     ];
-      //   }
+        return "RAI response submitted";
 
-      //   return [
-      //     `Removed from: ${props.appkParentId}`,
-      //     PA_AppkChildRemovedFromParent,
-      //   ];
-      // }
-      // case "legacy-withdraw-rai-request":
-      //   return ["RAI response withdrawn requested", PA_ResponseWithdrawn];
+      case "upload-subsequent-documents":
+        return "Subsequent documentation uploaded";
 
-      // return needs another parameter
       default:
-        return [BLANK_VALUE];
+        return BLANK_VALUE;
     }
   }, [props.event]);
 
-  if (LABEL === BLANK_VALUE) return null;
+  if (label === BLANK_VALUE) {
+    return null;
+  }
+
   return (
-    <AccordionItem key={props.id} value={props.id}>
+    <AccordionItem value={props.id}>
       <AccordionTrigger className="bg-gray-100 px-3">
         <p className="flex flex-row gap-2 text-gray-600">
-          <strong>{LABEL as string}</strong>
+          <strong>{label}</strong>
           {" - "}
           {props.timestamp
             ? format(new Date(props.timestamp), "eee, MMM d, yyyy hh:mm:ss a")
@@ -343,26 +146,30 @@ export const PackageActivity: FC<opensearch.changelog.Document> = (props) => {
         </p>
       </AccordionTrigger>
       <AccordionContent className="p-4">
-        <CONTENT {...props} />
+        <Submission {...props} />
       </AccordionContent>
     </AccordionItem>
   );
 };
 
 export const PackageActivities = () => {
-  const hook = usePackageActivities();
+  const {
+    data: packageActivity,
+    loading,
+    onDownloadAll,
+    accordianDefault,
+  } = usePackageActivities();
 
   return (
     <DetailsSection
       id="package_activity"
       title={
-        // needed to do this for the download all button
         <div className="flex justify-between">
-          {`Package Activity (${hook.data?.length})`}
-          {!!hook.data?.length && (
+          {`Package Activity (${packageActivity.length})`}
+          {packageActivity.length && (
             <Table.Button
-              loading={hook.loading}
-              onClick={hook.onDownloadAll}
+              loading={loading}
+              onClick={onDownloadAll}
               variant="outline"
             >
               Download all documents
@@ -371,21 +178,22 @@ export const PackageActivities = () => {
         </div>
       }
     >
-      {!hook.data?.length && (
+      {packageActivity.length === 0 && (
         <p className="text-gray-500">No package activity recorded</p>
       )}
+
       <Accordion
-        key={hook.accordianDefault[0]}
         type="multiple"
         className="flex flex-col gap-2"
-        defaultValue={hook.accordianDefault}
+        defaultValue={accordianDefault}
       >
-        {hook.data?.map((CL) => (
-          <PackageActivity {...CL._source} key={CL._source.id} />
+        {packageActivity.map((submission) => (
+          <PackageActivity
+            key={submission._source.id}
+            {...submission._source}
+          />
         ))}
       </Accordion>
     </DetailsSection>
   );
 };
-
-export * from "./hook";

--- a/react-app/src/formSchemas/capitated-amendment.ts
+++ b/react-app/src/formSchemas/capitated-amendment.ts
@@ -26,5 +26,3 @@ export const formSchema = events["capitated-amendment"].baseSchema.extend({
         "According to our records, this 1915(b) Waiver Number is not approved. You must supply an approved 1915(b) Initial or Renewal Waiver Number.",
     }),
 });
-
-// export type Schema = Awaited<ReturnType<typeof transform>>;

--- a/react-app/src/formSchemas/capitated-initial.ts
+++ b/react-app/src/formSchemas/capitated-initial.ts
@@ -13,5 +13,3 @@ export const formSchema = events["capitated-initial"].baseSchema.extend({
         "According to our records, this 1915(b) Waiver Number already exists. Please check the 1915(b) Waiver Number and try entering it again.",
     }),
 });
-
-// export type Schema = Awaited<ReturnType<typeof transform>>;

--- a/react-app/src/formSchemas/capitated-renewal.ts
+++ b/react-app/src/formSchemas/capitated-renewal.ts
@@ -26,5 +26,3 @@ export const formSchema = events["capitated-renewal"].baseSchema.extend({
         "According to our records, this 1915(b) Waiver Number is not approved. You must supply an approved 1915(b) Initial or Renewal Waiver Number.",
     }),
 });
-
-// export type Schema = Awaited<ReturnType<typeof transform>>;

--- a/react-app/src/formSchemas/contracting-amendment.ts
+++ b/react-app/src/formSchemas/contracting-amendment.ts
@@ -26,5 +26,3 @@ export const formSchema = events["contracting-amendment"].baseSchema.extend({
         "According to our records, this 1915(b) Waiver Number is not approved. You must supply an approved 1915(b) Initial or Renewal Waiver Number.",
     }),
 });
-
-// export type Schema = Awaited<ReturnType<typeof transform>>;

--- a/react-app/src/formSchemas/contracting-initial.ts
+++ b/react-app/src/formSchemas/contracting-initial.ts
@@ -13,5 +13,3 @@ export const formSchema = events["contracting-initial"].baseSchema.extend({
         "According to our records, this 1915(b) Waiver Number already exists. Please check the 1915(b) Waiver Number and try entering it again.",
     }),
 });
-
-// export type Schema = Awaited<ReturnType<typeof transform>>;

--- a/react-app/src/formSchemas/contracting-renewal.ts
+++ b/react-app/src/formSchemas/contracting-renewal.ts
@@ -26,5 +26,3 @@ export const formSchema = events["contracting-renewal"].baseSchema.extend({
         "According to our records, this 1915(b) Waiver Number is not approved. You must supply an approved 1915(b) Initial or Renewal Waiver Number.",
     }),
 });
-
-// export type Schema = Awaited<ReturnType<typeof transform>>;

--- a/react-app/src/formSchemas/index.ts
+++ b/react-app/src/formSchemas/index.ts
@@ -5,6 +5,7 @@ import * as contractingInitial from "./contracting-initial";
 import * as contractingAmendment from "./contracting-amendment";
 import * as contractingRenewal from "./contracting-renewal";
 import * as newMedicaidSubmission from "./new-medicaid-submission";
+import * as uploadSubsequentDocuments from "./upload-subsequent-documents";
 import * as newChipSubmission from "./new-chip-submission";
 import * as temporaryExtension from "./temporary-extension";
 import * as withdrawPackage from "./withdraw-package";
@@ -29,4 +30,5 @@ export const formSchemas = {
   "respond-to-rai-chip": respondtoRAI.formSchemaChip,
   "respond-to-rai-waiver": respondtoRAI.formSchemaWaivers,
   "respond-to-rai-medicaid": respondtoRAI.formSchemaMedicaid,
+  "upload-subsequent-documents": uploadSubsequentDocuments.formSchema,
 };

--- a/react-app/src/formSchemas/new-chip-submission.ts
+++ b/react-app/src/formSchemas/new-chip-submission.ts
@@ -12,5 +12,3 @@ export const formSchema = events["new-chip-submission"].baseSchema.extend({
         "According to our records, this SPA ID already exists. Please check the SPA ID and try entering it again.",
     }),
 });
-
-// export type Schema = Awaited<ReturnType<typeof transform>>;

--- a/react-app/src/formSchemas/new-medicaid-submission.ts
+++ b/react-app/src/formSchemas/new-medicaid-submission.ts
@@ -12,5 +12,3 @@ export const formSchema = events["new-medicaid-submission"].baseSchema.extend({
         "According to our records, this SPA ID already exists. Please check the SPA ID and try entering it again.",
     }),
 });
-
-// export type Schema = Awaited<ReturnType<typeof transform>>;

--- a/react-app/src/formSchemas/upload-subsequent-documents.ts
+++ b/react-app/src/formSchemas/upload-subsequent-documents.ts
@@ -1,0 +1,3 @@
+import { events } from "shared-types/events";
+
+export const formSchema = events["upload-subsequent-documents"].baseSchema;

--- a/react-app/src/utils/labelMappers.ts
+++ b/react-app/src/utils/labelMappers.ts
@@ -16,6 +16,8 @@ export const mapActionLabel = (a: Action) => {
       return "Request Temporary Extension";
     case Action.UPDATE_ID:
       return "Update ID";
+    case Action.UPLOAD_SUBSEQUENT_DOCUMENTS:
+      return "Upload Subsequent Documents";
     default:
       return "";
   }


### PR DESCRIPTION
## Purpose

Allow users to upload subsequent documentation to a submission

#### Linked Issues to Close

https://jiraent.cms.gov/browse/OY2-29368

## Approach

- create a new form utilizing `ActionForm`, which finds form schemas based on the event type and extracts the attachments from said schema. 
- due to new requirements, some work was required to adapt `ActionForm`, such as a more flexible `instructions` and `additionalInformation` props.
- add a new action label and determining condition.
- add lambda, transform, and event functions for `upload-subsequent-documents`
