### PR TITLE
feat(lamdba): add admin function for NOSO 2

### DIFF
--- a/lib/lambda/sinkChangelog.ts
+++ b/lib/lambda/sinkChangelog.ts
@@ -6,6 +6,7 @@ import {
   transformUpdateValuesSchema,
   transformDeleteSchema,
   transformedUpdateIdSchema,
+  transformSubmitValuesSchema,
 } from "./update/adminChangeSchemas";
 import { getPackageChangelog } from "libs/api/package";
 
@@ -67,7 +68,9 @@ const processAndIndex = async ({
       // query all changelog entries for this ID and create copies of all entries with new ID
       if (record.isAdminChange) {
         const schema = transformDeleteSchema(offset).or(
-          transformUpdateValuesSchema(offset).or(transformedUpdateIdSchema),
+          transformUpdateValuesSchema(offset)
+            .or(transformedUpdateIdSchema)
+            .or(transformSubmitValuesSchema),
         );
 
         const result = schema.safeParse(record);

--- a/lib/lambda/sinkMainProcessors.ts
+++ b/lib/lambda/sinkMainProcessors.ts
@@ -7,12 +7,14 @@ import {
   deleteAdminChangeSchema,
   updateValuesAdminChangeSchema,
   updateIdAdminChangeSchema,
+  submitNOSOAdminSchema,
 } from "./update/adminChangeSchemas";
 
 const removeDoubleQuotesSurroundingString = (str: string) => str.replace(/^"|"$/g, "");
 const adminRecordSchema = deleteAdminChangeSchema
   .or(updateValuesAdminChangeSchema)
-  .or(updateIdAdminChangeSchema);
+  .or(updateIdAdminChangeSchema)
+  .or(submitNOSOAdminSchema);
 
 type OneMacRecord = {
   id: string;

--- a/lib/lambda/update/adminChangeSchemas.ts
+++ b/lib/lambda/update/adminChangeSchemas.ts
@@ -48,3 +48,23 @@ export const transformedUpdateIdSchema = updateIdAdminChangeSchema.transform((da
   id: `${data.id}`,
   timestamp: Date.now(),
 }));
+
+export const submitNOSOAdminSchema = z
+  .object({
+    id: z.string(),
+    authority: z.string(),
+    status: z.string(),
+    submitterEmail: z.string(),
+    submitterName: z.string(),
+    adminChangeType: z.literal("NOSO"),
+  })
+  .and(z.record(z.string(), z.any()));
+
+export const transformSubmitValuesSchema = submitNOSOAdminSchema.transform((data) => ({
+  ...data,
+  adminChangeType: "NOSO",
+  event: "NOSO",
+  id: data.packageId,
+  packageId: data.packageId,
+  timestamp: Date.now(),
+}));

--- a/lib/lambda/update/submitNOSO.ts
+++ b/lib/lambda/update/submitNOSO.ts
@@ -1,0 +1,125 @@
+// JSON
+// {
+//   "_source": {
+//     "additionalInformation": "hello",
+//     "authority": "Medicaid SPA",
+//     "changedDate": "2025-01-23T20:08:06.742Z",
+//     "cmsStatus": "Submitted - Intake Needed",
+//     "description": null,
+//     "id": "OH-96-1234-ANDI",
+//     "makoChangedDate": "2025-01-23T20:08:06.742Z",
+//     "origin": "OneMAC",
+//     "raiWithdrawEnabled": false,
+//     "seatoolStatus": "Submitted",
+//     "state": "OH",
+//     "stateStatus": "Submitted",
+//     "statusDate": "2025-01-23T20:08:06.742Z",
+//     "proposedDate": 1738303200000,
+//     "subject": null,
+//     "submissionDate": "2025-01-23T20:08:06.742Z",
+//     "submitterEmail": "george@example.com",
+//     "submitterName": "George Harrison",
+//     "initialIntakeNeeded": true
+//   },
+//
+
+import { response } from "libs/handler-lib";
+import { APIGatewayEvent } from "aws-lambda";
+import { produceMessage } from "libs/api/kafka";
+import { getPackage } from "libs/api/package";
+import { ItemResult } from "shared-types/opensearch/main";
+import { submitNOSOAdminSchema } from "./adminChangeSchemas";
+
+import { getStatus } from "shared-types";
+
+interface submitMessageType {
+  id: string;
+  authority: string;
+  status: string;
+  submitterEmail: string;
+  submitterName: string;
+  adminChangeType: string;
+  stateStatus: string;
+  cmsStatus: string;
+}
+
+const sendSubmitMessage = async (item: submitMessageType) => {
+  const topicName = process.env.topicName as string;
+  if (!topicName) {
+    throw new Error("Topic name is not defined");
+  }
+  console.log("sending the follwing message...");
+  console.log("package data: ", JSON.stringify(item));
+
+  await produceMessage(
+    topicName,
+    item.id,
+    JSON.stringify({
+      ...item,
+      packageId: item.id,
+      origin: "SEATool",
+      isAdminChange: true,
+      adminChangeType: "NOSO",
+      description: null,
+      event: "NOSO",
+      state: item.id.substring(0, 2),
+      makoChangedDate: Date.now(),
+      changedDate: Date.now(),
+      statusDate: Date.now(),
+      changeMade: `${item.id} added to OneMAC. Package not originally submitted in OneMAC. At this time, the attachments for this package are unavailable in this system. Contact your CPOC to verify the initial submission documents.`,
+      changeReason: `This is a Not Originally Submitted in OneMAC (NOSO) that users need to see in OneMAC.`,
+    }),
+  );
+
+  return response({
+    statusCode: 200,
+    body: { message: `${item.id} has been submitted.` },
+  });
+};
+
+export const handler = async (event: APIGatewayEvent) => {
+  if (!event.body) {
+    return response({
+      statusCode: 400,
+      body: { message: "Event body required" },
+    });
+  }
+  try {
+    console.log("trying to submit a NOSO...");
+    // add a property for new ID
+    const item = submitNOSOAdminSchema.parse(
+      event.body === "string" ? JSON.parse(event.body) : event.body,
+    );
+
+    const { stateStatus, cmsStatus } = getStatus(item.status);
+    // check if it already exsists
+    const currentPackage: ItemResult | undefined = await getPackage(item.id);
+
+    console.log("checking package already exists...");
+
+    // currentpackage should have been entered in seaTool
+    if (currentPackage && currentPackage.found == true) {
+      return response({
+        statusCode: 400,
+        body: { message: `Package with id: ${item.id} already exists.` },
+      });
+    }
+
+    if (item.adminChangeType === "NOSO") {
+      console.log("attempting to send submit message...");
+      // copying over attachments is handled in sinkChangeLog
+      return await sendSubmitMessage({ ...item, stateStatus, cmsStatus });
+    }
+
+    return response({
+      statusCode: 400,
+      body: { message: "Could not create OneMAC package." },
+    });
+  } catch (err) {
+    console.error("Error has occured submitting package:", err);
+    return response({
+      statusCode: 500,
+      body: { message: err.message || "Internal Server Error" },
+    });
+  }
+};

--- a/lib/packages/shared-types/opensearch/changelog/index.ts
+++ b/lib/packages/shared-types/opensearch/changelog/index.ts
@@ -82,7 +82,8 @@ export type Document = Omit<AppkDocument, "event"> &
       | "withdraw-rai"
       | "update-values"
       | "update-id"
-      | "delete";
+      | "delete"
+      | "NOSO";
   };
 
 export type Response = Res<Document>;

--- a/lib/stacks/api.ts
+++ b/lib/stacks/api.ts
@@ -282,6 +282,18 @@ export class Api extends cdk.NestedStack {
           indexNamespace,
         },
       },
+      {
+        id: "submitNOSO",
+        entry: join(__dirname, "../lambda/update/submitNOSO.ts"),
+        environment: {
+          dbInfoSecretName,
+          topicName,
+          brokerString,
+          osDomain: `https://${openSearchDomainEndpoint}`,
+          indexNamespace,
+        },
+        provisionedConcurrency: 2,
+      },
     ];
 
     const lambdas = lambdaDefinitions.reduce(

--- a/react-app/src/features/package/admin-changes/index.tsx
+++ b/react-app/src/features/package/admin-changes/index.tsx
@@ -59,12 +59,13 @@ export const AdminChange: FC<opensearch.changelog.Document> = (props) => {
         }
         return ["Disable Formal RAI Response Withdraw", AC_WithdrawDisabled];
       }
