### PR TITLE
feat(tests): utils

### DIFF
--- a/react-app/src/utils/crumbs.test.ts
+++ b/react-app/src/utils/crumbs.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect} from 'vitest';
+import {
+  getDashboardTabForAuthority,
+  detailsAndActionsCrumbs,
+  dashboardCrumb,
+  detailsCrumb,
+  actionCrumb,
+} from './crumbs';
+import { Action } from 'shared-types/actions';
+
+describe('getDashboardTabForAuthority', () => {
+  it('should return "spas" for "CHIP SPA"', () => {
+    const result = getDashboardTabForAuthority("CHIP SPA" as any);
+    expect(result).toBe("spas");
+  });
+
+  it('should return "spas" for "Medicaid SPA"', () => {
+    const result = getDashboardTabForAuthority("Medicaid SPA" as any);
+    expect(result).toBe("spas");
+  });
+
+  it('should return "waivers" for "1915(b)"', () => {
+    const result = getDashboardTabForAuthority("1915(b)" as any);
+    expect(result).toBe("waivers");
+  });
+
+  it('should return "waivers" for "1915(c)"', () => {
+    const result = getDashboardTabForAuthority("1915(c)" as any);
+    expect(result).toBe("waivers");
+  });
+
+  it('should throw an error for an invalid authority', () => {
+    expect(() => getDashboardTabForAuthority("Invalid Authority" as any)).toThrow("Invalid authority");
+  });
+});
+
+describe('detailsAndActionsCrumbs', () => {
+  const id = "12345";
+  const authority = "CHIP SPA" as any;
+
+  it('should return default breadcrumbs without actionType', () => {
+    const expectedBreadcrumbs = [
+      dashboardCrumb(authority),
+      detailsCrumb(id, authority),
+    ];
+    const result = detailsAndActionsCrumbs({ id, authority });
+    expect(result).toEqual(expectedBreadcrumbs);
+  });
+
+  it('should return breadcrumbs including action crumb when actionType is provided', () => {
+    const actionType = Action.RESPOND_TO_RAI;
+    const expectedBreadcrumbs = [
+      dashboardCrumb(authority),
+      detailsCrumb(id, authority),
+      actionCrumb(actionType, id),
+    ];
+    const result = detailsAndActionsCrumbs({ id, authority, actionType });
+    expect(result).toEqual(expectedBreadcrumbs);
+  });
+});
+
+describe('dashboardCrumb', () => {
+  it('should return correct breadcrumb with authority', () => {
+    const result = dashboardCrumb("CHIP SPA" as any);
+    const expected = {
+      displayText: "Dashboard",
+      order: 1,
+      default: true,
+      to: "/dashboard?tab=spas",
+    };
+    expect(result).toEqual(expected);
+  });
+
+  it('should return correct breadcrumb without authority', () => {
+    const result = dashboardCrumb();
+    const expected = {
+      displayText: "Dashboard",
+      order: 1,
+      default: true,
+      to: "/dashboard",
+    };
+    expect(result).toEqual(expected);
+  });
+});
+
+describe('detailsCrumb', () => {
+  it('should return the correct details breadcrumb', () => {
+    const id = "12345";
+    const authority = "CHIP SPA" as any;
+    const result = detailsCrumb(id, authority);
+    const expected = {
+      displayText: id,
+      order: 2,
+      to: `/details/${authority}/${id}`,
+    };
+    expect(result).toEqual(expected);
+  });
+});
+
+describe('actionCrumb', () => {
+  it('should return the correct action breadcrumb', () => {
+    const actionType = Action.RESPOND_TO_RAI;
+    const id = "12345";
+    const result = actionCrumb(actionType, id);
+    const expected = {
+      displayText: "Respond to Formal RAI",
+      order: 3,
+      to: `/actions/${id}/${actionType}`,
+    };
+    expect(result).toEqual(expected);
+  });
+});

