### PR TITLE
fix(mocks): Edit SPA mock item ID format

### DIFF
--- a/lib/lambda/search.test.ts
+++ b/lib/lambda/search.test.ts
@@ -29,7 +29,7 @@ describe("getSearchData Handler", () => {
     const body = JSON.parse(res.body);
     expect(body).toBeTruthy();
     expect(body?.hits?.hits).toBeTruthy();
-    expect(body?.hits?.hits?.length).toEqual(16);
+    expect(body?.hits?.hits?.length).toEqual(17);
   });
 
   it("should handle errors during processing", async () => {

--- a/mocks/data/items.ts
+++ b/mocks/data/items.ts
@@ -12,6 +12,7 @@ export const EXISTING_ITEM_ID = "MD-00-0000";
 export const NOT_FOUND_ITEM_ID = "MD-0004.R00.00";
 export const NOT_EXISTING_ITEM_ID = "MD-11-0000";
 export const TEST_ITEM_ID = "MD-0005.R01.00";
+export const TEST_SPA_ITEM_ID = "MD-11-2020";
 export const EXISTING_ITEM_TEMPORARY_EXTENSION_ID = "MD-0005.R01.TE00";
 export const HI_TEST_ITEM_ID = "HI-0000.R00.00";
 export const CAPITATED_INITIAL_ITEM_ID = "SS-2234.R00.00";
@@ -151,6 +152,29 @@ const items: Record<string, TestItemResult> = {
             id: `${TEST_ITEM_ID}-0001`,
             event: "new-medicaid-submission",
             packageId: TEST_ITEM_ID,
+          },
+        },
+      ],
+      authority: "Medicaid SPA",
+    },
+  },
+  [TEST_SPA_ITEM_ID]: {
+    _id: TEST_SPA_ITEM_ID,
+    found: true,
+    _source: {
+      id: TEST_SPA_ITEM_ID,
+      seatoolStatus: SEATOOL_STATUS.APPROVED,
+      actionType: "New",
+      state: "MD",
+      origin: "OneMAC",
+      changedDate: "2024-11-26T18:17:21.557Z",
+      changelog: [
+        {
+          _id: `${TEST_SPA_ITEM_ID}-001`,
+          _source: {
+            id: `${TEST_SPA_ITEM_ID}-0001`,
+            event: "new-medicaid-submission",
+            packageId: TEST_SPA_ITEM_ID,
           },
         },
       ],

--- a/mocks/data/items.ts
+++ b/mocks/data/items.ts
@@ -155,7 +155,7 @@ const items: Record<string, TestItemResult> = {
           },
         },
       ],
-      authority: "Medicaid SPA",
+      authority: "1915(c)",
     },
   },
   [TEST_SPA_ITEM_ID]: {
@@ -525,7 +525,7 @@ const items: Record<string, TestItemResult> = {
   },
 };
 
-export const TEST_MED_SPA_ITEM = items[TEST_ITEM_ID] as opensearch.main.ItemResult;
+export const TEST_MED_SPA_ITEM = items[TEST_SPA_ITEM_ID] as opensearch.main.ItemResult;
 export const TEST_CHIP_SPA_ITEM = items[WITHDRAWN_CHANGELOG_ITEM_ID] as opensearch.main.ItemResult;
 export const TEST_1915B_ITEM = items[EXISTING_ITEM_APPROVED_NEW_ID] as opensearch.main.ItemResult;
 export const TEST_1915C_ITEM = items[INITIAL_RELEASE_APPK_ITEM_ID] as opensearch.main.ItemResult;

--- a/react-app/src/api/useGetPackageActions.test.ts
+++ b/react-app/src/api/useGetPackageActions.test.ts
@@ -4,7 +4,7 @@ import { Action } from "shared-types";
 import {
   errorApiPackageActionsHandler,
   WITHDRAW_RAI_ITEM_C,
-  TEST_ITEM_ID,
+  TEST_SPA_ITEM_ID,
   NOT_FOUND_ITEM_ID,
   NOT_EXISTING_ITEM_ID,
   setMockUsername,
@@ -25,7 +25,7 @@ describe("getPackageActions test", () => {
   });
 
   it("should return empty actions for package without actions", async () => {
-    const actions = await getPackageActions(TEST_ITEM_ID);
+    const actions = await getPackageActions(TEST_SPA_ITEM_ID);
     expect(actions).toEqual([]);
   });
 

--- a/react-app/src/features/forms/waiver/temporary-extension/temporary-extension.test.tsx
+++ b/react-app/src/features/forms/waiver/temporary-extension/temporary-extension.test.tsx
@@ -14,7 +14,7 @@ import {
   EXISTING_ITEM_APPROVED_NEW_ID,
   NOT_FOUND_ITEM_ID,
   VALID_ITEM_TEMPORARY_EXTENSION_ID,
-  TEST_ITEM_ID,
+  TEST_SPA_ITEM_ID,
 } from "mocks";
 
 const upload = uploadFiles<(typeof formSchemas)["temporary-extension"]>();
@@ -34,7 +34,7 @@ describe("Temporary Extension", () => {
     // set the Item Id to TEST_ITEM_ID
     await renderFormWithPackageSectionAsync(
       <TemporaryExtensionForm />,
-      TEST_ITEM_ID,
+      TEST_SPA_ITEM_ID,
       "Medicaid SPA",
     );
 
@@ -50,7 +50,7 @@ describe("Temporary Extension", () => {
       "Approved Initial or Renewal Waiver Number",
     );
     // grab second TEST_ITEM_ID (first one is in the breadcrumbs)
-    const approvedInitialAndRenewalValue = screen.getAllByText(TEST_ITEM_ID)[1];
+    const approvedInitialAndRenewalValue = screen.getAllByText(TEST_SPA_ITEM_ID)[1];
 
     // ensure Approved Initial and Renewal label and value exist and are in correct order
     expect(


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[Ticket to close](link-to-ticket)

## 💬 Description / Notes

In my split spa ticket, I would like to use the mock Medicaid SPA item in my unit tests. However when using it I found that the mock item has the wrong ID format.

## 🛠 Changes

Another mock data item has been added to represent a Medicaid SPA item. The authority of the previous mock item has been updated to match the ID based on its format.  Any tests that were referring to this ID were modified accordingly.

## 📸 Screenshots / Demo

<!-- ### Before -->

<!-- ### After -->