+      case "NOSO":
       case "legacy-admin-change":
         return [props.changeType || "Manual Update", AC_LegacyAdminChange];
       default:
         return [BLANK_VALUE, AC_Update];
     }
-  }, [props.actionType, props.changeType]);
+  }, [props.event, props.changeType, props.raiWithdrawEnabled]);
 
   return (
     <AccordionItem key={props.id} value={props.id}>


### PR DESCRIPTION
# ❌ NOT READY ❌ 

<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

[OY2-31182](https://jiraent.cms.gov/browse/OY2-31182)

## 💬 Description / Notes
Need to add the ability for an admin to run a lamdba for NOSOs to move over to mako

### Submit NOSO 
1. In lamdba functions go to mako-<branch>-api-submitNOSO
2. Click Test and JSON should be formated like:
`
{
  "body": {
    "id": "OH-96-0006",
    "authority": "Medicaid SPA",
    "status": "Submitted",
    "submitterEmail": "george@example.com",
    "submitterName": "George Harrison",
    "adminChangeType": "NOSO"
  }
}
`

## 🛠 Changes
added an admin function for creating a new submissions for NOSOs
- move change admin functions to their own folder 
- followed similar structure used for admin updatePackage 

## 📸 Screenshots / Demo

Running the lamdba function
<img width="1280" alt="Screenshot 2025-01-23 at 7 59 59 PM" src="https://github.com/user-attachments/assets/5ca2d5d9-f880-48b5-8aba-ec04eb492a3e" />

How the new package appears on dash
<img width="1297" alt="Screenshot 2025-01-23 at 7 58 25 PM" src="https://github.com/user-attachments/assets/c1fd4a29-bb39-4de6-9357-cf4a99a37039" />

How the package appears on package details
<img width="922" alt="Screenshot 2025-01-23 at 7 58 42 PM" src="https://github.com/user-attachments/assets/218a3713-e1ff-49ce-aa3f-b1836b0eeebc" />

<img width="652" alt="Screenshot 2025-01-23 at 7 58 49 PM" src="https://github.com/user-attachments/assets/12fc7ba8-427f-45b1-a28f-69611828efae" />
