### PR TITLE
fix(emails): send `upload-subsequent-documents` emails

### DIFF
--- a/lib/libs/email/content/uploadSubsequentDocuments/emailTemplates/AppKCMS.tsx
+++ b/lib/libs/email/content/uploadSubsequentDocuments/emailTemplates/AppKCMS.tsx
@@ -7,28 +7,25 @@ import {
 } from "../../email-components";
 import { BaseEmailTemplate } from "../../email-templates";
 
-export const AppKCMSEmail = (props: {
+export const AppKCMSEmail = ({
+  variables,
+}: {
   variables: Events["UploadSubsequentDocuments"] & CommonEmailVariables;
-}) => {
-  const variables = props.variables;
-  const previewText = `Action required: review new documents for 1915(c) ${variables.id} in OneMAC.`;
-  const heading = `New documents have been submitted for 1915(c) ${variables.id} in OneMAC.`;
-  return (
-    <BaseEmailTemplate
-      previewText={previewText}
-      heading={heading}
-      applicationEndpointUrl={variables.applicationEndpointUrl}
-      footerContent={<BasicFooter />}
-    >
-      <PackageDetails
-        details={{
-          "State or Territory": variables.territory,
-          "1915(c) Appendix K ID": variables.id,
-          Summary: variables.additionalInformation,
-        }}
-      />
-      <Attachments attachments={variables.attachments} />
-      <SubDocHowToAccess appEndpointURL={variables.applicationEndpointUrl} />
-    </BaseEmailTemplate>
-  );
-};
+}) => (
+  <BaseEmailTemplate
+    previewText={`Action required: review new documents for 1915(c) ${variables.id} in OneMAC.`}
+    heading={`New documents have been submitted for 1915(c) ${variables.id} in OneMAC.`}
+    applicationEndpointUrl={variables.applicationEndpointUrl}
+    footerContent={<BasicFooter />}
+  >
+    <PackageDetails
+      details={{
+        "State or Territory": variables.territory,
+        "1915(c) Appendix K ID": variables.id,
+        Summary: variables.additionalInformation,
+      }}
+    />
+    <Attachments attachments={variables.attachments} />
+    <SubDocHowToAccess appEndpointURL={variables.applicationEndpointUrl} />
+  </BaseEmailTemplate>
+);

--- a/lib/libs/email/content/uploadSubsequentDocuments/emailTemplates/AppKState.tsx
+++ b/lib/libs/email/content/uploadSubsequentDocuments/emailTemplates/AppKState.tsx
@@ -5,34 +5,30 @@ import { PackageDetails, Attachments, BasicFooter, Divider } from "../../email-c
 import { BaseEmailTemplate } from "../../email-templates";
 import { styles } from "../../email-styles";
 
-export const AppKStateEmail = (props: {
+export const AppKStateEmail = ({
+  variables,
+}: {
   variables: Events["UploadSubsequentDocuments"] & CommonEmailVariables;
-}) => {
-  const variables = props.variables;
-  const previewText = `Additional documents submitted for 1915(c) ${variables.id}`;
-  const heading = `You’ve successfully submitted the following to CMS reviewers for 1915(c) ${variables.id}`;
-
-  return (
-    <BaseEmailTemplate
-      previewText={previewText}
-      heading={heading}
-      applicationEndpointUrl={variables.applicationEndpointUrl}
-      footerContent={<BasicFooter />}
-    >
-      <PackageDetails
-        details={{
-          "State or Territory": variables.territory,
-          Name: variables.submitterName,
-          "Email Address": variables.submitterEmail,
-          "1915(c) Appendix K ID": variables.id,
-          Summary: variables.additionalInformation,
-        }}
-      />
-      <Attachments attachments={variables.attachments} />
-      <Divider />
-      <Text style={{ ...styles.text.base, marginTop: "16px" }}>
-        If you have questions or did not expect this email, please contact your CPOC.
-      </Text>
-    </BaseEmailTemplate>
-  );
-};
+}) => (
+  <BaseEmailTemplate
+    previewText={`Additional documents submitted for 1915(c) ${variables.id}`}
+    heading={`You've successfully submitted the following to CMS reviewers for 1915(c) ${variables.id}`}
+    applicationEndpointUrl={variables.applicationEndpointUrl}
+    footerContent={<BasicFooter />}
+  >
+    <PackageDetails
+      details={{
+        "State or Territory": variables.territory,
+        Name: variables.submitterName,
+        "Email Address": variables.submitterEmail,
+        "1915(c) Appendix K ID": variables.id,
+        Summary: variables.additionalInformation,
+      }}
+    />
+    <Attachments attachments={variables.attachments} />
+    <Divider />
+    <Text style={{ ...styles.text.base, marginTop: "16px" }}>
+      If you have questions or did not expect this email, please contact your CPOC.
+    </Text>
+  </BaseEmailTemplate>
+);

--- a/lib/libs/email/content/uploadSubsequentDocuments/emailTemplates/ChipSpaCMS.tsx
+++ b/lib/libs/email/content/uploadSubsequentDocuments/emailTemplates/ChipSpaCMS.tsx
@@ -11,25 +11,21 @@ export const ChipSpaCMSEmail = ({
   variables,
 }: {
   variables: Events["UploadSubsequentDocuments"] & CommonEmailVariables;
-}) => {
-  const previewText = `Action required: review new documents for CHIP SPA ${variables.id} in OneMAC.`;
-  const heading = `New documents have been submitted for CHIP SPA ${variables.id} in OneMAC.`;
-  return (
-    <BaseEmailTemplate
-      previewText={previewText}
-      heading={heading}
-      applicationEndpointUrl={variables.applicationEndpointUrl}
-      footerContent={<BasicFooter />}
-    >
-      <PackageDetails
-        details={{
-          "State or Territory": variables.territory,
-          "CHIP SPA Package ID": variables.id,
-          Summary: variables.additionalInformation,
-        }}
-      />
-      <Attachments attachments={variables.attachments} />
-      <SubDocHowToAccess appEndpointURL={variables.applicationEndpointUrl} />
-    </BaseEmailTemplate>
-  );
-};
+}) => (
+  <BaseEmailTemplate
+    previewText={`Action required: review new documents for CHIP SPA ${variables.id} in OneMAC.`}
+    heading={`New documents have been submitted for CHIP SPA ${variables.id} in OneMAC.`}
+    applicationEndpointUrl={variables.applicationEndpointUrl}
+    footerContent={<BasicFooter />}
+  >
+    <PackageDetails
+      details={{
+        "State or Territory": variables.territory,
+        "CHIP SPA Package ID": variables.id,
+        Summary: variables.additionalInformation,
+      }}
+    />
+    <Attachments attachments={variables.attachments} />
+    <SubDocHowToAccess appEndpointURL={variables.applicationEndpointUrl} />
+  </BaseEmailTemplate>
+);

