### PR TITLE
Fix(ui): fixing email verbiage for MEDSpa, CHIPSpa, and Waivers

### DIFF
--- a/lib/libs/email/content/withdrawConfirmation/emailTemplates/ChipSpaState.tsx
+++ b/lib/libs/email/content/withdrawConfirmation/emailTemplates/ChipSpaState.tsx
@@ -3,7 +3,7 @@ import { FollowUpNotice, BasicFooter } from "../../email-components";
 import { BaseEmailTemplate } from "../../email-templates";
 
 export const ChipSpaStateEmail = (props: {
-  variables: Events["WithdrawPackage"] & CommonEmailVariables;
+  variables: Events["WithdrawConfirmation"] & CommonEmailVariables;
 }) => {
   const variables = props.variables;
   return (

--- a/lib/libs/email/content/withdrawConfirmation/emailTemplates/ChipSpaState.tsx
+++ b/lib/libs/email/content/withdrawConfirmation/emailTemplates/ChipSpaState.tsx
@@ -13,7 +13,7 @@ export const ChipSpaStateEmail = (props: {
       applicationEndpointUrl={variables.applicationEndpointUrl}
       footerContent={<BasicFooter />}
     >
-      <FollowUpNotice isChip />
+      <FollowUpNotice isChip includeDidNotExpect={false} />
     </BaseEmailTemplate>
   );
 };

--- a/lib/libs/email/content/withdrawConfirmation/emailTemplates/MedSpaState.tsx
+++ b/lib/libs/email/content/withdrawConfirmation/emailTemplates/MedSpaState.tsx
@@ -13,7 +13,7 @@ export const MedSpaStateEmail = (props: {
       applicationEndpointUrl={variables.applicationEndpointUrl}
       footerContent={<BasicFooter />}
     >
-      <FollowUpNotice includeStateLead={false} />
+      <FollowUpNotice includeStateLead={false} includeDidNotExpect={true} />
     </BaseEmailTemplate>
   );
 };

--- a/lib/libs/email/content/withdrawConfirmation/emailTemplates/WaiverState.tsx
+++ b/lib/libs/email/content/withdrawConfirmation/emailTemplates/WaiverState.tsx
@@ -7,7 +7,7 @@ export const WaiverStateEmail = (props: {
 }) => {
   const variables = props.variables;
   const previewText = `Withdrawal of ${variables.authority} ${variables.id}`;
-  const heading = `This email is to confirm ${variables.authority} ${variables.id} was withdrawn by ${variables.submitterName}. The review of ${variables.authority} ${variables.id} has concluded.`;
+  const heading = `This email is to confirm ${variables.actionType} ${variables.id} was withdrawn by ${variables.submitterName}. The review of ${variables.actionType} ${variables.id} has concluded.`;
   return (
     <BaseEmailTemplate
       previewText={previewText}

--- a/lib/libs/email/content/withdrawConfirmation/index.tsx
+++ b/lib/libs/email/content/withdrawConfirmation/index.tsx
@@ -4,7 +4,7 @@ import { ChipSpaStateEmail, MedSpaStateEmail, WaiverStateEmail } from "./emailTe
 import { render } from "@react-email/render";
 
 const generateWithdrawEmail = async (
-  variables: Events["WithdrawPackage"] & CommonEmailVariables & { emails: EmailAddresses },
+  variables: Events["WithdrawConfirmation"] & CommonEmailVariables & { emails: EmailAddresses },
   subjectPrefix: string,
   EmailComponent: React.FC<{ variables: any }>,
 ) => {

--- a/lib/libs/email/index.ts
+++ b/lib/libs/email/index.ts
@@ -49,7 +49,7 @@ const emailTemplates: EmailTemplates = {
   "new-chip-submission": EmailContent.newSubmission,
   "temporary-extension": EmailContent.tempExtension,
   "withdraw-package": EmailContent.withdrawPackage,
-  "withdraw-confirmation": EmailContent.withdrawPackage,
+  "withdraw-confirmation": EmailContent.withdrawConfirmation,
   "withdraw-rai": EmailContent.withdrawRai,
   "contracting-initial": EmailContent.newSubmission,
   "capitated-initial": EmailContent.newSubmission,

--- a/lib/libs/email/index.ts
+++ b/lib/libs/email/index.ts
@@ -25,6 +25,7 @@ export type EmailTemplates = {
   "new-chip-submission": AuthoritiesWithUserTypesTemplate;
   "temporary-extension": AuthoritiesWithUserTypesTemplate;
   "withdraw-package": AuthoritiesWithUserTypesTemplate;
+  "withdraw-confirmation": AuthoritiesWithUserTypesTemplate;
   "withdraw-rai": AuthoritiesWithUserTypesTemplate;
   "contracting-initial": AuthoritiesWithUserTypesTemplate;
   "capitated-initial": AuthoritiesWithUserTypesTemplate;
@@ -48,6 +49,7 @@ const emailTemplates: EmailTemplates = {
   "new-chip-submission": EmailContent.newSubmission,
   "temporary-extension": EmailContent.tempExtension,
   "withdraw-package": EmailContent.withdrawPackage,
+  "withdraw-confirmation": EmailContent.withdrawPackage,
   "withdraw-rai": EmailContent.withdrawRai,
   "contracting-initial": EmailContent.newSubmission,
   "capitated-initial": EmailContent.newSubmission,

--- a/lib/libs/email/preview/WithdrawConfirmation/State/__snapshots__/WithdrawConfirmationState.test.tsx.snap
+++ b/lib/libs/email/preview/WithdrawConfirmation/State/__snapshots__/WithdrawConfirmationState.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`Withdraw Confirmation State Email Snapshot Test > renders a Appk Previe
                     <h1
                       style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                     >
-                      This email is to confirm 1915(c) CO-1234.R21.00 was withdrawn by George Harrison. The review of 1915(c) CO-1234.R21.00 has concluded.
+                      This email is to confirm Amend CO-1234.R21.00 was withdrawn by George Harrison. The review of Amend CO-1234.R21.00 has concluded.
                     </h1>
                     <hr
                       style="width: 100%; border-top: 1px solid #0071BD; margin: 16px 0px;"
@@ -243,7 +243,7 @@ exports[`Withdraw Confirmation State Email Snapshot Test > renders a Appk Previe
                   <h1
                     style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                   >
-                    This email is to confirm 1915(c) CO-1234.R21.00 was withdrawn by George Harrison. The review of 1915(c) CO-1234.R21.00 has concluded.
+                    This email is to confirm Amend CO-1234.R21.00 was withdrawn by George Harrison. The review of Amend CO-1234.R21.00 has concluded.
                   </h1>
                   <hr
                     style="width: 100%; border-top: 1px solid #0071BD; margin: 16px 0px;"
@@ -465,7 +465,7 @@ exports[`Withdraw Confirmation State Email Snapshot Test > renders a ChipSPA Pre
                     <h1
                       style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                     >
-                      This email is to confirm 1915(c) CO-1234.R21.00 was withdrawn by George Harrison. The review of 1915(c) CO-1234.R21.00 has concluded.
+                      This email is to confirm Amend CO-1234.R21.00 was withdrawn by George Harrison. The review of Amend CO-1234.R21.00 has concluded.
                     </h1>
                     <hr
                       style="width: 100%; border-top: 1px solid #0071BD; margin: 16px 0px;"
@@ -648,7 +648,7 @@ exports[`Withdraw Confirmation State Email Snapshot Test > renders a ChipSPA Pre
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any question or did not expect this email, please contact 
+                              If you have any question, please contact 
                               <a
                                 href="mailto:CHIPSPASubmissionMailBox@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -813,7 +813,7 @@ exports[`Withdraw Confirmation State Email Snapshot Test > renders a ChipSPA Pre
                           <p
                             style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                           >
-                            If you have any question or did not expect this email, please contact 
+                            If you have any question, please contact 
                             <a
                               href="mailto:CHIPSPASubmissionMailBox@cms.hhs.gov"
                               style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -1016,7 +1016,7 @@ exports[`Withdraw Confirmation State Email Snapshot Test > renders a Medicaid_SP
                     <h1
                       style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                     >
-                      This email is to confirm 1915(c) CO-1234.R21.00 was withdrawn by George Harrison. The review of 1915(c) CO-1234.R21.00 has concluded.
+                      This email is to confirm Amend CO-1234.R21.00 was withdrawn by George Harrison. The review of Amend CO-1234.R21.00 has concluded.
                     </h1>
                     <hr
                       style="width: 100%; border-top: 1px solid #0071BD; margin: 16px 0px;"
@@ -1199,7 +1199,7 @@ exports[`Withdraw Confirmation State Email Snapshot Test > renders a Medicaid_SP
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any question or did not expect this email, please contact 
+                              If you have any question, please contact 
                               <a
                                 href="mailto:CHIPSPASubmissionMailBox@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -1731,7 +1731,7 @@ exports[`Withdraw Confirmation State Email Snapshot Test > renders a Waiver Prev
                     <h1
                       style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                     >
-                      This email is to confirm 1915(c) CO-1234.R21.00 was withdrawn by George Harrison. The review of 1915(c) CO-1234.R21.00 has concluded.
+                      This email is to confirm Amend CO-1234.R21.00 was withdrawn by George Harrison. The review of Amend CO-1234.R21.00 has concluded.
                     </h1>
                     <hr
                       style="width: 100%; border-top: 1px solid #0071BD; margin: 16px 0px;"
@@ -1914,7 +1914,7 @@ exports[`Withdraw Confirmation State Email Snapshot Test > renders a Waiver Prev
                             <p
                               style="font-size: 14px; line-height: 24px; margin: 8px 0px 16px 0px;"
                             >
-                              If you have any question or did not expect this email, please contact 
+                              If you have any question, please contact 
                               <a
                                 href="mailto:CHIPSPASubmissionMailBox@cms.hhs.gov"
                                 style="color: rgb(6, 125, 247); text-decoration: underline;"
@@ -2223,7 +2223,7 @@ exports[`Withdraw Confirmation State Email Snapshot Test > renders a Waiver Prev
                     <h1
                       style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                     >
-                      This email is to confirm 1915(b) CO-1234.R21.00 was withdrawn by George Harrison. The review of 1915(b) CO-1234.R21.00 has concluded.
+                      This email is to confirm Amend CO-1234.R21.00 was withdrawn by George Harrison. The review of Amend CO-1234.R21.00 has concluded.
                     </h1>
                     <hr
                       style="width: 100%; border-top: 1px solid #0071BD; margin: 16px 0px;"
@@ -2388,7 +2388,7 @@ exports[`Withdraw Confirmation State Email Snapshot Test > renders a Waiver Prev
                   <h1
                     style="color: rgb(51, 51, 51); font-size: 20px; font-weight: bold; margin-bottom: 15px;"
                   >
-                    This email is to confirm 1915(b) CO-1234.R21.00 was withdrawn by George Harrison. The review of 1915(b) CO-1234.R21.00 has concluded.
+                    This email is to confirm Amend CO-1234.R21.00 was withdrawn by George Harrison. The review of Amend CO-1234.R21.00 has concluded.
                   </h1>
                   <hr
                     style="width: 100%; border-top: 1px solid #0071BD; margin: 16px 0px;"

--- a/lib/packages/shared-types/events/index.ts
+++ b/lib/packages/shared-types/events/index.ts
@@ -10,7 +10,7 @@ import * as contractingInitial from "./contracting-initial";
 import * as contractingRenewal from "./contracting-renewal";
 import * as temporaryExtension from "./temporary-extension";
 import * as withdrawPackage from "./withdraw-package";
-import * as WithdrawConfirmation from "./withdraw-confirmation";
+import * as withdrawConfirmation from "./withdraw-confirmation";
 import * as appk from "./app-k";
 
 import * as withdrawRai from "./withdraw-rai";
@@ -36,6 +36,7 @@ export const events = {
   "new-medicaid-submission": newMedicaidSubmission,
   "temporary-extension": temporaryExtension,
   "withdraw-package": withdrawPackage,
+  "withdraw-confirmation": withdrawConfirmation,
   "withdraw-rai": withdrawRai,
   "toggle-withdraw-rai": toggleWithdrawRai,
   "respond-to-rai": respondToRai,
@@ -59,7 +60,7 @@ export type Events = {
   RespondToRai: z.infer<typeof respondToRai.schema>;
   UploadSubsequentDocuments: z.infer<typeof uploadSubsequentDocuments.schema>;
   WithdrawPackage: z.infer<typeof withdrawPackage.schema>;
-  WithdrawConfirmation: z.infer<typeof WithdrawConfirmation.schema>;
+  WithdrawConfirmation: z.infer<typeof withdrawConfirmation.schema>;
   WithdrawRai: z.infer<typeof withdrawRai.schema>;
   ToggleWithdrawRai: z.infer<typeof toggleWithdrawRai.schema>;
 };

--- a/lib/packages/shared-types/events/index.ts
+++ b/lib/packages/shared-types/events/index.ts
@@ -10,6 +10,7 @@ import * as contractingInitial from "./contracting-initial";
 import * as contractingRenewal from "./contracting-renewal";
 import * as temporaryExtension from "./temporary-extension";
 import * as withdrawPackage from "./withdraw-package";
+import * as WithdrawConfirmation from "./withdraw-confirmation";
 import * as appk from "./app-k";
 
 import * as withdrawRai from "./withdraw-rai";
@@ -58,6 +59,7 @@ export type Events = {
   RespondToRai: z.infer<typeof respondToRai.schema>;
   UploadSubsequentDocuments: z.infer<typeof uploadSubsequentDocuments.schema>;
   WithdrawPackage: z.infer<typeof withdrawPackage.schema>;
+  WithdrawConfirmation: z.infer<typeof WithdrawConfirmation.schema>;
   WithdrawRai: z.infer<typeof withdrawRai.schema>;
   ToggleWithdrawRai: z.infer<typeof toggleWithdrawRai.schema>;
 };

--- a/lib/packages/shared-types/events/withdraw-confirmation.ts
+++ b/lib/packages/shared-types/events/withdraw-confirmation.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+import { attachmentArraySchemaOptional, attachmentArraySchema } from "../attachments";
+
+export const attachmentsDefault = z.object({
+  supportingDocumentation: z.object({
+    files: attachmentArraySchemaOptional(),
+    label: z.string().default("Supporting Documentation"),
+  }),
+});
+export const attachmentsChip = z.object({
+  officialWithdrawalLetter: z.object({
+    files: attachmentArraySchema(),
+    label: z.string().default("Official Withdrawal Letter"),
+  }),
+});
+
+export const baseSchema = z.object({
+  event: z.literal("withdraw-confirmation").default("withdraw-confirmation"),
+  id: z.string(),
+  authority: z.string(),
+  additionalInformation: z.string().trim().max(4000).optional(),
+  attachments: attachmentsDefault.or(attachmentsChip),
+});
+
+export const schema = baseSchema.extend({
+  origin: z.literal("mako").default("mako"),
+  submitterName: z.string(),
+  submitterEmail: z.string().email(),
+  timestamp: z.number(),
+});


### PR DESCRIPTION
## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

https://jiraent.cms.gov/browse/OY2-32814

## 💬 Description / Notes

1. Update the email body for Medicaid, CHIP, and Waiver Withdrawal Confirmation emails to match the confluence page. 
