### PR TITLE
feat(workspace): allow vars with _ to be excluded from eslint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,46 +11,57 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
-export default tseslint.config(eslint.configs.recommended, ...tseslint.configs.recommended, includeIgnoreFile(gitignorePath), {
-  plugins: {
-    // @ts-expect-error Types mismatch for eslint-plugin-react
-    react,
-    // @ts-expect-error https://github.com/facebook/react/pull/28773#issuecomment-2147149016
-    "react-hooks": fixupPluginRules(eslintReactHooks),
-  },
-  languageOptions: {
-    ecmaVersion: 2020,
-    sourceType: "module",
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  includeIgnoreFile(gitignorePath),
+  {
+    plugins: {
+      // @ts-expect-error Types mismatch for eslint-plugin-react
+      react,
+      // @ts-expect-error https://github.com/facebook/react/pull/28773#issuecomment-2147149016
+      "react-hooks": fixupPluginRules(eslintReactHooks),
+    },
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: "module",
 
-    parserOptions: {
-      ecmaFeatures: {
-        jsx: true,
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
       },
     },
-  },
 
-  settings: {
-    react: {
-      version: "detect",
+    settings: {
+      react: {
+        version: "detect",
+      },
+    },
+
+    rules: {
+      "@typescript-eslint/no-empty-interface": "off",
+      "react/react-in-jsx-scope": "off",
+      "react/jsx-no-useless-fragment": ["error", { allowExpressions: true }],
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          varsIgnorePattern: "^_",
+        },
+      ],
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-non-null-assertion": "off",
+      "@typescript-eslint/ban-ts-comment": [
+        "off",
+        {
+          "ts-ignore": false,
+          "ts-nocheck": false,
+          "ts-check": true,
+          "ts-expect-error": true,
+        },
+      ],
     },
   },
-
-  rules: {
-    "@typescript-eslint/no-empty-interface": "off",
-    "react/react-in-jsx-scope": "off",
-    "react/jsx-no-useless-fragment": ["error", { allowExpressions: true }],
-    "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn",
-    "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-non-null-assertion": "off",
-    "@typescript-eslint/ban-ts-comment": [
-      "off",
-      {
-        "ts-ignore": false,
-        "ts-nocheck": false,
-        "ts-check": true,
-        "ts-expect-error": true,
-      },
-    ],
-  },
-});
+);


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 💬 Description / Notes
Sometimes, it'd be nice to exclude certain properties from destructuring and not use them. This PR adds an exception for variables starting with `_`

## 🛠 Changes

- lint rule change


