### PR TITLE
fix(ui): added subtext to pdf links

### DIFF
--- a/react-app/src/features/faq/content/abpTemplate.tsx
+++ b/react-app/src/features/faq/content/abpTemplate.tsx
@@ -33,11 +33,15 @@ export const ABP_TEMPLATES: Template[] = [
     title: "ABP 3",
     text: "Selection of Benchmark Benefit Package or Benchmark-Equivalent Benefit Package",
     href: abp3PDF,
+    subtext: [
+      "Use only if ABP has an effective date earlier than 1/1/2020 or if only changing the Section 1937 Coverage Option of an ABP implemented before 1/1/2020",
+    ],
   },
   {
     title: "ABP 3.1",
     text: "Selection of Benchmark Benefit or Benchmark-Equivalent Benefit Package",
     href: abp31PDF,
+    subtext: ["Use only for ABPs effective on or after 1/1/2020"],
   },
   {
     title: "ABP 4",


### PR DESCRIPTION
## 🎫 Linked Ticket

https://github.com/Enterprise-CMCS/macpro-mako/pull/887
https://jiraent.cms.gov/browse/OY2-29929

## 💬 Description / Notes

Add links to the FAQ page to the corresponding MMDL template. (reference google drive folder)
Links should be ordered and worded like in the HCD figma
When clicked, the pdf template should open in a new tab

## 🛠 Changes

Given I am a Mako user, When I navigate to the FAQ page, Then I should be able to click the MMDL templates and view the template in a new tab.

Dev Note: The document names use the same title as the question/header on the FAQ page. For example, if the section header is "ABP 1: Alternative Benefit Plan Populations", then document on the google drive named "IG_ABP1_AlternativeBenefitPlanPopulations.doc" should be attached to that FAQ link.

Google Folder with MMDL Templates: https://drive.google.com/drive/folders/1C7LtmhwMoqJnfqfdOKUkhbgZ6W7uSgtt?usp=drive_link

Figma (reference "Final" tab): https://www.figma.com/design/TJcaOKbbiLOaMMV3MQmczT/MMDL-PDFs-into-OneMAC?node-id=329-9126&node-type=canvas&t=SCgkJLxfLZL69cZh-0
