### PR TITLE
fix(cloudwatch-role): allow log group creation for firehose role

### DIFF
--- a/lib/local-constructs/cloudwatch-to-s3/index.test.ts
+++ b/lib/local-constructs/cloudwatch-to-s3/index.test.ts
@@ -48,7 +48,7 @@ describe("CloudWatchToS3", () => {
           resources: [`${bucket.bucketArn}/*`],
         }),
         expect.objectContaining({
-          actions: ["logs:PutLogEvents"],
+          actions: ["logs:PutLogEvents", "logs:CreateLogGroup"],
           resources: [
             `arn:aws:logs:${cdk.Stack.of(cloudWatchToS3).region}:${
               cdk.Stack.of(cloudWatchToS3).account

--- a/lib/local-constructs/cloudwatch-to-s3/index.ts
+++ b/lib/local-constructs/cloudwatch-to-s3/index.ts
@@ -35,7 +35,7 @@ export class CloudWatchToS3 extends Construct {
 
     firehoseRole.addToPolicy(
       new PolicyStatement({
-        actions: ["logs:PutLogEvents"],
+        actions: ["logs:PutLogEvents", "logs:CreateLogGroup"],
         resources: [
           `arn:aws:logs:${cdk.Stack.of(this).region}:${
             cdk.Stack.of(this).account


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[Ticket to close](https://jiraent.cms.gov/browse/OY2-32301)

## 💬 Description / Notes
The log says there was an explicit deny rule for log creation.
I created an explicit allow on the cloudwatch resource policy

<!-- Briefly describe the background of the issue -->
<!-- If you feel the original ticket lacks important details, this would be the place to share them -->

## 🛠 Changes

<!-- List your code changes made to implement the solution -->

## 📸 Screenshots / Demo

<!-- ### Before -->

<!-- ### After -->
