### PR TITLE
fix(ui): Email in VAL

### DIFF
--- a/lib/libs/email/content/email-components.tsx
+++ b/lib/libs/email/content/email-components.tsx
@@ -233,6 +233,7 @@ const MailboxNotice = ({
 const FollowUpNotice = ({
   isChip,
   includeStateLead = true,
+  includeDidNotExpect = true,
   withDivider = true,
 }: {
   isChip?: boolean;
@@ -245,7 +246,9 @@ const FollowUpNotice = ({
     {isChip ? (
       <Section>
         <Text style={{ marginTop: "8px", fontSize: "14px" }}>
-          If you have any questions, please contact{" "}
+          {`If you have any question${
+            includeDidNotExpect ? " or did not expect this email" : ""
+          }, please contact `}
           <Link href={`mailto:${EMAIL_CONFIG.CHIP_EMAIL}`} style={{ textDecoration: "underline" }}>
             {EMAIL_CONFIG.CHIP_EMAIL}
           </Link>

--- a/lib/libs/email/content/email-components.tsx
+++ b/lib/libs/email/content/email-components.tsx
@@ -233,7 +233,6 @@ const MailboxNotice = ({
 const FollowUpNotice = ({
   isChip,
   includeStateLead = true,
-  includeDidNotExpect = true,
   withDivider = true,
 }: {
   isChip?: boolean;
@@ -256,9 +255,7 @@ const FollowUpNotice = ({
     ) : (
       <Section>
         <Text style={{ marginTop: "8px", fontSize: "14px" }}>
-          {`If you have any questions${
-            includeDidNotExpect ? " or did not expect this email" : ""
-          }, please contact `}
+          {`If you have any questions, please contact `}
           <Link href={`mailto:${EMAIL_CONFIG.SPA_EMAIL}`} style={{ textDecoration: "underline" }}>
             {EMAIL_CONFIG.SPA_EMAIL}
           </Link>

--- a/lib/libs/email/content/withdrawRai/emailTemplates/ChipSPAState.tsx
+++ b/lib/libs/email/content/withdrawRai/emailTemplates/ChipSPAState.tsx
@@ -23,6 +23,6 @@ export const ChipSpaStateEmail = ({
         Summary: variables.additionalInformation,
       }}
     />
-    <FollowUpNotice isChip />
+    <FollowUpNotice isChip includeDidNotExpect={false} />
   </BaseEmailTemplate>
 );

--- a/lib/libs/email/content/withdrawRai/emailTemplates/WaiverCMS.tsx
+++ b/lib/libs/email/content/withdrawRai/emailTemplates/WaiverCMS.tsx
@@ -1,5 +1,5 @@
 import { CommonEmailVariables, Events, EmailAddresses } from "shared-types";
-import { WithdrawRAI, Attachments, PackageDetails, BasicFooter } from "../../email-components";
+import { Attachments, PackageDetails, BasicFooter } from "../../email-components";
 import { BaseEmailTemplate } from "../../email-templates";
 
 export const WaiverCMSEmail = ({
@@ -9,11 +9,12 @@ export const WaiverCMSEmail = ({
 }) => (
   <BaseEmailTemplate
     previewText={`${variables.authority} ${variables.id} withdrawn`}
-    heading={`Withdraw Formal RAI Response for ${variables.authority} ${variables.id}`}
+    heading={`The OneMAC Submission Portal received a request to withdraw the Formal RAI Response. You are
+        are receiving this email notification as the Formal RAI for {variables.id} was withdrawn by{" "}
+        {variables.submitterName} {variables.submitterEmail}.`}
     applicationEndpointUrl={variables.applicationEndpointUrl}
     footerContent={<BasicFooter />}
   >
-    <WithdrawRAI variables={variables} />
     <PackageDetails
       details={{
         "State or Territory": variables.territory,

--- a/lib/libs/email/content/withdrawRai/emailTemplates/WaiverCMS.tsx
+++ b/lib/libs/email/content/withdrawRai/emailTemplates/WaiverCMS.tsx
@@ -10,8 +10,7 @@ export const WaiverCMSEmail = ({
   <BaseEmailTemplate
     previewText={`${variables.authority} ${variables.id} withdrawn`}
     heading={`The OneMAC Submission Portal received a request to withdraw the Formal RAI Response. You are
-        are receiving this email notification as the Formal RAI for {variables.id} was withdrawn by{" "}
-        {variables.submitterName} {variables.submitterEmail}.`}
+      are receiving this email notification as the Formal RAI for ${variables.id} was withdrawn by ${variables.submitterName} ${variables.submitterEmail}.`}
     applicationEndpointUrl={variables.applicationEndpointUrl}
     footerContent={<BasicFooter />}
   >

--- a/lib/libs/email/content/withdrawRai/emailTemplates/WaiverState.tsx
+++ b/lib/libs/email/content/withdrawRai/emailTemplates/WaiverState.tsx
@@ -11,8 +11,7 @@ export const WaiverStateEmail = ({
     <BaseEmailTemplate
       previewText={`${variables.authority} ${variables.id} Withdrawn`}
       heading={`The OneMAC Submission Portal received a request to withdraw the Formal RAI Response. You are
-        are receiving this email notification as the Formal RAI for {variables.id} was withdrawn by{" "}
-        {variables.submitterName} {variables.submitterEmail}.`}
+        are receiving this email notification as the Formal RAI for ${variables.id} was withdrawn by ${variables.submitterName} ${variables.submitterEmail}.`}
       applicationEndpointUrl={variables.applicationEndpointUrl}
       footerContent={<BasicFooter />}
     >

--- a/lib/libs/email/content/withdrawRai/emailTemplates/WaiverState.tsx
+++ b/lib/libs/email/content/withdrawRai/emailTemplates/WaiverState.tsx
@@ -25,7 +25,7 @@ export const WaiverStateEmail = ({
         }}
       />
       <MailboxNotice type="Waiver" onWaivers={false} />
-      <FollowUpNotice />
+      <FollowUpNotice includeDidNotExpect={false} />
     </BaseEmailTemplate>
   );
 };

--- a/lib/libs/email/content/withdrawRai/emailTemplates/WaiverState.tsx
+++ b/lib/libs/email/content/withdrawRai/emailTemplates/WaiverState.tsx
@@ -1,11 +1,5 @@
 import { CommonEmailVariables, Events, EmailAddresses } from "shared-types";
-import {
-  WithdrawRAI,
-  FollowUpNotice,
-  BasicFooter,
-  PackageDetails,
-  MailboxNotice,
-} from "../../email-components";
+import { FollowUpNotice, BasicFooter, PackageDetails, MailboxNotice } from "../../email-components";
 import { BaseEmailTemplate } from "../../email-templates";
 
 export const WaiverStateEmail = ({
@@ -16,11 +10,12 @@ export const WaiverStateEmail = ({
   return (
     <BaseEmailTemplate
       previewText={`${variables.authority} ${variables.id} Withdrawn`}
-      heading={`Withdraw Formal RAI Response for Waiver Package ${variables.id}`}
+      heading={`The OneMAC Submission Portal received a request to withdraw the Formal RAI Response. You are
+        are receiving this email notification as the Formal RAI for {variables.id} was withdrawn by{" "}
+        {variables.submitterName} {variables.submitterEmail}.`}
       applicationEndpointUrl={variables.applicationEndpointUrl}
       footerContent={<BasicFooter />}
     >
-      <WithdrawRAI variables={variables} />
       <PackageDetails
         details={{
           "State or Territory": variables.territory,

--- a/lib/libs/email/content/withdrawRai/index.tsx
+++ b/lib/libs/email/content/withdrawRai/index.tsx
@@ -37,7 +37,11 @@ export const withdrawRai: AuthoritiesWithUserTypesTemplate = {
       variables: Events["WithdrawRai"] & CommonEmailVariables & { emails: EmailAddresses },
     ) => {
       return {
-        to: [...variables.emails.cpocEmail, ...variables.emails.srtEmails],
+        to: [
+          ...variables.emails.cpocEmail,
+          ...variables.emails.srtEmails,
+          ...variables.emails.chipInbox,
+        ],
         cc: variables.emails.chipCcList,
         subject: `Withdraw Formal RAI Response for CHIP SPA Package ${variables.id}`,
         body: await render(<ChipSpaCMSEmail variables={variables} />),
@@ -47,12 +51,9 @@ export const withdrawRai: AuthoritiesWithUserTypesTemplate = {
       variables: Events["WithdrawRai"] & CommonEmailVariables & { emails: EmailAddresses },
     ) => {
       return {
-        to: [
-          ...variables.emails.cpocEmail,
-          ...variables.emails.srtEmails,
-          `${variables.submitterName} <${variables.submitterEmail}>`,
-        ],
-        cc: variables.emails.chipCcList,
+        to: variables.allStateUsersEmails?.length
+          ? variables.allStateUsersEmails
+          : [`${variables.submitterName} <${variables.submitterEmail}>`],
         subject: `Withdraw Formal RAI Response for CHIP SPA Package ${variables.id}`,
         body: await render(<ChipSpaStateEmail variables={variables} />),
       };

--- a/lib/libs/email/content/withdrawRai/index.tsx
+++ b/lib/libs/email/content/withdrawRai/index.tsx
@@ -94,6 +94,7 @@ export const withdrawRai: AuthoritiesWithUserTypesTemplate = {
           ...variables.emails.osgEmail,
           ...variables.emails.cpocEmail,
           ...variables.emails.srtEmails,
+          ...variables.emails.dhcbsooEmail,
         ],
         subject: `Withdraw Formal RAI Response for Waiver Package ${variables.id}`,
         body: await render(<WaiverCMSEmail variables={variables} />),

--- a/lib/libs/email/content/withdrawRai/index.tsx
+++ b/lib/libs/email/content/withdrawRai/index.tsx
@@ -106,7 +106,7 @@ export const withdrawRai: AuthoritiesWithUserTypesTemplate = {
         to: variables.allStateUsersEmails?.length
           ? variables.allStateUsersEmails
           : [`${variables.submitterName} <${variables.submitterEmail}>`],
-        subject: `Waiver Package ${variables.id} Withdraw Request`,
+        subject: `Withdraw Formal RAI Response for Waiver Package ${variables.id}`,
         body: await render(<WaiverStateEmail variables={variables} />),
       };
     },

--- a/lib/libs/email/preview/InitialSubmissions/State/__snapshots__/InitialSubmissionState.test.tsx.snap
+++ b/lib/libs/email/preview/InitialSubmissions/State/__snapshots__/InitialSubmissionState.test.tsx.snap
@@ -426,7 +426,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Amendment Capi
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -1210,7 +1210,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Amendment Capi
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -1792,7 +1792,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Amendment Capi
                                   <p
                                     style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                                   >
-                                    If you have any questions or did not expect this email, please contact 
+                                    If you have any questions, please contact 
                                     <a
                                       href="mailto:spa@cms.hhs.gov"
                                       style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -4274,7 +4274,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Amendment Cont
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -5058,7 +5058,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Amendment Cont
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -5640,7 +5640,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Amendment Cont
                                   <p
                                     style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                                   >
-                                    If you have any questions or did not expect this email, please contact 
+                                    If you have any questions, please contact 
                                     <a
                                       href="mailto:spa@cms.hhs.gov"
                                       style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -9604,7 +9604,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a AppKCMSEmailPr
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -10104,7 +10104,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a AppKCMSEmailPr
                           <p
                             style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                           >
-                            If you have any questions or did not expect this email, please contact 
+                            If you have any questions, please contact 
                             <a
                               href="mailto:spa@cms.hhs.gov"
                               style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -10661,7 +10661,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Chipspa Previe
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -11867,7 +11867,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Initial Capita
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -12651,7 +12651,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Initial Capita
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -13233,7 +13233,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Initial Capita
                                   <p
                                     style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                                   >
-                                    If you have any questions or did not expect this email, please contact 
+                                    If you have any questions, please contact 
                                     <a
                                       href="mailto:spa@cms.hhs.gov"
                                       style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -14727,7 +14727,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Initial Contra
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -15511,7 +15511,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Initial Contra
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -16093,7 +16093,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Initial Contra
                                   <p
                                     style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                                   >
-                                    If you have any questions or did not expect this email, please contact 
+                                    If you have any questions, please contact 
                                     <a
                                       href="mailto:spa@cms.hhs.gov"
                                       style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -19069,7 +19069,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Medicaid Spa P
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -19853,7 +19853,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Medicaid Spa P
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -20279,7 +20279,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Medicaid Spa P
                           <p
                             style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                           >
-                            If you have any questions or did not expect this email, please contact 
+                            If you have any questions, please contact 
                             <a
                               href="mailto:spa@cms.hhs.gov"
                               style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -20801,7 +20801,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Renewal Capita
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -21585,7 +21585,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Renewal Capita
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -22167,7 +22167,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Renewal Capita
                                   <p
                                     style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                                   >
-                                    If you have any questions or did not expect this email, please contact 
+                                    If you have any questions, please contact 
                                     <a
                                       href="mailto:spa@cms.hhs.gov"
                                       style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -24155,7 +24155,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Renewal Contra
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -24939,7 +24939,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Renewal Contra
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -25521,7 +25521,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Renewal Contra
                                   <p
                                     style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                                   >
-                                    If you have any questions or did not expect this email, please contact 
+                                    If you have any questions, please contact 
                                     <a
                                       href="mailto:spa@cms.hhs.gov"
                                       style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -28991,7 +28991,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a TempExt Previe
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -29775,7 +29775,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a TempExt Previe
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -30357,7 +30357,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a TempExt Previe
                                   <p
                                     style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                                   >
-                                    If you have any questions or did not expect this email, please contact 
+                                    If you have any questions, please contact 
                                     <a
                                       href="mailto:spa@cms.hhs.gov"
                                       style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -30923,7 +30923,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a TempExt Previe
                                 <p
                                   style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                                 >
-                                  If you have any questions or did not expect this email, please contact 
+                                  If you have any questions, please contact 
                                   <a
                                     href="mailto:spa@cms.hhs.gov"
                                     style="color: rgb(6, 125, 247); text-decoration: underline;"

--- a/lib/libs/email/preview/RespondToRai/State/__snapshots__/ResToRaiState.test.tsx.snap
+++ b/lib/libs/email/preview/RespondToRai/State/__snapshots__/ResToRaiState.test.tsx.snap
@@ -340,8 +340,7 @@ exports[`Respond To Rai State Email Snapshot Test > renders a ChipSPA Preview Te
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions, please contact
-                               
+                              If you have any question or did not expect this email, please contact 
                               <a
                                 href="mailto:CHIPSPASubmissionMailBox@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -749,8 +748,7 @@ exports[`Respond To Rai State Email Snapshot Test > renders a ChipSPA Preview Te
                           <p
                             style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                           >
-                            If you have any questions, please contact
-                             
+                            If you have any question or did not expect this email, please contact 
                             <a
                               href="mailto:CHIPSPASubmissionMailBox@cms.hhs.gov"
                               style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -1215,8 +1213,7 @@ exports[`Respond To Rai State Email Snapshot Test > renders a Medicaid_SPA Previ
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions, please contact
-                               
+                              If you have any question or did not expect this email, please contact 
                               <a
                                 href="mailto:CHIPSPASubmissionMailBox@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -2504,8 +2501,7 @@ exports[`Respond To Rai State Email Snapshot Test > renders a Waiver Capitated P
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions, please contact
-                               
+                              If you have any question or did not expect this email, please contact 
                               <a
                                 href="mailto:CHIPSPASubmissionMailBox@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"

--- a/lib/libs/email/preview/WithdrawConfirmation/State/__snapshots__/WithdrawConfirmationState.test.tsx.snap
+++ b/lib/libs/email/preview/WithdrawConfirmation/State/__snapshots__/WithdrawConfirmationState.test.tsx.snap
@@ -1366,7 +1366,7 @@ exports[`Withdraw Confirmation State Email Snapshot Test > renders a Medicaid_SP
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -1531,7 +1531,7 @@ exports[`Withdraw Confirmation State Email Snapshot Test > renders a Medicaid_SP
                           <p
                             style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                           >
-                            If you have any questions or did not expect this email, please contact 
+                            If you have any questions, please contact 
                             <a
                               href="mailto:spa@cms.hhs.gov"
                               style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -2082,7 +2082,7 @@ exports[`Withdraw Confirmation State Email Snapshot Test > renders a Waiver Prev
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"

--- a/lib/libs/email/preview/WithdrawConfirmation/State/__snapshots__/WithdrawConfirmationState.test.tsx.snap
+++ b/lib/libs/email/preview/WithdrawConfirmation/State/__snapshots__/WithdrawConfirmationState.test.tsx.snap
@@ -648,8 +648,7 @@ exports[`Withdraw Confirmation State Email Snapshot Test > renders a ChipSPA Pre
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions, please contact
-                               
+                              If you have any question or did not expect this email, please contact 
                               <a
                                 href="mailto:CHIPSPASubmissionMailBox@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -814,8 +813,7 @@ exports[`Withdraw Confirmation State Email Snapshot Test > renders a ChipSPA Pre
                           <p
                             style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                           >
-                            If you have any questions, please contact
-                             
+                            If you have any question or did not expect this email, please contact 
                             <a
                               href="mailto:CHIPSPASubmissionMailBox@cms.hhs.gov"
                               style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -1201,8 +1199,7 @@ exports[`Withdraw Confirmation State Email Snapshot Test > renders a Medicaid_SP
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions, please contact
-                               
+                              If you have any question or did not expect this email, please contact 
                               <a
                                 href="mailto:CHIPSPASubmissionMailBox@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -1917,8 +1914,7 @@ exports[`Withdraw Confirmation State Email Snapshot Test > renders a Waiver Prev
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions, please contact
-                               
+                              If you have any question or did not expect this email, please contact 
                               <a
                                 href="mailto:CHIPSPASubmissionMailBox@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"

--- a/lib/libs/email/preview/WithdrawPackage/State/__snapshots__/WithdrawPackageState.test.tsx.snap
+++ b/lib/libs/email/preview/WithdrawPackage/State/__snapshots__/WithdrawPackageState.test.tsx.snap
@@ -3022,7 +3022,7 @@ exports[`Withdraw Package State Email Snapshot Test > renders a Medicaid_SPA Pre
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -3391,7 +3391,7 @@ exports[`Withdraw Package State Email Snapshot Test > renders a Medicaid_SPA Pre
                           <p
                             style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                           >
-                            If you have any questions or did not expect this email, please contact 
+                            If you have any questions, please contact 
                             <a
                               href="mailto:spa@cms.hhs.gov"
                               style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -4560,7 +4560,7 @@ exports[`Withdraw Package State Email Snapshot Test > renders a Waiver Capitated
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions or did not expect this email, please contact 
+                              If you have any questions, please contact 
                               <a
                                 href="mailto:spa@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"

--- a/lib/libs/email/preview/WithdrawPackage/State/__snapshots__/WithdrawPackageState.test.tsx.snap
+++ b/lib/libs/email/preview/WithdrawPackage/State/__snapshots__/WithdrawPackageState.test.tsx.snap
@@ -1482,8 +1482,7 @@ exports[`Withdraw Package State Email Snapshot Test > renders a ChipSPA Preview 
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions, please contact
-                               
+                              If you have any question or did not expect this email, please contact 
                               <a
                                 href="mailto:CHIPSPASubmissionMailBox@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -1852,8 +1851,7 @@ exports[`Withdraw Package State Email Snapshot Test > renders a ChipSPA Preview 
                           <p
                             style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                           >
-                            If you have any questions, please contact
-                             
+                            If you have any question or did not expect this email, please contact 
                             <a
                               href="mailto:CHIPSPASubmissionMailBox@cms.hhs.gov"
                               style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -2653,8 +2651,7 @@ exports[`Withdraw Package State Email Snapshot Test > renders a Medicaid_SPA Pre
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions, please contact
-                               
+                              If you have any question or did not expect this email, please contact 
                               <a
                                 href="mailto:CHIPSPASubmissionMailBox@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -4191,8 +4188,7 @@ exports[`Withdraw Package State Email Snapshot Test > renders a Waiver Capitated
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any questions, please contact
-                               
+                              If you have any question or did not expect this email, please contact 
                               <a
                                 href="mailto:CHIPSPASubmissionMailBox@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"

--- a/lib/stacks/auth.ts
+++ b/lib/stacks/auth.ts
@@ -117,6 +117,7 @@ export class Auth extends cdk.NestedStack {
               "custom:username": cdk.aws_cognito.ProviderAttribute.other("preferred_username"),
               "custom:cms-roles": cdk.aws_cognito.ProviderAttribute.other("cmsRoles"),
               "custom:ismemberof": cdk.aws_cognito.ProviderAttribute.other("ismemberof"),
+              "custom:state": cdk.aws_cognito.ProviderAttribute.other("state"),
             },
           },
           attributeRequestMethod: cdk.aws_cognito.OidcAttributeRequestMethod.GET,


### PR DESCRIPTION
## 🎫 Linked Ticket

https://jiraent.cms.gov/browse/OY2-32669

[Ticket to close](link-to-ticket)

## 💬 Description / Notes

Fix code so that emails send to State user(s) when a Withdraw RAI Response package action for all waiver types is submitted.
Fix code so that emails send to CMS user(s) when a Withdraw RAI Response package action for all waiver types is submitted. 
Confirm the email templates match the content on the confluence page: https://confluenceent.cms.gov/display/MACPRO3/Email+Notifications+for+Package+Actions
