### PR TITLE
fix(ui): hide errors for individual files when uploading subsequent docs

### DIFF
--- a/react-app/src/components/ActionForm/index.tsx
+++ b/react-app/src/components/ActionForm/index.tsx
@@ -39,7 +39,7 @@ type EnforceSchemaProps<Shape extends z.ZodRawShape> = z.ZodObject<
     attachments?: z.ZodObject<{
       [Key in keyof Shape]: z.ZodObject<{
         label: z.ZodDefault<z.ZodString>;
-        files: z.ZodTypeAny;
+        files: z.ZodArray<z.ZodTypeAny, "many"> | z.ZodOptional<z.ZodArray<z.ZodTypeAny, "many">>;
       }>;
     }>;
   },

--- a/react-app/src/features/forms/post-submission/upload-subsequent-documents/index.tsx
+++ b/react-app/src/features/forms/post-submission/upload-subsequent-documents/index.tsx
@@ -26,13 +26,18 @@ const pickAttachmentsAndAdditionalInfo = (
     const shape = schema._def.shape();
 
     const optionalAttachmentsShape = Object.fromEntries(
-      Object.entries(shape.attachments.shape).map(([key, value]) => [
-        key,
-        z.object({
-          files: value._def.shape().files.optional(),
-          label: value._def.shape().label,
-        }),
-      ]),
+      Object.entries(shape.attachments.shape).map(([key, value]) => {
+        const files = value._def.shape().files;
+        const filesArray = files instanceof z.ZodArray ? files : files.unwrap();
+
+        return [
+          key,
+          z.object({
+            files: z.array(filesArray.element).optional(),
+            label: value._def.shape().label,
+          }),
+        ];
+      }),
     );
 
     return z


### PR DESCRIPTION


<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[OY2-32247](https://jiraent.cms.gov/browse/OY2-32247)

## 💬 Description / Notes

We needed to overwrite the previous schema with an optional value to hide the schema's attachments property's respective errors. This also meant the `files` property needed an update allowing us to access those properties in a type-safe way.

## 🛠 Changes

- some fancy zod manipulation

## 📸 Screenshots / Demo


https://github.com/user-attachments/assets/ca45dfd8-f93e-4d64-8e9b-63d47b1ec280

