### PR TITLE
feat(emails): App K Subsequent Submissions State & CMS

### DIFF
--- a/lib/libs/email/content/email-components.tsx
+++ b/lib/libs/email/content/email-components.tsx
@@ -92,6 +92,38 @@ const LoginInstructions = ({
   </ul>
 );
 
+const SubDocHowToAccess = ({
+  appEndpointURL,
+}: {
+  appEndpointURL: string;
+  useThisLink?: boolean;
+}) => (
+  <>
+    <Text style={{ ...styles.text.base, fontWeight: "bold" }}>How to Access:</Text>
+    <ul>
+      <li>
+        <Text style={styles.text.description}>
+          These documents can be found in OneMAC through this link{" "}
+          <Link href={appEndpointURL}>{appEndpointURL}</Link>.
+        </Text>
+      </li>
+      <li>
+        <Text style={styles.text.description}>
+          If you are not already logged in, click “Login” at the top of the page and log in using
+          your Enterprise User Administration (EUA) credentials.
+        </Text>
+      </li>
+
+      <li>
+        <Text style={styles.text.description}>
+          After you logged in, click the submission ID number on the dashboard page to view details.
+        </Text>
+      </li>
+    </ul>
+    <Hr style={styles.divider} />
+  </>
+);
+
 const Divider = () => <Hr style={styles.divider} />;
 
 const DetailsHeading = () => (
@@ -299,6 +331,7 @@ export {
   Textarea,
   EmailNav,
   LoginInstructions,
+  SubDocHowToAccess,
   DetailsHeading,
   Divider,
   Attachments,

--- a/lib/libs/email/content/upload-subsequent-documents/emailTemplates/AppKCMS.tsx
+++ b/lib/libs/email/content/upload-subsequent-documents/emailTemplates/AppKCMS.tsx
@@ -1,23 +1,21 @@
-import { Events } from "shared-types";
-import { CommonEmailVariables } from "shared-types";
-import { Text } from "@react-email/components";
+import { CommonEmailVariables, Events } from "shared-types";
 import {
   PackageDetails,
-  DetailsHeading,
-  Attachments,
   BasicFooter,
+  Attachments,
+  SubDocHowToAccess,
   Divider,
 } from "../../email-components";
 import { BaseEmailTemplate } from "../../email-templates";
 import { styles } from "../../email-styles";
+import { Text } from "@react-email/components";
 
-export const ChipSpaStateEmail = (props: {
+export const AppKCMSEmail = (props: {
   variables: Events["UploadSubsequentDocuments"] & CommonEmailVariables;
 }) => {
   const variables = props.variables;
-  const previewText = `Additional documents submitted for CHIP SPA ${variables.id}`;
-  const heading = `You’ve successfully submitted the following to CMS reviewers for CHIP SPA ${variables.id}`;
-
+  const previewText = `Action required: review new documents for 1915(c) ${variables.id} in OneMAC.`;
+  const heading = `New documents have been submitted for 1915(c) ${variables.id} in OneMAC.`;
   return (
     <BaseEmailTemplate
       previewText={previewText}
@@ -25,21 +23,16 @@ export const ChipSpaStateEmail = (props: {
       applicationEndpointUrl={variables.applicationEndpointUrl}
       footerContent={<BasicFooter />}
     >
-      <DetailsHeading />
       <PackageDetails
         details={{
           "State or territory": variables.territory,
-          Name: variables.submitterName,
-          "Email Address": variables.submitterEmail,
-          "CHIP SPA Package ID": variables.id,
+          "1915(c) Appendix K ID": variables.id,
           Summary: variables.additionalInformation,
         }}
       />
       <Attachments attachments={variables.attachments} />
       <Divider />
-      <Text style={{ ...styles.text.base, marginTop: "16px" }}>
-        If you have questions or did not expect this email, please contact your CPOC.
-      </Text>
+      <SubDocHowToAccess appEndpointURL={variables.applicationEndpointUrl} />
       <Text style={{ ...styles.text.base, marginTop: "16px" }}>Thank you.</Text>
     </BaseEmailTemplate>
   );

--- a/lib/libs/email/content/upload-subsequent-documents/emailTemplates/AppKState.tsx
+++ b/lib/libs/email/content/upload-subsequent-documents/emailTemplates/AppKState.tsx
@@ -11,12 +11,12 @@ import {
 import { BaseEmailTemplate } from "../../email-templates";
 import { styles } from "../../email-styles";
 
-export const ChipSpaStateEmail = (props: {
+export const AppKStateEmail = (props: {
   variables: Events["UploadSubsequentDocuments"] & CommonEmailVariables;
 }) => {
   const variables = props.variables;
-  const previewText = `Additional documents submitted for CHIP SPA ${variables.id}`;
-  const heading = `You’ve successfully submitted the following to CMS reviewers for CHIP SPA ${variables.id}`;
+  const previewText = `Additional documents submitted for 1915(c) ${variables.id}`;
+  const heading = `You’ve successfully submitted the following to CMS reviewers for 1915(c) ${variables.id}`;
 
   return (
     <BaseEmailTemplate
@@ -31,7 +31,7 @@ export const ChipSpaStateEmail = (props: {
           "State or territory": variables.territory,
           Name: variables.submitterName,
           "Email Address": variables.submitterEmail,
-          "CHIP SPA Package ID": variables.id,
+          "1915(c) Appendix K ID": variables.id,
           Summary: variables.additionalInformation,
         }}
       />

--- a/lib/libs/email/content/upload-subsequent-documents/emailTemplates/ChipSpaCMS.tsx
+++ b/lib/libs/email/content/upload-subsequent-documents/emailTemplates/ChipSpaCMS.tsx
@@ -1,5 +1,11 @@
 import { CommonEmailVariables, Events } from "shared-types";
-import { PackageDetails, BasicFooter, Attachments } from "../../email-components";
+import {
+  PackageDetails,
+  BasicFooter,
+  Attachments,
+  SubDocHowToAccess,
+  Divider,
+} from "../../email-components";
 import { BaseEmailTemplate } from "../../email-templates";
 import { styles } from "../../email-styles";
 import { Text } from "@react-email/components";
@@ -25,22 +31,8 @@ export const ChipSpaCMSEmail = (props: {
         }}
       />
       <Attachments attachments={variables.attachments} />
-      <Text style={{ ...styles.text.base, marginTop: "16px", fontWeight: "bold" }}>
-        How to Access:
-      </Text>
-      <Text style={{ ...styles.text.base, marginTop: "16px", marginLeft: "16px" }}>
-        • These documents can be found in OneMAC through this link{" "}
-        <a href={variables.applicationEndpointUrl} target="_blank">
-          {variables.applicationEndpointUrl}
-        </a>
-      </Text>
-      <Text style={{ ...styles.text.base, marginTop: "16px", marginLeft: "16px" }}>
-        • If you are not already logged in, click “Login” at the top of the page and log in using
-        your Enterprise User Administration (EUA) credentials.
-      </Text>
-      <Text style={{ ...styles.text.base, marginTop: "16px", marginLeft: "16px" }}>
-        • After you logged in, click the submission ID number on the dashboard page to view details.
-      </Text>
+      <Divider />
+      <SubDocHowToAccess appEndpointURL={variables.applicationEndpointUrl} />
       <Text style={{ ...styles.text.base, marginTop: "16px" }}>Thank you.</Text>
     </BaseEmailTemplate>
   );

--- a/lib/libs/email/content/upload-subsequent-documents/emailTemplates/index.tsx
+++ b/lib/libs/email/content/upload-subsequent-documents/emailTemplates/index.tsx
@@ -1,2 +1,4 @@
 export { ChipSpaCMSEmail } from "./ChipSpaCMS";
 export { ChipSpaStateEmail } from "./ChipSpaState";
+export { AppKStateEmail } from "./AppKState";
+export { AppKCMSEmail } from "./AppKCMS";

--- a/lib/libs/email/content/upload-subsequent-documents/index.tsx
+++ b/lib/libs/email/content/upload-subsequent-documents/index.tsx
@@ -1,6 +1,6 @@
 import { Events, Authority, EmailAddresses, CommonEmailVariables } from "shared-types";
 import { AuthoritiesWithUserTypesTemplate } from "../..";
-import { ChipSpaCMSEmail, ChipSpaStateEmail } from "./emailTemplates";
+import { ChipSpaCMSEmail, ChipSpaStateEmail, AppKCMSEmail, AppKStateEmail } from "./emailTemplates";
 import { render } from "@react-email/render";
 
 export const uploadSubsequentDocuments: AuthoritiesWithUserTypesTemplate = {
@@ -24,6 +24,32 @@ export const uploadSubsequentDocuments: AuthoritiesWithUserTypesTemplate = {
         to: [`${variables.submitterName} <${variables.submitterEmail}>`],
         subject: `Additional documents submitted for ${variables.actionType + variables.id}`,
         body: await render(<ChipSpaStateEmail variables={variables} />),
+      };
+    },
+  },
+  [Authority["1915c"]]: {
+    cms: async (
+      variables: Events["UploadSubsequentDocuments"] &
+        CommonEmailVariables & { emails: EmailAddresses },
+    ) => {
+      return {
+        to: [
+          ...variables.emails.osgEmail,
+          ...variables.emails.cpocEmail,
+          ...variables.emails.srtEmails,
+        ],
+        subject: `Action required: review new documents for ${variables.actionType + variables.id}`,
+        body: await render(<AppKCMSEmail variables={variables} />),
+      };
+    },
+    state: async (
+      variables: Events["UploadSubsequentDocuments"] &
+        CommonEmailVariables & { emails: EmailAddresses },
+    ) => {
+      return {
+        to: [`${variables.submitterName} <${variables.submitterEmail}>`],
+        subject: `Additional documents submitted for ${variables.actionType + variables.id}`,
+        body: await render(<AppKStateEmail variables={variables} />),
       };
     },
   },

--- a/lib/libs/email/preview/Upload Subsequent Documents/CMS/AppK.tsx
+++ b/lib/libs/email/preview/Upload Subsequent Documents/CMS/AppK.tsx
@@ -1,0 +1,24 @@
+import { AppKCMSEmail } from "../../../content/upload-subsequent-documents/emailTemplates";
+import { emailTemplateValue } from "../../../mock-data/new-submission";
+import * as attachments from "../../../mock-data/attachments";
+const AppKCMSEmailPreview = () => {
+  return (
+    <AppKCMSEmail
+      variables={{
+        ...emailTemplateValue,
+        event: "upload-subsequent-documents",
+        id: "CO-1234.R21.00",
+        authority: "1915(c)",
+        actionType: "Amend",
+        territory: "CO",
+        title: "A Perfect Appendix K Amendment Title",
+        attachments: {
+          appk: attachments.appk,
+          other: attachments.other,
+        },
+      }}
+    />
+  );
+};
+
+export default AppKCMSEmailPreview;

--- a/lib/libs/email/preview/Upload Subsequent Documents/State/AppK.tsx
+++ b/lib/libs/email/preview/Upload Subsequent Documents/State/AppK.tsx
@@ -1,0 +1,24 @@
+import { AppKStateEmail } from "../../../content/upload-subsequent-documents/emailTemplates";
+import { emailTemplateValue } from "../../../mock-data/new-submission";
+import * as attachments from "../../../mock-data/attachments";
+const AppKCMSEmailPreview = () => {
+  return (
+    <AppKStateEmail
+      variables={{
+        ...emailTemplateValue,
+        event: "upload-subsequent-documents",
+        id: "CO-1234.R21.00",
+        authority: "1915(c)",
+        actionType: "Amend",
+        territory: "CO",
+        title: "A Perfect Appendix K Amendment Title",
+        attachments: {
+          appk: attachments.appk,
+          other: attachments.other,
+        },
+      }}
+    />
+  );
+};
+
+export default AppKCMSEmailPreview;


### PR DESCRIPTION
## Purpose
- need to create appK email templates for uploading subsequent documention for both state and cms

#### Linked Issues to Close
https://jiraent.cms.gov/browse/OY2-30799
[Confluence Link](https://confluenceent.cms.gov/display/MACPRO3/Email+Notifications+for+Package+Actions#EmailNotificationsforPackageActions-CMSUsers.21)

### Screenshots
CMS:
<img width="560" alt="Screenshot 2024-12-05 at 4 30 47 PM" src="https://github.com/user-attachments/assets/2e41251b-e0e9-45a9-bbb2-a0d4e357c911">

State:
<img width="594" alt="Screenshot 2024-12-05 at 4 30 34 PM" src="https://github.com/user-attachments/assets/27996dfd-420b-4724-a26f-dceb839b2b21">

## Approach

- added new templates for AppK state & cms
- updated index.tsx file to have subject and recipients to match confluence
- converted some template code to components to be reused
- added minor styling changes across all sub doc templates

## Assorted Notes/Considerations/Learning
- component: `SubDocHowToAccess` should be used for the text "how to access.."
- a line break should be used to break up each section
