### PR TITLE
feat(withdraw-waiver-confirmation): Add logic to preview withdraw waiver confirmation emails

### DIFF
--- a/lib/libs/email/preview/WithdrawConfirmation/State/Waiver.tsx
+++ b/lib/libs/email/preview/WithdrawConfirmation/State/Waiver.tsx
@@ -1,0 +1,22 @@
+import { WaiverStateEmail } from "lib/libs/email/content/withdrawConfirmation/emailTemplates";
+import { emailTemplateValue } from "lib/libs/email/mock-data/new-submission";
+import * as attachments from "../../../mock-data/attachments";
+
+export default () => {
+  return (
+    <WaiverStateEmail
+      variables={{
+        ...emailTemplateValue,
+        event: "withdraw-package",
+        id: "CO-1234.R21.00",
+        authority: "1915(b)",
+        actionType: "Amend",
+        territory: "CO",
+        attachments: {
+          officialWithdrawalLetter: attachments.withdrawRequest,
+          supportingDocumentation: attachments.supportingDocumentation,
+        },
+      }}
+    />
+  );
+};


### PR DESCRIPTION
## 🎫 Linked Ticket
https://jiraent.cms.gov/browse/OY2-31440


## 💬 Description / Notes
Add logic to preview withdraw waiver confirmation emails for state users. Previous template logic was created by Andie in another ticket.


## 📸 Screenshots / Demo
<img width="735" alt="Screen Shot 2024-12-12 at 10 18 52 AM" src="https://github.com/user-attachments/assets/4072d989-56c5-46c6-b62e-c5e18f09ab72" />

