### PR TITLE
fix(login): Redirect after login based on user roles 2

### DIFF
--- a/react-app/src/features/dashboard/index.tsx
+++ b/react-app/src/features/dashboard/index.tsx
@@ -3,6 +3,8 @@ import { Plus as PlusIcon } from "lucide-react";
 import { getUser, useGetUser } from "@/api";
 import { WaiversList } from "./Lists/waivers";
 import { SpasList } from "./Lists/spas";
+import { UserRoles } from "shared-types";
+
 import {
   OsProvider,
   type OsTab,
@@ -40,7 +42,11 @@ export const Dashboard = () => {
   const { data: userObj } = useGetUser();
   const osData = useOsData();
 
-  if (userObj === undefined) {
+  if (
+    userObj === undefined ||
+    (userObj.user["custom:cms-roles"] &&
+      !Object.values(UserRoles).some((role) => userObj.user["custom:cms-roles"].includes(role)))
+  ) {
     return <Navigate to="/" />;
   }
 


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->
[OY2-32210](https://jiraent.cms.gov/browse/OY2-32210)

## 💬 Description / Notes

Users with no appropriate roles were being redirected to the dashboard after login, however, the dashboard page should only accessible to users with appropriate roles. Users without these roles should be redirected to the homepage.

## 🛠 Changes

If a user logs in and doesn't have the appropriate roles, the user will be redirected to the home page instead of the dashboard.

## 📸 Screenshots / Demo

<!-- ### Before -->

<!-- ### After -->
