### PR TITLE
fix: redirect to appropriate tab based on query string if provided

### DIFF
--- a/react-app/src/components/Opensearch/main/useOpensearch.ts
+++ b/react-app/src/components/Opensearch/main/useOpensearch.ts
@@ -150,5 +150,6 @@ export const useOsUrl = () => {
       sort: { field: "submissionDate", order: "desc" },
       ...queryObject,
     },
+    redirectTab: queryObject?.tab,
   });
 };

--- a/react-app/src/hooks/useParams.ts
+++ b/react-app/src/hooks/useParams.ts
@@ -8,7 +8,7 @@ import { useLocalStorage } from "./useLocalStorage";
  * LZ is a library which can compresses JSON into a uri string
  * and can decompresses JSON strings into state objects
  */
-export const useLzUrl = <T>(props: { key: string; initValue?: T }) => {
+export const useLzUrl = <T>(props: { key: string; initValue?: T; redirectTab?: string }) => {
   const [params, setParams] = useSearchParams();
   const [query, setQuery] = useLocalStorage("osQuery", null);
 
@@ -25,7 +25,8 @@ export const useLzUrl = <T>(props: { key: string; initValue?: T }) => {
 
     try {
       setQuery(decompress);
-      return JSON.parse(decompress);
+      const parsed = JSON.parse(decompress);
+      return { ...parsed, tab: props.redirectTab ?? parsed.tab };
     } catch {
       return props.initValue;
     }

--- a/react-app/src/hooks/useParams.ts
+++ b/react-app/src/hooks/useParams.ts
@@ -24,9 +24,15 @@ export const useLzUrl = <T>(props: { key: string; initValue?: T; redirectTab?: s
     if (!decompress) return props.initValue;
 
     try {
-      setQuery(decompress);
       const parsed = JSON.parse(decompress);
-      return { ...parsed, tab: props.redirectTab ?? parsed.tab };
+
+      if (props.redirectTab && parsed.tab !== props.redirectTab) {
+        setQuery(JSON.stringify(props.initValue));
+        return props.initValue;
+      }
+
+      setQuery(decompress);
+      return parsed;
     } catch {
       return props.initValue;
     }


### PR DESCRIPTION
## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[Ticket to close](https://jiraent.cms.gov/browse/OY2-32872)

## 💬 Description / Notes

After a SPA submission or Waiver submission, change dashboard redirect OS pre-load to go to appropriate tab.

## 🛠 Changes

Alter the OS initializer to check for redirect tab in search query which was being ignored.