--- a/lib/libs/email/content/uploadSubsequentDocuments/emailTemplates/ChipSpaState.tsx
+++ b/lib/libs/email/content/uploadSubsequentDocuments/emailTemplates/ChipSpaState.tsx
@@ -9,31 +9,26 @@ export const ChipSpaStateEmail = ({
   variables,
 }: {
   variables: Events["UploadSubsequentDocuments"] & CommonEmailVariables;
-}) => {
-  const previewText = `Additional documents submitted for CHIP SPA ${variables.id}`;
-  const heading = `You’ve successfully submitted the following to CMS reviewers for CHIP SPA ${variables.id}`;
-
-  return (
-    <BaseEmailTemplate
-      previewText={previewText}
-      heading={heading}
-      applicationEndpointUrl={variables.applicationEndpointUrl}
-      footerContent={<BasicFooter />}
-    >
-      <PackageDetails
-        details={{
-          "State or Territory": variables.territory,
-          Name: variables.submitterName,
-          "Email Address": variables.submitterEmail,
-          "CHIP SPA Package ID": variables.id,
-          Summary: variables.additionalInformation,
-        }}
-      />
-      <Attachments attachments={variables.attachments} />
-      <Divider />
-      <Text style={{ ...styles.text.base, marginTop: "16px" }}>
-        If you have questions or did not expect this email, please contact your CPOC.
-      </Text>
-    </BaseEmailTemplate>
-  );
-};
+}) => (
+  <BaseEmailTemplate
+    previewText={`Additional documents submitted for CHIP SPA ${variables.id}`}
+    heading={`You've successfully submitted the following to CMS reviewers for CHIP SPA ${variables.id}`}
+    applicationEndpointUrl={variables.applicationEndpointUrl}
+    footerContent={<BasicFooter />}
+  >
+    <PackageDetails
+      details={{
+        "State or Territory": variables.territory,
+        Name: variables.submitterName,
+        "Email Address": variables.submitterEmail,
+        "CHIP SPA Package ID": variables.id,
+        Summary: variables.additionalInformation,
+      }}
+    />
+    <Attachments attachments={variables.attachments} />
+    <Divider />
+    <Text style={{ ...styles.text.base, marginTop: "16px" }}>
+      If you have questions or did not expect this email, please contact your CPOC.
+    </Text>
+  </BaseEmailTemplate>
+);

--- a/lib/libs/email/content/uploadSubsequentDocuments/emailTemplates/MedSpaCMS.tsx
+++ b/lib/libs/email/content/uploadSubsequentDocuments/emailTemplates/MedSpaCMS.tsx
@@ -11,23 +11,21 @@ export const MedSpaCMSEmail = ({
   variables,
 }: {
   variables: Events["UploadSubsequentDocuments"] & CommonEmailVariables;
-}) => {
-  return (
-    <BaseEmailTemplate
-      previewText={`Medicaid SPA ${variables.id}`}
-      heading={`New documents have been submitted for Medicaid SPA ${variables.id} in OneMAC.`}
-      applicationEndpointUrl={variables.applicationEndpointUrl}
-      footerContent={<BasicFooter />}
-    >
-      <PackageDetails
-        details={{
-          "State or Territory": variables.territory,
-          "Medicaid SPA Package ID": variables.id,
-          Summary: variables.additionalInformation,
-        }}
-      />
-      <Attachments attachments={variables.attachments} />
-      <SubDocHowToAccess appEndpointURL={variables.applicationEndpointUrl} />
-    </BaseEmailTemplate>
-  );
-};
+}) => (
+  <BaseEmailTemplate
+    previewText={`Medicaid SPA ${variables.id}`}
+    heading={`New documents have been submitted for Medicaid SPA ${variables.id} in OneMAC.`}
+    applicationEndpointUrl={variables.applicationEndpointUrl}
+    footerContent={<BasicFooter />}
+  >
+    <PackageDetails
+      details={{
+        "State or Territory": variables.territory,
+        "Medicaid SPA Package ID": variables.id,
+        Summary: variables.additionalInformation,
+      }}
+    />
+    <Attachments attachments={variables.attachments} />
+    <SubDocHowToAccess appEndpointURL={variables.applicationEndpointUrl} />
+  </BaseEmailTemplate>
+);