--- a/react-app/src/utils/crumbs.test.ts
+++ b/react-app/src/utils/crumbs.test.ts
@@ -9,6 +9,7 @@ import {
 import { Action } from 'shared-types/actions';
 
 describe('getDashboardTabForAuthority', () => {
+   //test for authority  
   it('should return "spas" for "CHIP SPA"', () => {
     const result = getDashboardTabForAuthority("CHIP SPA" as any);
     expect(result).toBe("spas");

--- a/react-app/src/utils/date.ts
+++ b/react-app/src/utils/date.ts
@@ -1,5 +1,0 @@
-export function isISOString(str: string): boolean {
-  // ISO 8601 date format: YYYY-MM-DDTHH:mm:ss.sssZ
-  const isoDatePattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
-  return isoDatePattern.test(str);
-}

--- a/react-app/src/utils/formOrigin.test.ts
+++ b/react-app/src/utils/formOrigin.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { getFormOrigin } from './formOrigin';
+import { Authority } from 'shared-types/authority';
+
+vi.mock('./crumbs', () => ({
+  getDashboardTabForAuthority: vi.fn(() => 'spas'), // Mock return value
+}));
+
+describe('getFormOrigin', () => {
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    originalLocation = window.location;
+
+    const mockLocation = {
+      ...originalLocation,
+      search: '',
+      assign: vi.fn(),
+      reload: vi.fn(),
+      replace: vi.fn(),
+    };
+
+    Object.defineProperty(window, 'location', {
+      value: mockLocation,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    });
+    vi.clearAllMocks(); // Clear mocks after each test
+  });
+
+  it('should return the correct pathname and search for dashboard origin', () => {
+    window.location.search = `?origin=dashboard`;
+
+    const authority = "chip spa" as Authority; // Use string assertion
+
+    const result = getFormOrigin({ authority });
+
+    expect(result).toEqual({
+      pathname: `/dashboard`,
+      search: new URLSearchParams({ tab: 'spas' }).toString(),
+    });
+  // Other tests remain unchanged
+});
+  it('should return the correct pathname for spa submission origin', () => {
+    window.location.search = `?origin=spas`;
+
+    const result = getFormOrigin();
+
+    expect(result).toEqual({
+      pathname: `/dashboard`,
+      search: new URLSearchParams({ tab: 'spas' }).toString(),
+    });
+  });
+
+  it('should return the correct pathname for waiver submission origin', () => {
+    window.location.search = `?origin=waivers`;
+
+    const result = getFormOrigin();
+
+    expect(result).toEqual({
+      pathname: `/dashboard`,
+      search: new URLSearchParams({ tab: 'waivers' }).toString(),
+    });
+  });
+
+  it('should return the default pathname for unknown origin', () => {
+    window.location.search = '';
+
+    const result = getFormOrigin();
+
+    expect(result).toEqual({
+      pathname: `/dashboard`,
+    });
+  });
+});

--- a/react-app/src/utils/index.ts
+++ b/react-app/src/utils/index.ts
@@ -1,5 +1,4 @@
 export * from "./createContextProvider";
-export * from "./date";
 export * from "./stateNames";
 export * from "./textHelpers";
 export * from "./labelMappers";
@@ -7,7 +6,6 @@ export * from "./user";
 export * from "./TestWrapper";
 export * from "./common-types";
 export * from "./crumbs";
-export * from "./date";
 export * from "./labels";
 export * from "./utils";
 export * from "./zod";

--- a/react-app/src/utils/stateName.test.ts
+++ b/react-app/src/utils/stateName.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect} from "vitest";
+import { convertStateAbbrToFullName } from "./stateNames"; 
+
+describe("convertStateAbbrToFullName", () => {
+  it("should return the full state name for a valid abbreviation", () => {
+    expect(convertStateAbbrToFullName("CA")).toBe("California");
+    expect(convertStateAbbrToFullName("NY")).toBe("New York");
+    expect(convertStateAbbrToFullName("TX")).toBe("Texas");
+    expect(convertStateAbbrToFullName("FL")).toBe("Florida");
+  });
+
+  it("should return the input string for an invalid abbreviation", () => {
+    expect(convertStateAbbrToFullName("CAL")).toBe("CAL");
+  });
+
+  it("should handle empty input gracefully", () => {
+    expect(convertStateAbbrToFullName("")).toBe("");
+  });
+});

--- a/react-app/src/utils/textHelpers.test.ts
+++ b/react-app/src/utils/textHelpers.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { removeUnderscoresAndCapitalize, convertCamelCaseToWords } from './textHelpers';
+
+describe('removeUnderscoresAndCapitalize', () => {
+  it('should replace underscores with spaces and capitalize each word', () => {
+    expect(removeUnderscoresAndCapitalize("hello_world")).toBe("Hello World");
+    expect(removeUnderscoresAndCapitalize("remove_this_string")).toBe("Remove This String");
+  });
+
+  it('should remove trailing "s" from the end of the capitalized string', () => {
+    expect(removeUnderscoresAndCapitalize("dogs")).toBe("Dog");
+    expect(removeUnderscoresAndCapitalize("cat_and_dogs")).toBe("Cat And Dog");
+  });
+
+  it('should handle empty strings', () => {
+    expect(removeUnderscoresAndCapitalize("")).toBe("");
+  });
+
+  it('should handle strings without underscores', () => {
+    expect(removeUnderscoresAndCapitalize("hello")).toBe("Hello");
+    expect(removeUnderscoresAndCapitalize("test")).toBe("Test");
+  });
+});
+
+describe('convertCamelCaseToWords', () => {
+  it('should convert camel case to words', () => {
+    expect(convertCamelCaseToWords("helloWorld")).toBe("Hello World");
+    expect(convertCamelCaseToWords("convertCamelCaseToWords")).toBe("Convert Camel Case To Words");
+  });
+
+  it('should handle leading uppercase letters', () => {
+    expect(convertCamelCaseToWords("CamelCase")).toBe("Camel Case");
+    expect(convertCamelCaseToWords("HelloWorld")).toBe("Hello World");
+  });
+
+  it('should handle no camel case', () => {
+    expect(convertCamelCaseToWords("justwords")).toBe("Justwords");
+  });
+});


### PR DESCRIPTION
## Purpose

The importance of testing our code goes without saying. At the time we were moving fast and “breaking” things so to speak, but now in an effort to really mature MAKO and start to prepare for production we would like to improve not only test coverage but also the general stability of our code.

A lot of our newer code has unit tests built in, but that leaves some of the older rough edges to be tested. The fact of the matter is we are still developing against this older cold and in doing so it can be quite flaky. We would like to take the first step and unit test the building blocks to confidently grow the code base into the future.

The following utils should pass unit testing. The complexity is identified in the title of the story.

createContextProvider
crumbs
date (file can be removed)
formOrigin
location
stateNames
textHelpers
utils_

#### Linked Issues to Close

_Links to issue(s) that are closed by this PR. Be sure to use the phrase "Closes #XXX" for each issue, so they automatically close_

## Approach

stateNames (review)
textHelpers (review)
formOrigin (review)
crumbs (review)
date (file was deleted as it could be removed)

## Assorted Notes/Considerations/Learning

createContextProvider (can be removed in the future, doesn't need to be tested according to Brian and Asharon
location (will be removed for it's own ticket)
utils (has unit testing already, doesn't need to be tested)