### PR TITLE
fix(schema): remove logic for determining next business day for `submissionDate`

### DIFF
--- a/lib/lambda/sinkMainProcessors.test.ts
+++ b/lib/lambda/sinkMainProcessors.test.ts
@@ -115,7 +115,7 @@ describe("insertOneMacRecordsFromKafkaIntoMako", () => {
           statusDate: offsetToUtc(new Date(1732645041526)).toISOString(),
           proposedDate: 1732597200000,
           subject: null,
-          submissionDate: "2024-11-26T00:00:00.000Z",
+          submissionDate: "2024-11-26T18:17:21.526Z",
           submitterEmail: "george@example.com",
           submitterName: "George Harrison",
           initialIntakeNeeded: true,

--- a/lib/packages/shared-types/opensearch/main/transforms/app-k.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/app-k.ts
@@ -1,34 +1,30 @@
 import { events, getStatus, SEATOOL_STATUS } from "shared-types";
-import {
-  getNextBusinessDayTimestamp,
-  seaToolFriendlyTimestamp,
-} from "../../../../shared-utils/seatool-date-helper";
+import { seaToolFriendlyTimestamp } from "../../../../shared-utils/seatool-date-helper";
 
 export const transform = () => {
   return events["app-k"].schema.transform((data) => {
     const { stateStatus, cmsStatus } = getStatus(SEATOOL_STATUS.PENDING);
-    const timestampDate = data.timestamp ? new Date(data.timestamp) : undefined;
+    const timestampDate = new Date(data.timestamp);
     const todayEpoch = seaToolFriendlyTimestamp(timestampDate);
-    const nextBusinessDayEpoch = getNextBusinessDayTimestamp(timestampDate);
 
     return {
       title: data.title,
       additionalInformation: data.additionalInformation,
       authority: data.authority,
-      changedDate: timestampDate?.toISOString() || null,
+      changedDate: timestampDate.toISOString(),
       cmsStatus,
       description: null,
       id: data.id,
-      makoChangedDate: timestampDate?.toISOString() || null,
+      makoChangedDate: timestampDate.toISOString(),
       origin: "OneMAC",
       raiWithdrawEnabled: false, // Set to false for new submissions
       seatoolStatus: SEATOOL_STATUS.PENDING,
       state: data.id?.split("-")?.[0],
       stateStatus,
-      statusDate: new Date(todayEpoch).toISOString() || null,
+      statusDate: new Date(todayEpoch).toISOString(),
       proposedDate: data.proposedEffectiveDate,
       subject: null,
-      submissionDate: new Date(nextBusinessDayEpoch).toISOString() || null,
+      submissionDate: timestampDate.toISOString(),
       submitterEmail: data.submitterEmail,
       submitterName: data.submitterName,
       actionType: data.actionType,

--- a/lib/packages/shared-types/opensearch/main/transforms/capitated-amendment.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/capitated-amendment.ts
@@ -1,34 +1,29 @@
 import { events, getStatus, SEATOOL_STATUS } from "shared-types";
-import {
-  getNextBusinessDayTimestamp,
-  seaToolFriendlyTimestamp,
-} from "../../../../shared-utils/seatool-date-helper";
+import { seaToolFriendlyTimestamp } from "../../../../shared-utils/seatool-date-helper";
 
 export const transform = () => {
-  // any adhoc logic
   return events["capitated-amendment"].schema.transform((data) => {
     const { stateStatus, cmsStatus } = getStatus(SEATOOL_STATUS.PENDING);
-    const timestampDate = data.timestamp ? new Date(data.timestamp) : undefined;
+    const timestampDate = new Date(data.timestamp);
     const todayEpoch = seaToolFriendlyTimestamp(timestampDate);
-    const nextBusinessDayEpoch = getNextBusinessDayTimestamp(timestampDate);
 
     return {
       additionalInformation: data.additionalInformation,
       authority: data.authority,
-      changedDate: timestampDate?.toISOString() || null,
+      changedDate: timestampDate.toISOString(),
       cmsStatus,
       description: null,
       id: data.id,
-      makoChangedDate: timestampDate?.toISOString() || null,
+      makoChangedDate: timestampDate.toISOString(),
       origin: "OneMAC",
       raiWithdrawEnabled: false, // Set to false for new submissions
       seatoolStatus: SEATOOL_STATUS.PENDING,
       state: data.id?.split("-")?.[0],
       stateStatus,
-      statusDate: new Date(todayEpoch).toISOString() || null,
+      statusDate: new Date(todayEpoch).toISOString(),
       proposedDate: data.proposedEffectiveDate, // wish this was proposedEffectiveDate
       subject: null,
-      submissionDate: new Date(nextBusinessDayEpoch).toISOString() || null,
+      submissionDate: timestampDate.toISOString(),
       submitterEmail: data.submitterEmail,
       submitterName: data.submitterName,
       actionType: data.actionType,

--- a/lib/packages/shared-types/opensearch/main/transforms/capitated-initial.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/capitated-initial.ts
@@ -1,34 +1,29 @@
 import { events, getStatus, SEATOOL_STATUS } from "shared-types";
-import {
-  getNextBusinessDayTimestamp,
-  seaToolFriendlyTimestamp,
-} from "../../../../shared-utils/seatool-date-helper";
+import { seaToolFriendlyTimestamp } from "../../../../shared-utils/seatool-date-helper";
 
 export const transform = () => {
-  // any adhoc logic
   return events["capitated-initial"].schema.transform((data) => {
     const { stateStatus, cmsStatus } = getStatus(SEATOOL_STATUS.PENDING);
-    const timestampDate = data.timestamp ? new Date(data.timestamp) : undefined;
+    const timestampDate = new Date(data.timestamp);
     const todayEpoch = seaToolFriendlyTimestamp(timestampDate);
-    const nextBusinessDayEpoch = getNextBusinessDayTimestamp(timestampDate);
 
     return {
       additionalInformation: data.additionalInformation,
       authority: data.authority,
-      changedDate: timestampDate?.toISOString() || null,
+      changedDate: timestampDate.toISOString(),
       cmsStatus,
       description: null,
       id: data.id,
-      makoChangedDate: timestampDate?.toISOString() || null,
+      makoChangedDate: timestampDate.toISOString(),
       origin: "OneMAC",
       raiWithdrawEnabled: false, // Set to false for new submissions
       seatoolStatus: SEATOOL_STATUS.PENDING,
       state: data.id?.split("-")?.[0],
       stateStatus,
-      statusDate: new Date(todayEpoch).toISOString() || null,
+      statusDate: new Date(todayEpoch).toISOString(),
       proposedDate: data.proposedEffectiveDate, // wish this was proposedEffectiveDate
       subject: null,
-      submissionDate: new Date(nextBusinessDayEpoch).toISOString() || null,
+      submissionDate: timestampDate.toISOString(),
       submitterEmail: data.submitterEmail,
       submitterName: data.submitterName,
       actionType: data.actionType,

--- a/lib/packages/shared-types/opensearch/main/transforms/capitated-renewal.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/capitated-renewal.ts
@@ -1,34 +1,29 @@
 import { events, getStatus, SEATOOL_STATUS } from "shared-types";
-import {
-  getNextBusinessDayTimestamp,
-  seaToolFriendlyTimestamp,
-} from "../../../../shared-utils/seatool-date-helper";
+import { seaToolFriendlyTimestamp } from "../../../../shared-utils/seatool-date-helper";
 
 export const transform = () => {
-  // any adhoc logic
   return events["capitated-renewal"].schema.transform((data) => {
     const { stateStatus, cmsStatus } = getStatus(SEATOOL_STATUS.PENDING);
-    const timestampDate = data.timestamp ? new Date(data.timestamp) : undefined;
+    const timestampDate = new Date(data.timestamp);
     const todayEpoch = seaToolFriendlyTimestamp(timestampDate);
-    const nextBusinessDayEpoch = getNextBusinessDayTimestamp(timestampDate);
 
     return {
       additionalInformation: data.additionalInformation,
       authority: data.authority,
-      changedDate: timestampDate?.toISOString() || null,
+      changedDate: timestampDate.toISOString(),
       cmsStatus,
       description: null,
       id: data.id,
-      makoChangedDate: timestampDate?.toISOString() || null,
+      makoChangedDate: timestampDate.toISOString(),
       origin: "OneMAC",
       raiWithdrawEnabled: false, // Set to false for new submissions
       seatoolStatus: SEATOOL_STATUS.PENDING,
       state: data.id?.split("-")?.[0],
       stateStatus,
-      statusDate: new Date(todayEpoch).toISOString() || null,
+      statusDate: new Date(todayEpoch).toISOString(),
       proposedDate: data.proposedEffectiveDate, // wish this was proposedEffectiveDate
       subject: null,
-      submissionDate: new Date(nextBusinessDayEpoch).toISOString() || null,
+      submissionDate: timestampDate.toISOString(),
       submitterEmail: data.submitterEmail,
       submitterName: data.submitterName,
       actionType: data.actionType,

--- a/lib/packages/shared-types/opensearch/main/transforms/contracting-amendment.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/contracting-amendment.ts
@@ -1,34 +1,29 @@
 import { events, getStatus, SEATOOL_STATUS } from "shared-types";
-import {
-  getNextBusinessDayTimestamp,
-  seaToolFriendlyTimestamp,
-} from "../../../../shared-utils/seatool-date-helper";
+import { seaToolFriendlyTimestamp } from "../../../../shared-utils/seatool-date-helper";
 
 export const transform = () => {
-  // any adhoc logic
   return events["contracting-amendment"].schema.transform((data) => {
     const { stateStatus, cmsStatus } = getStatus(SEATOOL_STATUS.PENDING);
-    const timestampDate = data.timestamp ? new Date(data.timestamp) : undefined;
+    const timestampDate = new Date(data.timestamp);
     const todayEpoch = seaToolFriendlyTimestamp(timestampDate);
-    const nextBusinessDayEpoch = getNextBusinessDayTimestamp(timestampDate);
 
     return {
       additionalInformation: data.additionalInformation,
       authority: data.authority,
-      changedDate: timestampDate?.toISOString() || null,
+      changedDate: timestampDate.toISOString(),
       cmsStatus,
       description: null,
       id: data.id,
-      makoChangedDate: timestampDate?.toISOString() || null,
+      makoChangedDate: timestampDate.toISOString(),
       origin: "OneMAC",
       raiWithdrawEnabled: false, // Set to false for new submissions
       seatoolStatus: SEATOOL_STATUS.PENDING,
       state: data.id?.split("-")?.[0],
       stateStatus,
-      statusDate: new Date(todayEpoch).toISOString() || null,
+      statusDate: new Date(todayEpoch).toISOString(),
       proposedDate: data.proposedEffectiveDate, // wish this was proposedEffectiveDate
       subject: null,
-      submissionDate: new Date(nextBusinessDayEpoch).toISOString() || null,
+      submissionDate: timestampDate.toISOString(),
       submitterEmail: data.submitterEmail,
       submitterName: data.submitterName,
       actionType: data.actionType,

--- a/lib/packages/shared-types/opensearch/main/transforms/contracting-initial.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/contracting-initial.ts
@@ -1,34 +1,29 @@
 import { events, getStatus, SEATOOL_STATUS } from "shared-types";
-import {
-  getNextBusinessDayTimestamp,
-  seaToolFriendlyTimestamp,
-} from "../../../../shared-utils/seatool-date-helper";
+import { seaToolFriendlyTimestamp } from "../../../../shared-utils/seatool-date-helper";
 
 export const transform = () => {
-  // any adhoc logic
   return events["contracting-initial"].schema.transform((data) => {
     const { stateStatus, cmsStatus } = getStatus(SEATOOL_STATUS.PENDING);
-    const timestampDate = data.timestamp ? new Date(data.timestamp) : undefined;
+    const timestampDate = new Date(data.timestamp);
     const todayEpoch = seaToolFriendlyTimestamp(timestampDate);
-    const nextBusinessDayEpoch = getNextBusinessDayTimestamp(timestampDate);
 
     return {
       additionalInformation: data.additionalInformation,
       authority: data.authority,
-      changedDate: timestampDate?.toISOString() || null,
+      changedDate: timestampDate.toISOString(),
       cmsStatus,
       description: null,
       id: data.id,
-      makoChangedDate: timestampDate?.toISOString() || null,
+      makoChangedDate: timestampDate.toISOString(),
       origin: "OneMAC",
       raiWithdrawEnabled: false, // Set to false for new submissions
       seatoolStatus: SEATOOL_STATUS.PENDING,
       state: data.id?.split("-")?.[0],
       stateStatus,
-      statusDate: new Date(todayEpoch).toISOString() || null,
+      statusDate: new Date(todayEpoch).toISOString(),
       proposedDate: data.proposedEffectiveDate, // wish this was proposedEffectiveDate
       subject: null,
-      submissionDate: new Date(nextBusinessDayEpoch).toISOString() || null,
+      submissionDate: timestampDate.toISOString(),
       submitterEmail: data.submitterEmail,
       submitterName: data.submitterName,
       actionType: data.actionType,

--- a/lib/packages/shared-types/opensearch/main/transforms/contracting-renewal.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/contracting-renewal.ts
@@ -1,34 +1,29 @@
 import { events, getStatus, SEATOOL_STATUS } from "shared-types";
-import {
-  getNextBusinessDayTimestamp,
-  seaToolFriendlyTimestamp,
-} from "../../../../shared-utils/seatool-date-helper";
+import { seaToolFriendlyTimestamp } from "../../../../shared-utils/seatool-date-helper";
 
 export const transform = () => {
-  // any adhoc logic
   return events["contracting-renewal"].schema.transform((data) => {
     const { stateStatus, cmsStatus } = getStatus(SEATOOL_STATUS.PENDING);
-    const timestampDate = data.timestamp ? new Date(data.timestamp) : undefined;
+    const timestampDate = new Date(data.timestamp);
     const todayEpoch = seaToolFriendlyTimestamp(timestampDate);
-    const nextBusinessDayEpoch = getNextBusinessDayTimestamp(timestampDate);
 
     return {
       additionalInformation: data.additionalInformation,
       authority: data.authority,
-      changedDate: timestampDate?.toISOString() || null,
+      changedDate: timestampDate?.toISOString(),
       cmsStatus,
       description: null,
       id: data.id,
-      makoChangedDate: timestampDate?.toISOString() || null,
+      makoChangedDate: timestampDate?.toISOString(),
       origin: "OneMAC",
       raiWithdrawEnabled: false, // Set to false for new submissions
       seatoolStatus: SEATOOL_STATUS.PENDING,
       state: data.id?.split("-")?.[0],
       stateStatus,
-      statusDate: new Date(todayEpoch).toISOString() || null,
+      statusDate: new Date(todayEpoch).toISOString(),
       proposedDate: data.proposedEffectiveDate, // wish this was proposedEffectiveDate
       subject: null,
-      submissionDate: new Date(nextBusinessDayEpoch).toISOString() || null,
+      submissionDate: timestampDate.toISOString(),
       submitterEmail: data.submitterEmail,
       submitterName: data.submitterName,
       actionType: data.actionType,

--- a/lib/packages/shared-types/opensearch/main/transforms/new-chip-submission.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/new-chip-submission.ts
@@ -1,34 +1,29 @@
 import { events, getStatus, SEATOOL_STATUS } from "shared-types";
-import {
-  getNextBusinessDayTimestamp,
-  seaToolFriendlyTimestamp,
-} from "../../../../shared-utils/seatool-date-helper";
+import { seaToolFriendlyTimestamp } from "../../../../shared-utils/seatool-date-helper";
 
 export const transform = () => {
-  // any adhoc logic
   return events["new-chip-submission"].schema.transform((data) => {
     const { stateStatus, cmsStatus } = getStatus(SEATOOL_STATUS.PENDING);
-    const timestampDate = data.timestamp ? new Date(data.timestamp) : undefined;
+    const timestampDate = new Date(data.timestamp);
     const todayEpoch = seaToolFriendlyTimestamp(timestampDate);
-    const nextBusinessDayEpoch = getNextBusinessDayTimestamp(timestampDate);
 
     return {
       additionalInformation: data.additionalInformation,
       authority: data.authority,
-      changedDate: timestampDate?.toISOString() || null,
+      changedDate: timestampDate.toISOString(),
       cmsStatus,
       description: null,
       id: data.id,
-      makoChangedDate: timestampDate?.toISOString() || null,
+      makoChangedDate: timestampDate.toISOString(),
       origin: "OneMAC",
       raiWithdrawEnabled: false, // Set to false for new submissions
       seatoolStatus: SEATOOL_STATUS.PENDING,
       state: data.id?.split("-")?.[0],
       stateStatus,
-      statusDate: new Date(todayEpoch).toISOString() || null,
+      statusDate: new Date(todayEpoch).toISOString(),
       proposedDate: data.proposedEffectiveDate, // wish this was proposedEffectiveDate
       subject: null,
-      submissionDate: new Date(nextBusinessDayEpoch).toISOString() || null,
+      submissionDate: timestampDate.toISOString(),
       submitterEmail: data.submitterEmail,
       submitterName: data.submitterName,
       actionType: data.actionType,

--- a/lib/packages/shared-types/opensearch/main/transforms/new-medicaid-submission.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/new-medicaid-submission.ts
@@ -1,34 +1,29 @@
 import { events, getStatus, SEATOOL_STATUS } from "shared-types";
-import {
-  getNextBusinessDayTimestamp,
-  seaToolFriendlyTimestamp,
-} from "../../../../shared-utils/seatool-date-helper";
+import { seaToolFriendlyTimestamp } from "../../../../shared-utils/seatool-date-helper";
 
 export const transform = () => {
-  // any adhoc logic
   return events["new-medicaid-submission"].schema.transform((data) => {
     const { stateStatus, cmsStatus } = getStatus(SEATOOL_STATUS.PENDING);
-    const timestampDate = data.timestamp ? new Date(data.timestamp) : undefined;
+    const timestampDate = new Date(data.timestamp);
     const todayEpoch = seaToolFriendlyTimestamp(timestampDate);
-    const nextBusinessDayEpoch = getNextBusinessDayTimestamp(timestampDate);
 
     return {
       additionalInformation: data.additionalInformation,
       authority: data.authority,
-      changedDate: timestampDate?.toISOString() || null,
+      changedDate: timestampDate.toISOString(),
       cmsStatus,
       description: null,
       id: data.id,
-      makoChangedDate: timestampDate?.toISOString() || null,
+      makoChangedDate: timestampDate.toISOString(),
       origin: "OneMAC",
       raiWithdrawEnabled: false, // Set to false for new submissions
       seatoolStatus: SEATOOL_STATUS.PENDING,
       state: data.id?.split("-")?.[0],
       stateStatus,
-      statusDate: new Date(todayEpoch).toISOString() || null,
+      statusDate: new Date(todayEpoch).toISOString(),
       proposedDate: data.proposedEffectiveDate, // wish this was proposedEffectiveDate
       subject: null,
-      submissionDate: new Date(nextBusinessDayEpoch).toISOString() || null,
+      submissionDate: timestampDate.toISOString(),
       submitterEmail: data.submitterEmail,
       submitterName: data.submitterName,
       initialIntakeNeeded: true,

--- a/lib/packages/shared-types/opensearch/main/transforms/temporary-extension.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/temporary-extension.ts
@@ -1,33 +1,28 @@
 import { events, SEATOOL_STATUS } from "shared-types";
-import {
-  getNextBusinessDayTimestamp,
-  seaToolFriendlyTimestamp,
-} from "../../../../shared-utils/seatool-date-helper";
+import { seaToolFriendlyTimestamp } from "../../../../shared-utils/seatool-date-helper";
 
 export const transform = () => {
-  // any adhoc logic
   return events["temporary-extension"].schema.transform((data) => {
-    const timestampDate = data.timestamp ? new Date(data.timestamp) : undefined;
+    const timestampDate = new Date(data.timestamp);
     const todayEpoch = seaToolFriendlyTimestamp(timestampDate);
-    const nextBusinessDayEpoch = getNextBusinessDayTimestamp(timestampDate);
 
     return {
       additionalInformation: data.additionalInformation,
       authority: data.authority,
-      changedDate: timestampDate?.toISOString() || null,
+      changedDate: timestampDate?.toISOString(),
       cmsStatus: "Requested",
       description: null,
       id: data.id,
-      makoChangedDate: timestampDate?.toISOString() || null,
+      makoChangedDate: timestampDate?.toISOString(),
       origin: "OneMAC",
       originalWaiverNumber: data.waiverNumber,
       raiWithdrawEnabled: false, // Set to false for new submissions
       seatoolStatus: SEATOOL_STATUS.PENDING,
       state: data.id?.split("-")?.[0],
       stateStatus: "Submitted",
-      statusDate: new Date(todayEpoch).toISOString() || null,
+      statusDate: new Date(todayEpoch).toISOString(),
       subject: null,
-      submissionDate: new Date(nextBusinessDayEpoch).toISOString() || null,
+      submissionDate: timestampDate.toISOString(),
       submitterEmail: data.submitterEmail,
       submitterName: data.submitterName,
       actionType: data.actionType,


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[OY2-31064](https://jiraent.cms.gov/browse/OY2-31064)

## 💬 Description / Notes

<!-- Briefly describe the background of the issue -->
<!-- If you feel the original ticket lacks important details, this would be the place to share them -->

With bidirectional Seatool no longer a concern, this PR removes the logic determining the intial submission date, which maintained consistency 

## 🛠 Changes

<!-- List your code changes made to implement the solution -->

- remove the `nextBusinessDayEpoch` variable and adjust conditional logic 