--- a/lib/libs/email/content/uploadSubsequentDocuments/emailTemplates/MedSpaState.tsx
+++ b/lib/libs/email/content/uploadSubsequentDocuments/emailTemplates/MedSpaState.tsx
@@ -12,7 +12,7 @@ export const MedSpaStateEmail = ({
 }) => (
   <BaseEmailTemplate
     previewText={`Additional documents submitted for Medicaid SPA ${variables.id}`}
-    heading={`You’ve successfully submitted the following to CMS reviewers for Medicaid SPA ${variables.id}`}
+    heading={`You've successfully submitted the following to CMS reviewers for Medicaid SPA ${variables.id}`}
     applicationEndpointUrl={variables.applicationEndpointUrl}
     footerContent={<BasicFooter />}
   >

--- a/lib/libs/email/content/uploadSubsequentDocuments/emailTemplates/MedSpaState.tsx
+++ b/lib/libs/email/content/uploadSubsequentDocuments/emailTemplates/MedSpaState.tsx
@@ -5,31 +5,29 @@ import { PackageDetails, Attachments, BasicFooter } from "../../email-components
 import { BaseEmailTemplate } from "../../email-templates";
 import { styles } from "../../email-styles";
 
-export const MedSpaStateEmail = (props: {
+export const MedSpaStateEmail = ({
+  variables,
+}: {
   variables: Events["UploadSubsequentDocuments"] & CommonEmailVariables;
-}) => {
-  const variables = props.variables;
-
-  return (
-    <BaseEmailTemplate
-      previewText={`Additional documents submitted for Medicaid SPA ${variables.id}`}
-      heading={`You’ve successfully submitted the following to CMS reviewers for Medicaid SPA ${variables.id}`}
-      applicationEndpointUrl={variables.applicationEndpointUrl}
-      footerContent={<BasicFooter />}
-    >
-      <PackageDetails
-        details={{
-          "State or Territory": variables.territory,
-          Name: variables.submitterName,
-          "Email Address": variables.submitterEmail,
-          "Medicaid SPA Package ID": variables.id,
-          Summary: variables.additionalInformation,
-        }}
-      />
-      <Attachments attachments={variables.attachments} />
-      <Text style={{ ...styles.text.base, marginTop: "16px" }}>
-        If you have questions or did not expect this email, please contact your CPOC.
-      </Text>
-    </BaseEmailTemplate>
-  );
-};
+}) => (
+  <BaseEmailTemplate
+    previewText={`Additional documents submitted for Medicaid SPA ${variables.id}`}
+    heading={`You’ve successfully submitted the following to CMS reviewers for Medicaid SPA ${variables.id}`}
+    applicationEndpointUrl={variables.applicationEndpointUrl}
+    footerContent={<BasicFooter />}
+  >
+    <PackageDetails
+      details={{
+        "State or Territory": variables.territory,
+        Name: variables.submitterName,
+        "Email Address": variables.submitterEmail,
+        "Medicaid SPA Package ID": variables.id,
+        Summary: variables.additionalInformation,
+      }}
+    />
+    <Attachments attachments={variables.attachments} />
+    <Text style={{ ...styles.text.base, marginTop: "16px" }}>
+      If you have questions or did not expect this email, please contact your CPOC.
+    </Text>
+  </BaseEmailTemplate>
+);

--- a/lib/libs/email/content/uploadSubsequentDocuments/emailTemplates/Waiver1915BCMS.tsx
+++ b/lib/libs/email/content/uploadSubsequentDocuments/emailTemplates/Waiver1915BCMS.tsx
@@ -11,23 +11,21 @@ export const WaiversEmailCMS = ({
   variables,
 }: {
   variables: Events["UploadSubsequentDocuments"] & CommonEmailVariables;
-}) => {
-  return (
-    <BaseEmailTemplate
-      previewText={`Action required: review new documents for 1915(B) ${variables.id} in OneMAC.`}
-      heading={`New documents have been submitted for 1915(B) ${variables.id} in OneMAC.`}
-      applicationEndpointUrl={variables.applicationEndpointUrl}
-      footerContent={<BasicFooter />}
-    >
-      <PackageDetails
-        details={{
-          "State or Territory": variables.territory,
-          "Waiver Package ID": variables.id,
-          Summary: variables.additionalInformation,
-        }}
-      />
-      <Attachments attachments={variables.attachments} />
-      <SubDocHowToAccess appEndpointURL={variables.applicationEndpointUrl} />
-    </BaseEmailTemplate>
-  );
-};
+}) => (
+  <BaseEmailTemplate
+    previewText={`Action required: review new documents for 1915(B) ${variables.id} in OneMAC.`}
+    heading={`New documents have been submitted for 1915(B) ${variables.id} in OneMAC.`}
+    applicationEndpointUrl={variables.applicationEndpointUrl}
+    footerContent={<BasicFooter />}
+  >
+    <PackageDetails
+      details={{
+        "State or Territory": variables.territory,
+        "Waiver Package ID": variables.id,
+        Summary: variables.additionalInformation,
+      }}
+    />
+    <Attachments attachments={variables.attachments} />
+    <SubDocHowToAccess appEndpointURL={variables.applicationEndpointUrl} />
+  </BaseEmailTemplate>
+);

--- a/lib/libs/email/content/uploadSubsequentDocuments/emailTemplates/Waiver1915BState.tsx
+++ b/lib/libs/email/content/uploadSubsequentDocuments/emailTemplates/Waiver1915BState.tsx
@@ -8,28 +8,26 @@ export const WaiversEmailState = ({
   variables,
 }: {
   variables: Events["UploadSubsequentDocuments"] & CommonEmailVariables;
-}) => {
-  return (
-    <BaseEmailTemplate
-      previewText={`Action required: review new documents for 1915(B) ${variables.id}.`}
-      heading={`You’ve successfully submitted the following to CMS reviewers for 1915(B) ${variables.id}:`}
-      applicationEndpointUrl={variables.applicationEndpointUrl}
-      footerContent={<BasicFooter />}
-    >
-      <PackageDetails
-        details={{
-          "State or Territory": variables.territory,
-          Name: variables.submitterName,
-          "Email Address": variables.submitterEmail,
-          "Waiver Package ID": variables.id,
-          Summary: variables.additionalInformation,
-        }}
-      />
-      <Attachments attachments={variables.attachments} />
-      <Divider />
-      <Text style={{ ...styles.text.base, marginTop: "16px" }}>
-        If you have questions or did not expect this email, please contact your CPOC.
-      </Text>
-    </BaseEmailTemplate>
-  );
-};
+}) => (
+  <BaseEmailTemplate
+    previewText={`Action required: review new documents for 1915(B) ${variables.id}.`}
+    heading={`You've successfully submitted the following to CMS reviewers for 1915(B) ${variables.id}:`}
+    applicationEndpointUrl={variables.applicationEndpointUrl}
+    footerContent={<BasicFooter />}
+  >
+    <PackageDetails
+      details={{
+        "State or Territory": variables.territory,
+        Name: variables.submitterName,
+        "Email Address": variables.submitterEmail,
+        "Waiver Package ID": variables.id,
+        Summary: variables.additionalInformation,
+      }}
+    />
+    <Attachments attachments={variables.attachments} />
+    <Divider />
+    <Text style={{ ...styles.text.base, marginTop: "16px" }}>
+      If you have questions or did not expect this email, please contact your CPOC.
+    </Text>
+  </BaseEmailTemplate>
+);

