### PR TITLE
update dashboard search to allow whitespace

### DIFF
--- a/react-app/src/components/SearchForm/index.tsx
+++ b/react-app/src/components/SearchForm/index.tsx
@@ -1,7 +1,7 @@
-import { FC, useEffect, useState } from "react";
 import { useDebounce } from "@/hooks";
-import { XIcon, Loader } from "lucide-react";
 import { motion } from "framer-motion";
+import { Loader, XIcon } from "lucide-react";
+import { FC, useEffect, useState } from "react";
 
 export const SearchForm: FC<{
   handleSearch: (s: string) => void;
@@ -21,9 +21,8 @@ export const SearchForm: FC<{
   };
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const updateText = event.target.value.trim();
+    const updateText = event.target.value;
     setSearchText(updateText);
-    if (!updateText) handleSearch("");
   };
 
   return (


### PR DESCRIPTION
## Purpose

Fixes an issue where the search on the dashboard would not allow a space to be entered in the search field

#### Linked Issues to Close

Closes [OY2-31074](https://jiraent.cms.gov/browse/OY2-31074)

## Approach

There was code that would trim leading and trailing whitespace from the search
