### PR TITLE
Fix(ui): fix withdraw-confirmation email for chipspa, medspa, waivers

### DIFF
--- a/lib/libs/email/content/withdrawConfirmation/emailTemplates/ChipSpaState.tsx
+++ b/lib/libs/email/content/withdrawConfirmation/emailTemplates/ChipSpaState.tsx
@@ -13,7 +13,7 @@ export const ChipSpaStateEmail = (props: {
       applicationEndpointUrl={variables.applicationEndpointUrl}
       footerContent={<BasicFooter />}
     >
-      <FollowUpNotice isChip />
+      <FollowUpNotice isChip includeDidNotExpect={false} />
     </BaseEmailTemplate>
   );
 };

--- a/lib/libs/email/content/withdrawConfirmation/emailTemplates/MedSpaState.tsx
+++ b/lib/libs/email/content/withdrawConfirmation/emailTemplates/MedSpaState.tsx
@@ -13,7 +13,7 @@ export const MedSpaStateEmail = (props: {
       applicationEndpointUrl={variables.applicationEndpointUrl}
       footerContent={<BasicFooter />}
     >
-      <FollowUpNotice includeStateLead={false} />
+      <FollowUpNotice includeStateLead={false} includeDidNotExpect={true} />
     </BaseEmailTemplate>
   );
 };

--- a/lib/libs/email/content/withdrawConfirmation/emailTemplates/WaiverState.tsx
+++ b/lib/libs/email/content/withdrawConfirmation/emailTemplates/WaiverState.tsx
@@ -7,7 +7,7 @@ export const WaiverStateEmail = (props: {
 }) => {
   const variables = props.variables;
   const previewText = `Withdrawal of ${variables.authority} ${variables.id}`;
-  const heading = `This email is to confirm ${variables.authority} ${variables.id} was withdrawn by ${variables.submitterName}. The review of ${variables.authority} ${variables.id} has concluded.`;
+  const heading = `This email is to confirm ${variables.actionType} ${variables.id} was withdrawn by ${variables.submitterName}. The review of ${variables.actionType} ${variables.id} has concluded.`;
   return (
     <BaseEmailTemplate
       previewText={previewText}


### PR DESCRIPTION
## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

https://jiraent.cms.gov/browse/OY2-32814

## 💬 Description / Notes

1. Update the email body for Medicaid, CHIP and Waiver Withdrawal Confirmation emails to match the confluence page. 

## 🛠 Changes

Env - VAL
Login as a State user and do a withdraw package action for any form type. Ex: Medicaid SPA.
Login to SEA Tool and add the details. Once the form is saved, flip the status to "Withdrawn", and save the form.
The package status should display as "Package Withdrawn" in mako.
Check the email notification for the State user. (Email will be sent to all state users, there is no CMS email for this action).