--- a/lib/libs/email/content/uploadSubsequentDocuments/index.tsx
+++ b/lib/libs/email/content/uploadSubsequentDocuments/index.tsx
@@ -1,6 +1,15 @@
 import { Events, Authority, EmailAddresses, CommonEmailVariables } from "shared-types";
 import { AuthoritiesWithUserTypesTemplate } from "../..";
-import { ChipSpaCMSEmail, ChipSpaStateEmail, AppKCMSEmail, AppKStateEmail } from "./emailTemplates";
+import {
+  ChipSpaCMSEmail,
+  ChipSpaStateEmail,
+  AppKCMSEmail,
+  AppKStateEmail,
+  MedSpaStateEmail,
+  MedSpaCMSEmail,
+  WaiversEmailCMS,
+  WaiversEmailState,
+} from "./emailTemplates";
 import { render } from "@react-email/render";
 
 export const uploadSubsequentDocuments: AuthoritiesWithUserTypesTemplate = {
@@ -24,6 +33,55 @@ export const uploadSubsequentDocuments: AuthoritiesWithUserTypesTemplate = {
         to: [`${variables.submitterName} <${variables.submitterEmail}>`],
         subject: `Additional documents submitted for ${variables.actionType + variables.id}`,
         body: await render(<ChipSpaStateEmail variables={variables} />),
+      };
+    },
+  },
+  [Authority.MED_SPA]: {
+    cms: async (
+      variables: Events["UploadSubsequentDocuments"] &
+        CommonEmailVariables & { emails: EmailAddresses },
+    ) => {
+      return {
+        to: variables.emails.chipInbox,
+        cc: variables.emails.chipCcList,
+        subject: `Action required: review new documents for ${variables.actionType + variables.id}`,
+        body: await render(<MedSpaCMSEmail variables={variables} />),
+      };
+    },
+    state: async (
+      variables: Events["UploadSubsequentDocuments"] &
+        CommonEmailVariables & { emails: EmailAddresses },
+    ) => {
+      return {
+        to: [`${variables.submitterName} <${variables.submitterEmail}>`],
+        subject: `Additional documents submitted for ${variables.actionType + variables.id}`,
+        body: await render(<MedSpaStateEmail variables={variables} />),
+      };
+    },
+  },
+  [Authority["1915b"]]: {
+    cms: async (
+      variables: Events["UploadSubsequentDocuments"] &
+        CommonEmailVariables & { emails: EmailAddresses },
+    ) => {
+      return {
+        to: [
+          ...variables.emails.osgEmail,
+          ...variables.emails.cpocEmail,
+          ...variables.emails.srtEmails,
+        ],
+        subject: `Action required: review new documents for ${variables.actionType + variables.id}`,
+        body: await render(<WaiversEmailCMS variables={variables} />),
+      };
+    },
+    state: async (
+      variables: Events["UploadSubsequentDocuments"] &
+        CommonEmailVariables & { emails: EmailAddresses },
+    ) => {
+      return {
+        to: [`${variables.submitterName} <${variables.submitterEmail}>`],
+        subject: `Additional documents submitted for ${variables.actionType + variables.id}`,
+        body: await render(<WaiversEmailState variables={variables} />),
       };
     },
   },

--- a/lib/libs/email/content/uploadSubsequentDocuments/index.tsx
+++ b/lib/libs/email/content/uploadSubsequentDocuments/index.tsx
@@ -21,7 +21,7 @@ export const uploadSubsequentDocuments: AuthoritiesWithUserTypesTemplate = {
       return {
         to: variables.emails.chipInbox,
         cc: variables.emails.chipCcList,
-        subject: `Action required: review new documents for ${variables.actionType + variables.id}`,
+        subject: `Action required: review new documents for ${variables.authority} ${variables.id}`,
         body: await render(<ChipSpaCMSEmail variables={variables} />),
       };
     },
@@ -31,7 +31,7 @@ export const uploadSubsequentDocuments: AuthoritiesWithUserTypesTemplate = {
     ) => {
       return {
         to: [`${variables.submitterName} <${variables.submitterEmail}>`],
-        subject: `Additional documents submitted for ${variables.actionType + variables.id}`,
+        subject: `Additional documents submitted for ${variables.authority} ${variables.id}`,
         body: await render(<ChipSpaStateEmail variables={variables} />),
       };
     },
@@ -44,7 +44,7 @@ export const uploadSubsequentDocuments: AuthoritiesWithUserTypesTemplate = {
       return {
         to: variables.emails.chipInbox,
         cc: variables.emails.chipCcList,
-        subject: `Action required: review new documents for ${variables.actionType + variables.id}`,
+        subject: `Action required: review new documents for ${variables.authority} ${variables.id}`,
         body: await render(<MedSpaCMSEmail variables={variables} />),
       };
     },
@@ -54,7 +54,7 @@ export const uploadSubsequentDocuments: AuthoritiesWithUserTypesTemplate = {
     ) => {
       return {
         to: [`${variables.submitterName} <${variables.submitterEmail}>`],
-        subject: `Additional documents submitted for ${variables.actionType + variables.id}`,
+        subject: `Additional documents submitted for ${variables.authority} ${variables.id}`,
         body: await render(<MedSpaStateEmail variables={variables} />),
       };
     },
@@ -70,7 +70,7 @@ export const uploadSubsequentDocuments: AuthoritiesWithUserTypesTemplate = {
           ...variables.emails.cpocEmail,
           ...variables.emails.srtEmails,
         ],
-        subject: `Action required: review new documents for ${variables.actionType + variables.id}`,
+        subject: `Action required: review new documents for ${variables.authority} ${variables.id}`,
         body: await render(<WaiversEmailCMS variables={variables} />),
       };
     },
