### PR TITLE
feat(ui): remove ability for state users to view type/subtype

### DIFF
--- a/react-app/src/features/package/package-details/hooks.tsx
+++ b/react-app/src/features/package/package-details/hooks.tsx
@@ -1,4 +1,4 @@
-import { isCmsUser, isStateUser } from "shared-utils";
+import { isCmsUser, isStateUser, formatSeatoolDate } from "shared-utils";
 
 import { OneMacUser } from "@/api/useGetUser";
 import { BLANK_VALUE } from "@/consts";
@@ -8,7 +8,6 @@ import { Authority, opensearch } from "shared-types";
 import { convertStateAbbrToFullName, LABELS } from "@/utils";
 import { format } from "date-fns";
 import { useMemo, useState } from "react";
-import { formatSeatoolDate } from "shared-utils";
 
 export const ReviewTeamList: FC<opensearch.main.Document> = (props) => {
   const [expanded, setExpanded] = useState(false);

--- a/react-app/src/features/package/package-details/hooks.tsx
+++ b/react-app/src/features/package/package-details/hooks.tsx
@@ -1,4 +1,4 @@
-import { isCmsUser } from "shared-utils";
+import { isCmsUser, isStateUser } from "shared-utils";
 
 import { OneMacUser } from "@/api/useGetUser";
 import { BLANK_VALUE } from "@/consts";
@@ -77,8 +77,8 @@ export const recordDetails = (data: opensearch.main.Document): DetailSectionItem
     value: data.types
       ? data.types.map((T) => <p key={T?.SPA_TYPE_ID}>{T?.SPA_TYPE_NAME}</p>)
       : BLANK_VALUE,
-    canView: () => {
-      return !(data.actionType === "Extend");
+    canView: ({ user }) => {
+      return !(data.actionType === "Extend") && isStateUser(user) === false;
     },
   },
   {
@@ -86,8 +86,8 @@ export const recordDetails = (data: opensearch.main.Document): DetailSectionItem
     value: data.subTypes
       ? data.subTypes.map((T) => <p key={T?.TYPE_ID}>{T?.TYPE_NAME}</p>)
       : BLANK_VALUE,
-    canView: () => {
-      return !(data.actionType === "Extend");
+    canView: ({ user }) => {
+      return !(data.actionType === "Extend") && isStateUser(user) === false;
     },
   },
   {

--- a/react-app/src/features/package/package-details/index.tsx
+++ b/react-app/src/features/package/package-details/index.tsx
@@ -21,6 +21,7 @@ export const DetailItemsGrid: FC<{
   containerStyle?: string;
 }> = (props) => {
   const { data: user } = useGetUser();
+
   return (
     <div
       className={cn(
@@ -29,14 +30,14 @@ export const DetailItemsGrid: FC<{
       )}
     >
       {props.displayItems.map(({ label, value, canView }) => {
-        return !canView(user) ? null : (
+        return canView(user) ? (
           <div key={label}>
             <h3 style={{ fontWeight: 700 }}>{label}</h3>
             <div style={{ fontWeight: 400 }} className="py-2">
               {value}
             </div>
           </div>
-        );
+        ) : null;
       })}
     </div>
   );


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[Remove "Type" and "Subtype" fields from the State View on the Package Details Page](https://jiraent.cms.gov/browse/OY2-30981)


## 🛠 Changes

Adjust conditions to prevent `Type`/`Subtype` from being displayed to state users

## 📸 Screenshots / Demo

### Before 
![Screenshot 2024-12-13 at 8 55 56 AM](https://github.com/user-attachments/assets/38797895-9ca2-4473-83d8-47ae648d2874)

### After
![Screenshot 2024-12-13 at 8 55 23 AM](https://github.com/user-attachments/assets/fbd28527-72c9-42c7-8181-b2051143e318)
