### PR TITLE
fix(ui): Replace Response with Letter

### DIFF
--- a/react-app/src/features/faq/content/oneMACFAQContent.tsx
+++ b/react-app/src/features/faq/content/oneMACFAQContent.tsx
@@ -1132,7 +1132,7 @@ export const oneMACFAQContent: FAQContent[] = [
               </thead>
               <tbody>
                 <tr>
-                  <td className="border border-gray-300 px-4 py-2">Waiver RAI Letter*</td>
+                  <td className="border border-gray-300 px-4 py-2">Waiver RAI Response Letter*</td>
                   <td className="border border-gray-300 px-4 py-2">
                     Official response to CMS to support RAI inquiries for the Waiver submission
                   </td>

--- a/react-app/src/features/faq/content/oneMACFAQContent.tsx
+++ b/react-app/src/features/faq/content/oneMACFAQContent.tsx
@@ -1132,7 +1132,7 @@ export const oneMACFAQContent: FAQContent[] = [
               </thead>
               <tbody>
                 <tr>
-                  <td className="border border-gray-300 px-4 py-2">Waiver RAI Response*</td>
+                  <td className="border border-gray-300 px-4 py-2">Waiver RAI Letter*</td>
                   <td className="border border-gray-300 px-4 py-2">
                     Official response to CMS to support RAI inquiries for the Waiver submission
                   </td>


### PR DESCRIPTION

## 🎫 Linked Ticket

https://jiraent.cms.gov/browse/OY2-31827?filter=-1

## 💬 Description / Notes

1. Add the word "Letter" to the "Waiver RAI Response" title on the FAQ page. (reference screenshot)

## 🛠 Changes

Enter the URL and click on FAQ tab.
Expand the section - What are the attachments for a 1915(b) Waiver and 1915(c) Appendix K response to Request for Additional Information (RAI)?
Attachment type displayed as "Waiver RAI Response*" instead of "Waiver RAI Response Letter*".

## 📸 Screenshots / Demo

![image](https://github.com/user-attachments/assets/baa45369-09fc-4e49-beda-fa0049ed64f1)
