### PR TITLE
feat(ui): Remove MMDL Card Choices in Mako

### DIFF
--- a/react-app/src/components/BreadCrumb/create-breadcrumbs.ts
+++ b/react-app/src/components/BreadCrumb/create-breadcrumbs.ts
@@ -23,11 +23,6 @@ const newSubmissionPageRouteMapper: Record<
     displayText:
       "Medicaid Eligibility, Enrollment, Administration, and Health Homes",
   },
-  "medicaid-abp": {
-    to: "/new-submission/spa/medicaid/landing/medicaid-abp",
-    displayText:
-      "Medicaid Alternative Benefits Plans (ABP), and Medicaid Premiums and Cost Sharing",
-  },
   chip: {
     to: "/new-submission/spa/chip",
     displayText: "CHIP SPA Type",

--- a/react-app/src/features/selection-flow/external-landing/ExternalAppLandingPage.tsx
+++ b/react-app/src/features/selection-flow/external-landing/ExternalAppLandingPage.tsx
@@ -76,41 +76,6 @@ const ExternalAppLandingPage = ({
   );
 };
 
-export const MedicaidABPLandingPage = () => (
-  <ExternalAppLandingPage
-    pageTitle={
-      "Medicaid Alternative Benefits Plans (ABP), and Medicaid Premiums and Cost Sharing"
-    }
-    image={<MMDLLogo />}
-    description={
-      <LandingPageDescription>
-        <p className="mb-4">
-          <b>
-            Medicaid Alternative Benefits Plans (ABP), and Medicaid Premiums and
-            Cost Sharing are managed within the{" "}
-            <a
-              className="text-sky-700 hover:text-sky-800 underline"
-              href={EXTERNAL_APP.MMDL}
-              target="_blank"
-              rel="noreferrer"
-            >
-              Medicaid Model Data Lab (MMDL)
-            </a>
-            .
-          </b>
-        </p>
-        <p>
-          The MMDL system allows states to apply for changes to their State
-          plan, and access report on Medicaid program
-          administration/implementation.
-        </p>
-      </LandingPageDescription>
-    }
-    buttonLabel={"Enter the MMDL system"}
-    buttonLink={EXTERNAL_APP.MMDL}
-  />
-);
-
 export const MedicaidEligibilityLandingPage = () => (
   <ExternalAppLandingPage
     pageTitle={

--- a/react-app/src/features/selection-flow/options.tsx
+++ b/react-app/src/features/selection-flow/options.tsx
@@ -39,12 +39,6 @@ export const MEDICAID_SPA_OPTIONS: OptionData[] = [
     to: "/new-submission/spa/medicaid/landing/medicaid-eligibility",
   },
   {
-    title:
-      "Medicaid Alternative Benefits Plans (ABP), and Medicaid Premiums and Cost Sharing",
-    description: "Redirects to the MMDL submission system",
-    to: "/new-submission/spa/medicaid/landing/medicaid-abp",
-  },
-  {
     title: "All Other Medicaid SPA Submissions",
     description: "Create a new Medicaid State Plan Amendment",
     to: {

--- a/react-app/src/router.tsx
+++ b/react-app/src/router.tsx
@@ -97,10 +97,6 @@ export const router = createBrowserRouter([
         element: <F.ChipSPASubmissionOptions />,
       },
       {
-        path: "/new-submission/spa/medicaid/landing/medicaid-abp",
-        element: <F.MedicaidABPLandingPage />,
-      },
-      {
         path: "/new-submission/spa/medicaid/landing/medicaid-eligibility",
         element: <F.MedicaidEligibilityLandingPage />,
       },

--- a/test/e2e/tests/a11y/index.spec.ts
+++ b/test/e2e/tests/a11y/index.spec.ts
@@ -14,7 +14,6 @@ const staticRoutes = [
   "/new-submission/waiver/b",
   "/new-submission/waiver/b/b4",
   "/new-submission/waiver/b/capitated",
-  "/new-submission/spa/medicaid/landing/medicaid-abp",
   "/new-submission/spa/medicaid/landing/medicaid-eligibility",
   "/new-submission/spa/chip/landing/chip-eligibility",
   "/new-submission/waiver/b/capitated/amendment/create",


### PR DESCRIPTION
## Purpose

All card choices and links that previously redirected users to MMDL for Medicaid ABP, Premiums and Cost Sharing; and CHIP Eligibility submissions are removed. (reference figma)

Verify that users can access all other card choices, and they continue to work as expected. 

## Approach

Given that I am a Developer, When a user navigates to a Medicaid or CHIP SPA in Mako, the card choices that redirect the user to the MMDL system must be removed. 