@@ -80,7 +80,7 @@ export const uploadSubsequentDocuments: AuthoritiesWithUserTypesTemplate = {
     ) => {
       return {
         to: [`${variables.submitterName} <${variables.submitterEmail}>`],
-        subject: `Additional documents submitted for ${variables.actionType + variables.id}`,
+        subject: `Additional documents submitted for ${variables.authority} ${variables.id}`,
         body: await render(<WaiversEmailState variables={variables} />),
       };
     },
@@ -96,7 +96,7 @@ export const uploadSubsequentDocuments: AuthoritiesWithUserTypesTemplate = {
           ...variables.emails.cpocEmail,
           ...variables.emails.srtEmails,
         ],
-        subject: `Action required: review new documents for ${variables.actionType + variables.id}`,
+        subject: `Action required: review new documents for ${variables.authority} ${variables.id}`,
         body: await render(<AppKCMSEmail variables={variables} />),
       };
     },
@@ -106,7 +106,7 @@ export const uploadSubsequentDocuments: AuthoritiesWithUserTypesTemplate = {
     ) => {
       return {
         to: [`${variables.submitterName} <${variables.submitterEmail}>`],
-        subject: `Additional documents submitted for ${variables.actionType + variables.id}`,
+        subject: `Additional documents submitted for ${variables.authority} ${variables.id}`,
         body: await render(<AppKStateEmail variables={variables} />),
       };
     },

