### PR TITLE
fix(emails): send `upload-subsequent-documents` emails

### DIFF
--- a/lib/libs/email/content/uploadSubsequentDocuments/index.tsx
+++ b/lib/libs/email/content/uploadSubsequentDocuments/index.tsx
@@ -1,6 +1,15 @@
 import { Events, Authority, EmailAddresses, CommonEmailVariables } from "shared-types";
 import { AuthoritiesWithUserTypesTemplate } from "../..";
-import { ChipSpaCMSEmail, ChipSpaStateEmail, AppKCMSEmail, AppKStateEmail } from "./emailTemplates";
+import {
+  ChipSpaCMSEmail,
+  ChipSpaStateEmail,
+  AppKCMSEmail,
+  AppKStateEmail,
+  MedSpaStateEmail,
+  MedSpaCMSEmail,
+  WaiversEmailCMS,
+  WaiversEmailState,
+} from "./emailTemplates";
 import { render } from "@react-email/render";
 
 export const uploadSubsequentDocuments: AuthoritiesWithUserTypesTemplate = {
@@ -24,6 +33,55 @@ export const uploadSubsequentDocuments: AuthoritiesWithUserTypesTemplate = {
         to: [`${variables.submitterName} <${variables.submitterEmail}>`],
         subject: `Additional documents submitted for ${variables.actionType + variables.id}`,
         body: await render(<ChipSpaStateEmail variables={variables} />),
+      };
+    },
+  },
+  [Authority.MED_SPA]: {
+    cms: async (
+      variables: Events["UploadSubsequentDocuments"] &
+        CommonEmailVariables & { emails: EmailAddresses },
+    ) => {
+      return {
+        to: variables.emails.chipInbox,
+        cc: variables.emails.chipCcList,
+        subject: `Action required: review new documents for ${variables.actionType + variables.id}`,
+        body: await render(<MedSpaCMSEmail variables={variables} />),
+      };
+    },
+    state: async (
+      variables: Events["UploadSubsequentDocuments"] &
+        CommonEmailVariables & { emails: EmailAddresses },
+    ) => {
+      return {
+        to: [`${variables.submitterName} <${variables.submitterEmail}>`],
+        subject: `Additional documents submitted for ${variables.actionType + variables.id}`,
+        body: await render(<MedSpaStateEmail variables={variables} />),
+      };
+    },
+  },
+  [Authority["1915b"]]: {
+    cms: async (
+      variables: Events["UploadSubsequentDocuments"] &
+        CommonEmailVariables & { emails: EmailAddresses },
+    ) => {
+      return {
+        to: [
+          ...variables.emails.osgEmail,
+          ...variables.emails.cpocEmail,
+          ...variables.emails.srtEmails,
+        ],
+        subject: `Action required: review new documents for ${variables.actionType + variables.id}`,
+        body: await render(<WaiversEmailCMS variables={variables} />),
+      };
+    },
+    state: async (
+      variables: Events["UploadSubsequentDocuments"] &
+        CommonEmailVariables & { emails: EmailAddresses },
+    ) => {
+      return {
+        to: [`${variables.submitterName} <${variables.submitterEmail}>`],
+        subject: `Additional documents submitted for ${variables.actionType + variables.id}`,
+        body: await render(<WaiversEmailState variables={variables} />),
       };
     },
   },

--- a/lib/packages/shared-types/events/upload-subsequent-documents.ts
+++ b/lib/packages/shared-types/events/upload-subsequent-documents.ts
@@ -12,6 +12,7 @@ export const baseSchema = z.object({
     }),
   ),
   id: z.string(),
+  authority: z.string(),
 });
 
 export const schema = baseSchema.extend({

--- a/mocks/data/submit/changelog.ts
+++ b/mocks/data/submit/changelog.ts
@@ -140,6 +140,7 @@ export const uploadSubsequentDocuments = {
   event: "upload-subsequent-documents",
   attachments: {},
   additionalInformation: "Some additional information about this submission.",
+  authority: "1915(b)",
 };
 
 export const temporaryExtension = {

--- a/react-app/src/features/forms/post-submission/upload-subsequent-documents/index.tsx
+++ b/react-app/src/features/forms/post-submission/upload-subsequent-documents/index.tsx
@@ -52,6 +52,7 @@ const pickAttachmentsAndAdditionalInfo = (
           .refine((value) => value.trim().length > 0, {
             message: "Additional Information can not be only whitespace.",
           }),
+        authority: z.string(),
       })
       .refine(
         (data) =>
@@ -90,7 +91,7 @@ const getTitle = (originalSubmissionEvent: string) => {
 };
 
 export const UploadSubsequentDocuments = () => {
-  const { id } = useParams<{ id: string }>();
+  const { id, authority } = useParams<{ id: string; authority: string }>();
   const { data: submission, isLoading: isSubmissionLoading } = useGetItem(id);
 
   if (isSubmissionLoading === true) {
@@ -157,6 +158,7 @@ export const UploadSubsequentDocuments = () => {
         property: "id",
         documentChecker: (check) => check.recordExists,
       }}
+      defaultValues={{ authority }}
       additionalInformation={{
         required: true,
         title: "Reason for subsequent documents",


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[OY2-33286](https://jiraent.cms.gov/browse/OY2-33286)

## 💬 Description / Notes

<!-- Briefly describe the background of the issue -->
<!-- If you feel the original ticket lacks important details, this would be the place to share them -->

Emails work on the `authority` property, which determines the template from the email template map. Therefore, without sending the `authority` property when submitting the `upload-subsequent-documents` form, the email sending failed 

## 🛠 Changes

<!-- List your code changes made to implement the solution -->

- add `authority` to `upload-subsequent-documents` schema
- add `authority` to the `defaultValues` prop in `ActionForm` 