### PR TITLE
feat(email): Handles additional information line breaks by converting them to <br> elements

### DIFF
--- a/lib/libs/email/content/email-components.tsx
+++ b/lib/libs/email/content/email-components.tsx
@@ -1,5 +1,5 @@
 import { Column, Heading, Hr, Link, Row, Section, Text } from "@react-email/components";
-import { ReactNode } from "react";
+import { ReactNode, Fragment } from "react";
 import {
   Attachment,
   AttachmentKey,
@@ -190,7 +190,16 @@ const PackageDetails = ({ details }: { details: Record<string, ReactNode> }) => 
                 Summary:
               </Heading>
             </Text>
-            <Text style={styles.text.base}>{value ?? "No additional information submitted"}</Text>
+            <Text style={styles.text.base}>
+              {value
+                ? value.split("\n").map((line, index, array) => (
+                    <Fragment key={index}>
+                      {line}
+                      {index !== array.length - 1 && <br />}
+                    </Fragment>
+                  ))
+                : "No additional information submitted"}
+            </Text>
           </Row>
         );
       }

--- a/lib/libs/email/preview/InitialSubmissions/State/Waiver1915bContracting/Amendment.tsx
+++ b/lib/libs/email/preview/InitialSubmissions/State/Waiver1915bContracting/Amendment.tsx
@@ -6,6 +6,7 @@ export default () => {
     <Waiver1915bStateEmail
       variables={{
         ...emailTemplateValue,
+        additionalInformation: "",
         waiverNumber: "CO-1234.R21.00",
         attachments: {
           b4WaiverApplication: {

--- a/lib/libs/email/preview/InitialSubmissions/State/Waiver1915bContracting/Initial.tsx
+++ b/lib/libs/email/preview/InitialSubmissions/State/Waiver1915bContracting/Initial.tsx
@@ -6,6 +6,8 @@ export default () => {
     <Waiver1915bStateEmail
       variables={{
         ...emailTemplateValue,
+        additionalInformation:
+          "This is text\n\n\nwith a bunch of b/n linebreaks\n\n\n\n\n\n\n\n to test that linebreaks get converted to <br> elements",
         attachments: {
           b4WaiverApplication: {
             label: "1915(b) Comprehensive (Contracting) Waiver Application Pre-print",

--- a/lib/libs/email/preview/InitialSubmissions/State/Waiver1915bContracting/Renewal.tsx
+++ b/lib/libs/email/preview/InitialSubmissions/State/Waiver1915bContracting/Renewal.tsx
@@ -7,6 +7,7 @@ export default () => {
       variables={{
         ...emailTemplateValue,
         waiverNumber: "CO-1234.R21.00",
+        additionalInformation: "Testing with an emoji 😄",
         attachments: {
           b4IndependentAssessment: {
             label: "1915(b) Comprehensive (Contracting) Waiver Independent Assessment",

--- a/lib/libs/email/preview/InitialSubmissions/State/__snapshots__/InitialSubmissionState.test.tsx.snap
+++ b/lib/libs/email/preview/InitialSubmissions/State/__snapshots__/InitialSubmissionState.test.tsx.snap
@@ -7529,7 +7529,20 @@ exports[`Initial Submission State Email Snapshot Test > renders a Amendment Cont
                                   <p
                                     style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                                   >
-                                    This submission includes necessary documentation for requested updates to the state’s Medicaid plan, in alignment with CMS requirements.
+                                    This is text
+                                    <br />
+                                    <br />
+                                    <br />
+                                    with a bunch of b/n linebreaks
+                                    <br />
+                                    <br />
+                                    <br />
+                                    <br />
+                                    <br />
+                                    <br />
+                                    <br />
+                                    <br />
+                                     to test that linebreaks get converted to &lt;br&gt; elements
                                   </p>
                                 </tr>
                               </tbody>
@@ -8023,7 +8036,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Amendment Cont
                                   <p
                                     style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                                   >
-                                    This submission includes necessary documentation for requested updates to the state’s Medicaid plan, in alignment with CMS requirements.
+                                    Testing with an emoji 😄
                                   </p>
                                 </tr>
                               </tbody>
@@ -8517,7 +8530,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Amendment Cont
                                   <p
                                     style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                                   >
-                                    This submission includes necessary documentation for requested updates to the state’s Medicaid plan, in alignment with CMS requirements.
+                                    No additional information submitted
                                   </p>
                                 </tr>
                               </tbody>
@@ -9012,7 +9025,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Amendment Cont
                                 <p
                                   style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                                 >
-                                  This submission includes necessary documentation for requested updates to the state’s Medicaid plan, in alignment with CMS requirements.
+                                  No additional information submitted
                                 </p>
                               </tr>
                             </tbody>
@@ -17982,7 +17995,20 @@ exports[`Initial Submission State Email Snapshot Test > renders a Initial Contra
                                   <p
                                     style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                                   >
-                                    This submission includes necessary documentation for requested updates to the state’s Medicaid plan, in alignment with CMS requirements.
+                                    This is text
+                                    <br />
+                                    <br />
+                                    <br />
+                                    with a bunch of b/n linebreaks
+                                    <br />
+                                    <br />
+                                    <br />
+                                    <br />
+                                    <br />
+                                    <br />
+                                    <br />
+                                    <br />
+                                     to test that linebreaks get converted to &lt;br&gt; elements
                                   </p>
                                 </tr>
                               </tbody>
@@ -18477,7 +18503,20 @@ exports[`Initial Submission State Email Snapshot Test > renders a Initial Contra
                                 <p
                                   style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                                 >
-                                  This submission includes necessary documentation for requested updates to the state’s Medicaid plan, in alignment with CMS requirements.
+                                  This is text
+                                  <br />
+                                  <br />
+                                  <br />
+                                  with a bunch of b/n linebreaks
+                                  <br />
+                                  <br />
+                                  <br />
+                                  <br />
+                                  <br />
+                                  <br />
+                                  <br />
+                                  <br />
+                                   to test that linebreaks get converted to &lt;br&gt; elements
                                 </p>
                               </tr>
                             </tbody>
@@ -27410,7 +27449,20 @@ exports[`Initial Submission State Email Snapshot Test > renders a Renewal Contra
                                   <p
                                     style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                                   >
-                                    This submission includes necessary documentation for requested updates to the state’s Medicaid plan, in alignment with CMS requirements.
+                                    This is text
+                                    <br />
+                                    <br />
+                                    <br />
+                                    with a bunch of b/n linebreaks
+                                    <br />
+                                    <br />
+                                    <br />
+                                    <br />
+                                    <br />
+                                    <br />
+                                    <br />
+                                    <br />
+                                     to test that linebreaks get converted to &lt;br&gt; elements
                                   </p>
                                 </tr>
                               </tbody>
@@ -27904,7 +27956,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Renewal Contra
                                   <p
                                     style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                                   >
-                                    This submission includes necessary documentation for requested updates to the state’s Medicaid plan, in alignment with CMS requirements.
+                                    Testing with an emoji 😄
                                   </p>
                                 </tr>
                               </tbody>
@@ -28399,7 +28451,7 @@ exports[`Initial Submission State Email Snapshot Test > renders a Renewal Contra
                                 <p
                                   style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                                 >
-                                  This submission includes necessary documentation for requested updates to the state’s Medicaid plan, in alignment with CMS requirements.
+                                  Testing with an emoji 😄
                                 </p>
                               </tr>
                             </tbody>


### PR DESCRIPTION
## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[Ticket to close](https://jiraent.cms.gov/browse/OY2-32380)

## 💬 Description / Notes

* updates rendering of email templates to manually handle line breaks by converting them to `<br>` elements

## 📸 Screenshots / Demo

### Before
![Screenshot 2025-02-25 at 11 32 28 AM](https://github.com/user-attachments/assets/a7015fe3-d716-451d-8dfb-202ebdd0f99b)


 ### After
![Screenshot 2025-02-25 at 11 32 52 AM](https://github.com/user-attachments/assets/a68b6873-96ab-4c61-8898-1198449c3fcb)