--- a/lib/libs/email/content/uploadSubsequentDocuments/index.tsx
+++ b/lib/libs/email/content/uploadSubsequentDocuments/index.tsx
@@ -19,8 +19,7 @@ export const uploadSubsequentDocuments: AuthoritiesWithUserTypesTemplate = {
         CommonEmailVariables & { emails: EmailAddresses },
     ) => {
       return {
-        to: variables.emails.chipInbox,
-        cc: variables.emails.chipCcList,
+        to: [...variables.emails.cpocEmail, ...variables.emails.srtEmails],
         subject: `Action required: review new documents for ${variables.authority} ${variables.id}`,
         body: await render(<ChipSpaCMSEmail variables={variables} />),
       };
@@ -42,8 +41,7 @@ export const uploadSubsequentDocuments: AuthoritiesWithUserTypesTemplate = {
         CommonEmailVariables & { emails: EmailAddresses },
     ) => {
       return {
-        to: variables.emails.chipInbox,
-        cc: variables.emails.chipCcList,
+        to: [...variables.emails.cpocEmail, ...variables.emails.srtEmails],
         subject: `Action required: review new documents for ${variables.authority} ${variables.id}`,
         body: await render(<MedSpaCMSEmail variables={variables} />),
       };
@@ -65,11 +63,7 @@ export const uploadSubsequentDocuments: AuthoritiesWithUserTypesTemplate = {
         CommonEmailVariables & { emails: EmailAddresses },
     ) => {
       return {
-        to: [
-          ...variables.emails.osgEmail,
-          ...variables.emails.cpocEmail,
-          ...variables.emails.srtEmails,
-        ],
+        to: [...variables.emails.cpocEmail, ...variables.emails.srtEmails],
         subject: `Action required: review new documents for ${variables.authority} ${variables.id}`,
         body: await render(<WaiversEmailCMS variables={variables} />),
       };

--- a/lib/libs/email/preview/UploadSubsequentDocuments/State/CHIP_SPA.tsx
+++ b/lib/libs/email/preview/UploadSubsequentDocuments/State/CHIP_SPA.tsx
@@ -1,9 +1,9 @@
 import { emailTemplateValue } from "libs/email/mock-data/upload-subsequent-documents";
-import { ChipSpaCMSEmail } from "libs/email/content/uploadSubsequentDocuments/emailTemplates";
+import { ChipSpaStateEmail } from "libs/email/content/uploadSubsequentDocuments/emailTemplates";
 import * as attachments from "libs/email/mock-data/attachments";
 const ChipSpaStateEmailPreview = () => {
   return (
-    <ChipSpaCMSEmail
+    <ChipSpaStateEmail
       variables={{
         ...emailTemplateValue,
         id: "CO-24-1234",

--- a/lib/libs/email/preview/UploadSubsequentDocuments/State/__snapshots__/UpSubDocState.test.tsx.snap
+++ b/lib/libs/email/preview/UploadSubsequentDocuments/State/__snapshots__/UpSubDocState.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a AppKCMSE
                     <h1
                       style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                     >
-                      You’ve successfully submitted the following to CMS reviewers for 1915(c) CO-1234.R21.00
+                      You've successfully submitted the following to CMS reviewers for 1915(c) CO-1234.R21.00
                     </h1>
                     <table
                       align="center"
@@ -521,7 +521,7 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a AppKCMSE
                   <h1
                     style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                   >
-                    You’ve successfully submitted the following to CMS reviewers for 1915(c) CO-1234.R21.00
+                    You've successfully submitted the following to CMS reviewers for 1915(c) CO-1234.R21.00
                   </h1>
                   <table
                     align="center"
@@ -1021,7 +1021,7 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a ChipSPA 
                     <h1
                       style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                     >
-                      You’ve successfully submitted the following to CMS reviewers for 1915(c) CO-1234.R21.00
+                      You've successfully submitted the following to CMS reviewers for 1915(c) CO-1234.R21.00
                     </h1>
                     <table
                       align="center"
@@ -1406,9 +1406,9 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a ChipSPA 
         <div
           style="display: none; overflow: hidden; line-height: 1px; opacity: 0; max-height: 0; max-width: 0;"
         >
-          Action required: review new documents for CHIP SPA CO-24-1234 in OneMAC.
+          Additional documents submitted for CHIP SPA CO-24-1234
           <div>
-             ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
+             ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
           </div>
         </div>
         <body
@@ -1463,7 +1463,7 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a ChipSPA 
                     <h1
                       style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                     >
-                      New documents have been submitted for CHIP SPA CO-24-1234 in OneMAC.
+                      You've successfully submitted the following to CMS reviewers for CHIP SPA CO-24-1234
                     </h1>
                     <table
                       align="center"
@@ -1509,6 +1509,82 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a ChipSPA 
                                       style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
                                     >
                                       CO
+                                    </p>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <table
+                              align="center"
+                              border="0"
+                              cellpadding="0"
+                              cellspacing="0"
+                              role="presentation"
+                              width="100%"
+                            >
+                              <tbody
+                                style="width: 100%;"
+                              >
+                                <tr
+                                  style="width: 100%;"
+                                >
+                                  <td
+                                    align="left"
+                                    data-id="__react-email-column"
+                                    style="width: 50%;"
+                                  >
+                                    <p
+                                      style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; font-weight: 600; letter-spacing: -0.5px;"
+                                    >
+                                      Name
+                                      :
+                                    </p>
+                                  </td>
+                                  <td
+                                    data-id="__react-email-column"
+                                  >
+                                    <p
+                                      style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
+                                    >
+                                      George Harrison
+                                    </p>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <table
+                              align="center"
+                              border="0"
+                              cellpadding="0"
+                              cellspacing="0"
+                              role="presentation"
+                              width="100%"
+                            >
+                              <tbody
+                                style="width: 100%;"
+                              >
+                                <tr
+                                  style="width: 100%;"
+                                >
+                                  <td
+                                    align="left"
+                                    data-id="__react-email-column"
+                                    style="width: 50%;"
+                                  >
+                                    <p
+                                      style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; font-weight: 600; letter-spacing: -0.5px;"
+                                    >
+                                      Email Address
+                                      :
+                                    </p>
+                                  </td>
+                                  <td
+                                    data-id="__react-email-column"
+                                  >
+                                    <p
+                                      style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
+                                    >
+                                      george@example.com
                                     </p>
                                   </td>
                                 </tr>
@@ -2154,42 +2230,10 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a ChipSPA 
                       style="width: 100%; border-top: 1px solid #0071BD; margin: 16px 0px;"
                     />
                     <p
-                      style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51); font-weight: bold;"
+                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
                     >
-                      How to Access:
+                      If you have questions or did not expect this email, please contact your CPOC.
                     </p>
-                    <ul>
-                      <li>
-                        <p
-                          style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
-                        >
-                          These documents can be found in OneMAC through this link
-                           
-                          <a
-                            href="https://mako-dev.cms.gov/"
-                            style="color: rgb(6, 125, 247); text-decoration: none;"
-                            target="_blank"
-                          >
-                            https://mako-dev.cms.gov/
-                          </a>
-                          .
-                        </p>
-                      </li>
-                      <li>
-                        <p
-                          style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
-                        >
-                          If you are not already logged in, click “Login” at the top of the page and log in using your Enterprise User Administration (EUA) credentials.
-                        </p>
-                      </li>
-                      <li>
-                        <p
-                          style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
-                        >
-                          After you logged in, click the submission ID number on the dashboard page to view details.
-                        </p>
-                      </li>
-                    </ul>
                     <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >
@@ -2265,9 +2309,9 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a ChipSPA 
       <div
         style="display: none; overflow: hidden; line-height: 1px; opacity: 0; max-height: 0; max-width: 0;"
       >
-        Action required: review new documents for CHIP SPA CO-24-1234 in OneMAC.
+        Additional documents submitted for CHIP SPA CO-24-1234
         <div>
-           ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
+           ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
         </div>
       </div>
       <body
@@ -2322,7 +2366,7 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a ChipSPA 
                   <h1
                     style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                   >
-                    New documents have been submitted for CHIP SPA CO-24-1234 in OneMAC.
+                    You've successfully submitted the following to CMS reviewers for CHIP SPA CO-24-1234
                   </h1>
                   <table
                     align="center"
@@ -2368,6 +2412,82 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a ChipSPA 
                                     style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
                                   >
                                     CO
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                          <table
+                            align="center"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            width="100%"
+                          >
+                            <tbody
+                              style="width: 100%;"
+                            >
+                              <tr
+                                style="width: 100%;"
+                              >
+                                <td
+                                  align="left"
+                                  data-id="__react-email-column"
+                                  style="width: 50%;"
+                                >
+                                  <p
+                                    style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; font-weight: 600; letter-spacing: -0.5px;"
+                                  >
+                                    Name
+                                    :
+                                  </p>
+                                </td>
+                                <td
+                                  data-id="__react-email-column"
+                                >
+                                  <p
+                                    style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
+                                  >
+                                    George Harrison
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                          <table
+                            align="center"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            width="100%"
+                          >
+                            <tbody
+                              style="width: 100%;"
+                            >
+                              <tr
+                                style="width: 100%;"
+                              >
+                                <td
+                                  align="left"
+                                  data-id="__react-email-column"
+                                  style="width: 50%;"
+                                >
+                                  <p
+                                    style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; font-weight: 600; letter-spacing: -0.5px;"
+                                  >
+                                    Email Address
+                                    :
+                                  </p>
+                                </td>
+                                <td
+                                  data-id="__react-email-column"
+                                >
+                                  <p
+                                    style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
+                                  >
+                                    george@example.com
                                   </p>
                                 </td>
                               </tr>
@@ -3013,42 +3133,10 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a ChipSPA 
                     style="width: 100%; border-top: 1px solid #0071BD; margin: 16px 0px;"
                   />
                   <p
-                    style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51); font-weight: bold;"
+                    style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
                   >
-                    How to Access:
+                    If you have questions or did not expect this email, please contact your CPOC.
                   </p>
-                  <ul>
-                    <li>
-                      <p
-                        style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
-                      >
-                        These documents can be found in OneMAC through this link
-                         
-                        <a
-                          href="https://mako-dev.cms.gov/"
-                          style="color: rgb(6, 125, 247); text-decoration: none;"
-                          target="_blank"
-                        >
-                          https://mako-dev.cms.gov/
-                        </a>
-                        .
-                      </p>
-                    </li>
-                    <li>
-                      <p
-                        style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
-                      >
-                        If you are not already logged in, click “Login” at the top of the page and log in using your Enterprise User Administration (EUA) credentials.
-                      </p>
-                    </li>
-                    <li>
-                      <p
-                        style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
-                      >
-                        After you logged in, click the submission ID number on the dashboard page to view details.
-                      </p>
-                    </li>
-                  </ul>
                   <p
                     style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                   >
@@ -3238,7 +3326,7 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a Medicaid
                     <h1
                       style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                     >
-                      You’ve successfully submitted the following to CMS reviewers for 1915(c) CO-1234.R21.00
+                      You've successfully submitted the following to CMS reviewers for 1915(c) CO-1234.R21.00
                     </h1>
                     <table
                       align="center"
@@ -3623,9 +3711,9 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a Medicaid
         <div
           style="display: none; overflow: hidden; line-height: 1px; opacity: 0; max-height: 0; max-width: 0;"
         >
-          Action required: review new documents for CHIP SPA CO-24-1234 in OneMAC.
+          Additional documents submitted for CHIP SPA CO-24-1234
           <div>
-             ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
+             ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
           </div>
         </div>
         <body
@@ -3680,7 +3768,7 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a Medicaid
                     <h1
                       style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                     >
-                      New documents have been submitted for CHIP SPA CO-24-1234 in OneMAC.
+                      You've successfully submitted the following to CMS reviewers for CHIP SPA CO-24-1234
                     </h1>
                     <table
                       align="center"
@@ -3726,6 +3814,82 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a Medicaid
                                       style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
                                     >
                                       CO
+                                    </p>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <table
+                              align="center"
+                              border="0"
+                              cellpadding="0"
+                              cellspacing="0"
+                              role="presentation"
+                              width="100%"
+                            >
+                              <tbody
+                                style="width: 100%;"
+                              >
+                                <tr
+                                  style="width: 100%;"
+                                >
+                                  <td
+                                    align="left"
+                                    data-id="__react-email-column"
+                                    style="width: 50%;"
+                                  >
+                                    <p
+                                      style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; font-weight: 600; letter-spacing: -0.5px;"
+                                    >
+                                      Name
+                                      :
+                                    </p>
+                                  </td>
+                                  <td
+                                    data-id="__react-email-column"
+                                  >
+                                    <p
+                                      style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
+                                    >
+                                      George Harrison
+                                    </p>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <table
+                              align="center"
+                              border="0"
+                              cellpadding="0"
+                              cellspacing="0"
+                              role="presentation"
+                              width="100%"
+                            >
+                              <tbody
+                                style="width: 100%;"
+                              >
+                                <tr
+                                  style="width: 100%;"
+                                >
+                                  <td
+                                    align="left"
+                                    data-id="__react-email-column"
+                                    style="width: 50%;"
+                                  >
+                                    <p
+                                      style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; font-weight: 600; letter-spacing: -0.5px;"
+                                    >
+                                      Email Address
+                                      :
+                                    </p>
+                                  </td>
+                                  <td
+                                    data-id="__react-email-column"
+                                  >
+                                    <p
+                                      style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
+                                    >
+                                      george@example.com
                                     </p>
                                   </td>
                                 </tr>
@@ -4371,42 +4535,10 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a Medicaid
                       style="width: 100%; border-top: 1px solid #0071BD; margin: 16px 0px;"
                     />
                     <p
-                      style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51); font-weight: bold;"
+                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
                     >
-                      How to Access:
+                      If you have questions or did not expect this email, please contact your CPOC.
                     </p>
-                    <ul>
-                      <li>
-                        <p
-                          style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
-                        >
-                          These documents can be found in OneMAC through this link
-                           
-                          <a
-                            href="https://mako-dev.cms.gov/"
-                            style="color: rgb(6, 125, 247); text-decoration: none;"
-                            target="_blank"
-                          >
-                            https://mako-dev.cms.gov/
-                          </a>
-                          .
-                        </p>
-                      </li>
-                      <li>
-                        <p
-                          style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
-                        >
-                          If you are not already logged in, click “Login” at the top of the page and log in using your Enterprise User Administration (EUA) credentials.
-                        </p>
-                      </li>
-                      <li>
-                        <p
-                          style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
-                        >
-                          After you logged in, click the submission ID number on the dashboard page to view details.
-                        </p>
-                      </li>
-                    </ul>
                     <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >
@@ -4538,7 +4670,7 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a Medicaid
                     <h1
                       style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                     >
-                      You’ve successfully submitted the following to CMS reviewers for Medicaid SPA CO-24-1234
+                      You've successfully submitted the following to CMS reviewers for Medicaid SPA CO-24-1234
                     </h1>
                     <table
                       align="center"
@@ -5438,7 +5570,7 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a Medicaid
                   <h1
                     style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                   >
-                    You’ve successfully submitted the following to CMS reviewers for Medicaid SPA CO-24-1234
+                    You've successfully submitted the following to CMS reviewers for Medicaid SPA CO-24-1234
                   </h1>
                   <table
                     align="center"
@@ -6395,7 +6527,7 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a Waiver C
                     <h1
                       style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                     >
-                      You’ve successfully submitted the following to CMS reviewers for 1915(c) CO-1234.R21.00
+                      You've successfully submitted the following to CMS reviewers for 1915(c) CO-1234.R21.00
                     </h1>
                     <table
                       align="center"
@@ -6780,9 +6912,9 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a Waiver C
         <div
           style="display: none; overflow: hidden; line-height: 1px; opacity: 0; max-height: 0; max-width: 0;"
         >
-          Action required: review new documents for CHIP SPA CO-24-1234 in OneMAC.
+          Additional documents submitted for CHIP SPA CO-24-1234
           <div>
-             ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
+             ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
           </div>
         </div>
         <body
@@ -6837,7 +6969,7 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a Waiver C
                     <h1
                       style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                     >
-                      New documents have been submitted for CHIP SPA CO-24-1234 in OneMAC.
+                      You've successfully submitted the following to CMS reviewers for CHIP SPA CO-24-1234
                     </h1>
                     <table
                       align="center"
@@ -6883,6 +7015,82 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a Waiver C
                                       style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
                                     >
                                       CO
+                                    </p>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <table
+                              align="center"
+                              border="0"
+                              cellpadding="0"
+                              cellspacing="0"
+                              role="presentation"
+                              width="100%"
+                            >
+                              <tbody
+                                style="width: 100%;"
+                              >
+                                <tr
+                                  style="width: 100%;"
+                                >
+                                  <td
+                                    align="left"
+                                    data-id="__react-email-column"
+                                    style="width: 50%;"
+                                  >
+                                    <p
+                                      style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; font-weight: 600; letter-spacing: -0.5px;"
+                                    >
+                                      Name
+                                      :
+                                    </p>
+                                  </td>
+                                  <td
+                                    data-id="__react-email-column"
+                                  >
+                                    <p
+                                      style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
+                                    >
+                                      George Harrison
+                                    </p>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <table
+                              align="center"
+                              border="0"
+                              cellpadding="0"
+                              cellspacing="0"
+                              role="presentation"
+                              width="100%"
+                            >
+                              <tbody
+                                style="width: 100%;"
+                              >
+                                <tr
+                                  style="width: 100%;"
+                                >
+                                  <td
+                                    align="left"
+                                    data-id="__react-email-column"
+                                    style="width: 50%;"
+                                  >
+                                    <p
+                                      style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; font-weight: 600; letter-spacing: -0.5px;"
+                                    >
+                                      Email Address
+                                      :
+                                    </p>
+                                  </td>
+                                  <td
+                                    data-id="__react-email-column"
+                                  >
+                                    <p
+                                      style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
+                                    >
+                                      george@example.com
                                     </p>
                                   </td>
                                 </tr>
@@ -7528,42 +7736,10 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a Waiver C
                       style="width: 100%; border-top: 1px solid #0071BD; margin: 16px 0px;"
                     />
                     <p
-                      style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51); font-weight: bold;"
+                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
                     >
-                      How to Access:
+                      If you have questions or did not expect this email, please contact your CPOC.
                     </p>
-                    <ul>
-                      <li>
-                        <p
-                          style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
-                        >
-                          These documents can be found in OneMAC through this link
-                           
-                          <a
-                            href="https://mako-dev.cms.gov/"
-                            style="color: rgb(6, 125, 247); text-decoration: none;"
-                            target="_blank"
-                          >
-                            https://mako-dev.cms.gov/
-                          </a>
-                          .
-                        </p>
-                      </li>
-                      <li>
-                        <p
-                          style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
-                        >
-                          If you are not already logged in, click “Login” at the top of the page and log in using your Enterprise User Administration (EUA) credentials.
-                        </p>
-                      </li>
-                      <li>
-                        <p
-                          style="font-size: 14px; line-height: 1.4; margin: 4px 0px 4px 0px; color: rgb(51, 51, 51);"
-                        >
-                          After you logged in, click the submission ID number on the dashboard page to view details.
-                        </p>
-                      </li>
-                    </ul>
                     <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >
@@ -7695,7 +7871,7 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a Waiver C
                     <h1
                       style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                     >
-                      You’ve successfully submitted the following to CMS reviewers for Medicaid SPA CO-24-1234
+                      You've successfully submitted the following to CMS reviewers for Medicaid SPA CO-24-1234
                     </h1>
                     <table
                       align="center"
@@ -8594,7 +8770,7 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a Waiver C
                     <h1
                       style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                     >
-                      You’ve successfully submitted the following to CMS reviewers for 1915(B) CO-24-1234:
+                      You've successfully submitted the following to CMS reviewers for 1915(B) CO-24-1234:
                     </h1>
                     <table
                       align="center"
@@ -9497,7 +9673,7 @@ exports[`Upload Subsequent Document CMS Email Snapshot Test > renders a Waiver C
                   <h1
                     style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                   >
-                    You’ve successfully submitted the following to CMS reviewers for 1915(B) CO-24-1234:
+                    You've successfully submitted the following to CMS reviewers for 1915(B) CO-24-1234:
                   </h1>
                   <table
                     align="center"

--- a/lib/packages/shared-types/events/upload-subsequent-documents.ts
+++ b/lib/packages/shared-types/events/upload-subsequent-documents.ts
@@ -12,6 +12,7 @@ export const baseSchema = z.object({
     }),
   ),
   id: z.string(),
+  authority: z.string(),
 });
 
 export const schema = baseSchema.extend({

--- a/mocks/data/submit/changelog.ts
+++ b/mocks/data/submit/changelog.ts
@@ -140,6 +140,7 @@ export const uploadSubsequentDocuments = {
   event: "upload-subsequent-documents",
   attachments: {},
   additionalInformation: "Some additional information about this submission.",
+  authority: "1915(b)",
 };
 
 export const temporaryExtension = {

--- a/react-app/src/features/forms/post-submission/upload-subsequent-documents/index.tsx
+++ b/react-app/src/features/forms/post-submission/upload-subsequent-documents/index.tsx
@@ -52,6 +52,7 @@ const pickAttachmentsAndAdditionalInfo = (
           .refine((value) => value.trim().length > 0, {
             message: "Additional Information can not be only whitespace.",
           }),
+        authority: z.string(),
       })
       .refine(
         (data) =>
@@ -90,7 +91,7 @@ const getTitle = (originalSubmissionEvent: string) => {
 };
 
 export const UploadSubsequentDocuments = () => {
-  const { id } = useParams<{ id: string }>();
+  const { id, authority } = useParams<{ id: string; authority: string }>();
   const { data: submission, isLoading: isSubmissionLoading } = useGetItem(id);
 
   if (isSubmissionLoading === true) {
@@ -157,6 +158,7 @@ export const UploadSubsequentDocuments = () => {
         property: "id",
         documentChecker: (check) => check.recordExists,
       }}
+      defaultValues={{ authority }}
       additionalInformation={{
         required: true,
         title: "Reason for subsequent documents",


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[OY2-33286](https://jiraent.cms.gov/browse/OY2-33286)

## 💬 Description / Notes

<!-- Briefly describe the background of the issue -->
<!-- If you feel the original ticket lacks important details, this would be the place to share them -->

Emails work on the `authority` property, which determines the template from the email template map. Therefore, without sending the `authority` property when submitting the `upload-subsequent-documents` form, the email sending failed 

## 🛠 Changes

<!-- List your code changes made to implement the solution -->

- add `authority` to `upload-subsequent-documents` schema
- add `authority` to the `defaultValues` prop in `ActionForm` 