### PR TITLE
fix(lambda): ignore `null` values for Proposed Effective Date

### DIFF
--- a/lib/lambda/sinkMainProcessors.test.ts
+++ b/lib/lambda/sinkMainProcessors.test.ts
@@ -445,7 +445,7 @@ describe("insertNewSeatoolRecordsFromKafkaIntoMako", () => {
           leadAnalystName: "Michael Chen",
           leadAnalystOfficerId: 67890,
           locked: false,
-          proposedDate: null,
+          proposedDate: undefined,
           raiReceivedDate: null,
           raiRequestedDate: null,
           raiWithdrawEnabled: false,

--- a/lib/packages/shared-types/opensearch/main/transforms/seatool.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/seatool.ts
@@ -72,6 +72,7 @@ const getRaiDate = (data: SeaTool) => {
 };
 
 const getDateStringOrNullFromEpoc = (epocDate: number | null | undefined) =>
+  // `undefined` fallback value is ignored by opensearch and doesn't overwrite the existing record value
   epocDate !== null && epocDate !== undefined ? new Date(epocDate).toISOString() : undefined;
 
 const compileSrtList = (

--- a/lib/packages/shared-types/opensearch/main/transforms/seatool.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/seatool.ts
@@ -72,7 +72,7 @@ const getRaiDate = (data: SeaTool) => {
 };
 
 const getDateStringOrNullFromEpoc = (epocDate: number | null | undefined) =>
-  epocDate !== null && epocDate !== undefined ? new Date(epocDate).toISOString() : null;
+  epocDate !== null && epocDate !== undefined ? new Date(epocDate).toISOString() : undefined;
 
 const compileSrtList = (
   officers: SeatoolOfficer[] | null | undefined,


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[OY2-32025)](https://jiraent.cms.gov/browse/OY2-32025)

## 💬 Description / Notes

<!-- Briefly describe the background of the issue -->
<!-- If you feel the original ticket lacks important details, this would be the place to share them -->

In OpenSearch, setting a value to null removes the corresponding field from the document. We previously used null as a fallback for the proposedEffectiveDate, which unintentionally overwrote the existing value by removing the field.

To prevent this, we leveraged OpenSearch’s behavior of ignoring undefined values. By using undefined as the fallback, the field remains untouched in the document.

While this solution works, I consider it a bit of a hack that lacks clarity for future maintainers. To make the intent more explicit, I left a comment in the code. However, I believe a better approach would be to omit the field entirely if proposedEffectiveDate is null.

## 🛠 Changes

<!-- List your code changes made to implement the solution -->

- fallback value for function determining proposed effective date is now `undefined`
