### PR TITLE
Fix(emails): fixed verbiage text for emails (MedSPA and ChipSPA)

### DIFF
--- a/lib/libs/email/content/newSubmission/emailTemplates/ChipSpaCMS.tsx
+++ b/lib/libs/email/content/newSubmission/emailTemplates/ChipSpaCMS.tsx
@@ -6,6 +6,8 @@ import {
   Attachments,
 } from "../../email-components";
 import { BaseEmailTemplate } from "../../email-templates";
+import { Link, Text } from "@react-email/components";
+import { styles } from "../../email-styles";
 
 export const ChipSpaCMSEmail = ({
   variables,
@@ -32,6 +34,14 @@ export const ChipSpaCMSEmail = ({
         }}
       />
       <Attachments attachments={variables.attachments} />
+      <Text style={{ ...styles.text.base, marginTop: "16px" }}>
+        {" "}
+        If the contents of this email seem suspicious, do not open them, and instead forward this
+        email to{" "}
+        <Link href={`mailto:SPAM@CMS.HHS.gov`} style={{ textDecoration: "underline" }}>
+          CHIPSPASubmissionMailBox@CMS.HHS.gov
+        </Link>
+      </Text>
     </BaseEmailTemplate>
   );
 };

--- a/lib/libs/email/content/newSubmission/emailTemplates/ChipSpaState.tsx
+++ b/lib/libs/email/content/newSubmission/emailTemplates/ChipSpaState.tsx
@@ -12,7 +12,6 @@ export const ChipSpaStateEmail = (props: {
   const previewText = `CHIP SPA ${variables.id} Submitted`;
   const heading =
     "This is confirmation that you submitted a CHIP State Plan Amendment to CMS for review:";
-
   return (
     <BaseEmailTemplate
       previewText={previewText}

--- a/lib/libs/email/content/newSubmission/emailTemplates/ChipSpaState.tsx
+++ b/lib/libs/email/content/newSubmission/emailTemplates/ChipSpaState.tsx
@@ -1,7 +1,7 @@
 import { Events } from "shared-types";
 import { CommonEmailVariables } from "shared-types";
 import { Link, Text } from "@react-email/components";
-import { PackageDetails } from "../../email-components";
+import { PackageDetails, BasicFooter } from "../../email-components";
 import { BaseEmailTemplate } from "../../email-templates";
 import { styles } from "../../email-styles";
 
@@ -18,6 +18,7 @@ export const ChipSpaStateEmail = (props: {
       previewText={previewText}
       heading={heading}
       applicationEndpointUrl={variables.applicationEndpointUrl}
+      footerContent={<BasicFooter />}
     >
       <PackageDetails
         details={{

--- a/lib/libs/email/content/newSubmission/emailTemplates/MedSpaState.tsx
+++ b/lib/libs/email/content/newSubmission/emailTemplates/MedSpaState.tsx
@@ -1,7 +1,7 @@
 import { Events } from "shared-types";
 import { formatNinetyDaysDate, formatDate } from "shared-utils";
 import { CommonEmailVariables } from "shared-types";
-import { PackageDetails, FollowUpNotice, MailboxNotice } from "../../email-components";
+import { PackageDetails, FollowUpNotice, MailboxNotice, BasicFooter } from "../../email-components";
 import { BaseEmailTemplate } from "../../email-templates";
 import { Text } from "@react-email/components";
 import { styles } from "../../email-styles";
@@ -17,6 +17,7 @@ export const MedSpaStateEmail = (props: {
       previewText={previewText}
       heading={heading}
       applicationEndpointUrl={variables.applicationEndpointUrl}
+      footerContent={<BasicFooter />}
     >
       <PackageDetails
         details={{

--- a/lib/libs/email/preview/InitialSubmissions/CMS/__snapshots__/InitialSubmissionCMS.test.tsx.snap
+++ b/lib/libs/email/preview/InitialSubmissions/CMS/__snapshots__/InitialSubmissionCMS.test.tsx.snap
@@ -1461,6 +1461,20 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a Amendment Waiver
                       </tbody>
                     </table>
                     <p
+                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
+                    >
+                       
+                      If the contents of this email seem suspicious, do not open them, and instead forward this email to
+                       
+                      <a
+                        href="mailto:SPAM@CMS.HHS.gov"
+                        style="color: rgb(6, 125, 247); text-decoration: underline;"
+                        target="_blank"
+                      >
+                        CHIPSPASubmissionMailBox@CMS.HHS.gov
+                      </a>
+                    </p>
+                    <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >
                       Thank you.
@@ -7086,6 +7100,20 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a Amendment Waiver
                         </tr>
                       </tbody>
                     </table>
+                    <p
+                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
+                    >
+                       
+                      If the contents of this email seem suspicious, do not open them, and instead forward this email to
+                       
+                      <a
+                        href="mailto:SPAM@CMS.HHS.gov"
+                        style="color: rgb(6, 125, 247); text-decoration: underline;"
+                        target="_blank"
+                      >
+                        CHIPSPASubmissionMailBox@CMS.HHS.gov
+                      </a>
+                    </p>
                     <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >
@@ -15574,6 +15602,20 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a Chipspa Preview 
                       </tbody>
                     </table>
                     <p
+                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
+                    >
+                       
+                      If the contents of this email seem suspicious, do not open them, and instead forward this email to
+                       
+                      <a
+                        href="mailto:SPAM@CMS.HHS.gov"
+                        style="color: rgb(6, 125, 247); text-decoration: underline;"
+                        target="_blank"
+                      >
+                        CHIPSPASubmissionMailBox@CMS.HHS.gov
+                      </a>
+                    </p>
+                    <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >
                       Thank you.
@@ -16502,6 +16544,20 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a Chipspa Preview 
                       </tr>
                     </tbody>
                   </table>
+                  <p
+                    style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
+                  >
+                     
+                    If the contents of this email seem suspicious, do not open them, and instead forward this email to
+                     
+                    <a
+                      href="mailto:SPAM@CMS.HHS.gov"
+                      style="color: rgb(6, 125, 247); text-decoration: underline;"
+                      target="_blank"
+                    >
+                      CHIPSPASubmissionMailBox@CMS.HHS.gov
+                    </a>
+                  </p>
                   <p
                     style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                   >
@@ -18073,6 +18129,20 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a Initial Waiver C
                         </tr>
                       </tbody>
                     </table>
+                    <p
+                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
+                    >
+                       
+                      If the contents of this email seem suspicious, do not open them, and instead forward this email to
+                       
+                      <a
+                        href="mailto:SPAM@CMS.HHS.gov"
+                        style="color: rgb(6, 125, 247); text-decoration: underline;"
+                        target="_blank"
+                      >
+                        CHIPSPASubmissionMailBox@CMS.HHS.gov
+                      </a>
+                    </p>
                     <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >
@@ -22565,6 +22635,20 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a Initial Waiver C
                         </tr>
                       </tbody>
                     </table>
+                    <p
+                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
+                    >
+                       
+                      If the contents of this email seem suspicious, do not open them, and instead forward this email to
+                       
+                      <a
+                        href="mailto:SPAM@CMS.HHS.gov"
+                        style="color: rgb(6, 125, 247); text-decoration: underline;"
+                        target="_blank"
+                      >
+                        CHIPSPASubmissionMailBox@CMS.HHS.gov
+                      </a>
+                    </p>
                     <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >
@@ -28736,6 +28820,20 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a Medicaid Spa Pre
                       </tbody>
                     </table>
                     <p
+                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
+                    >
+                       
+                      If the contents of this email seem suspicious, do not open them, and instead forward this email to
+                       
+                      <a
+                        href="mailto:SPAM@CMS.HHS.gov"
+                        style="color: rgb(6, 125, 247); text-decoration: underline;"
+                        target="_blank"
+                      >
+                        CHIPSPASubmissionMailBox@CMS.HHS.gov
+                      </a>
+                    </p>
+                    <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >
                       Thank you.
@@ -32791,6 +32889,20 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a Renewal Waiver C
                         </tr>
                       </tbody>
                     </table>
+                    <p
+                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
+                    >
+                       
+                      If the contents of this email seem suspicious, do not open them, and instead forward this email to
+                       
+                      <a
+                        href="mailto:SPAM@CMS.HHS.gov"
+                        style="color: rgb(6, 125, 247); text-decoration: underline;"
+                        target="_blank"
+                      >
+                        CHIPSPASubmissionMailBox@CMS.HHS.gov
+                      </a>
+                    </p>
                     <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >
@@ -37919,6 +38031,20 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a Renewal Waiver C
                         </tr>
                       </tbody>
                     </table>
+                    <p
+                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
+                    >
+                       
+                      If the contents of this email seem suspicious, do not open them, and instead forward this email to
+                       
+                      <a
+                        href="mailto:SPAM@CMS.HHS.gov"
+                        style="color: rgb(6, 125, 247); text-decoration: underline;"
+                        target="_blank"
+                      >
+                        CHIPSPASubmissionMailBox@CMS.HHS.gov
+                      </a>
+                    </p>
                     <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >
@@ -44633,6 +44759,20 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a TempExt Preview 
                         </tr>
                       </tbody>
                     </table>
+                    <p
+                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
+                    >
+                       
+                      If the contents of this email seem suspicious, do not open them, and instead forward this email to
+                       
+                      <a
+                        href="mailto:SPAM@CMS.HHS.gov"
+                        style="color: rgb(6, 125, 247); text-decoration: underline;"
+                        target="_blank"
+                      >
+                        CHIPSPASubmissionMailBox@CMS.HHS.gov
+                      </a>
+                    </p>
                     <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >

--- a/lib/libs/email/preview/InitialSubmissions/State/__snapshots__/InitialSubmissionState.test.tsx.snap
+++ b/lib/libs/email/preview/InitialSubmissions/State/__snapshots__/InitialSubmissionState.test.tsx.snap
@@ -816,7 +816,36 @@ exports[`Initial Submission State Email Snapshot Test > renders a Amendment Capi
                   >
                     <tbody>
                       <tr>
-                        <td />
+                        <td>
+                          <table
+                            align="center"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 14px; padding: 0px 0px; font-weight: 300; background-color: rgb(0, 113, 189); color: rgb(255, 255, 255); text-align: center;"
+                            width="100%"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    U.S. Centers for Medicare & Medicaid Services
+                                  </p>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    © 
+                                    2023
+                                     | 7500 Security Boulevard, Baltimore, MD 21244
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -1241,7 +1270,36 @@ exports[`Initial Submission State Email Snapshot Test > renders a Amendment Capi
                   >
                     <tbody>
                       <tr>
-                        <td />
+                        <td>
+                          <table
+                            align="center"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 14px; padding: 0px 0px; font-weight: 300; background-color: rgb(0, 113, 189); color: rgb(255, 255, 255); text-align: center;"
+                            width="100%"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    U.S. Centers for Medicare & Medicaid Services
+                                  </p>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    © 
+                                    2023
+                                     | 7500 Security Boulevard, Baltimore, MD 21244
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -4664,7 +4722,36 @@ exports[`Initial Submission State Email Snapshot Test > renders a Amendment Cont
                   >
                     <tbody>
                       <tr>
-                        <td />
+                        <td>
+                          <table
+                            align="center"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 14px; padding: 0px 0px; font-weight: 300; background-color: rgb(0, 113, 189); color: rgb(255, 255, 255); text-align: center;"
+                            width="100%"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    U.S. Centers for Medicare & Medicaid Services
+                                  </p>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    © 
+                                    2023
+                                     | 7500 Security Boulevard, Baltimore, MD 21244
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -5089,7 +5176,36 @@ exports[`Initial Submission State Email Snapshot Test > renders a Amendment Cont
                   >
                     <tbody>
                       <tr>
-                        <td />
+                        <td>
+                          <table
+                            align="center"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 14px; padding: 0px 0px; font-weight: 300; background-color: rgb(0, 113, 189); color: rgb(255, 255, 255); text-align: center;"
+                            width="100%"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    U.S. Centers for Medicare & Medicaid Services
+                                  </p>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    © 
+                                    2023
+                                     | 7500 Security Boulevard, Baltimore, MD 21244
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -11064,7 +11180,36 @@ exports[`Initial Submission State Email Snapshot Test > renders a Chipspa Previe
                   >
                     <tbody>
                       <tr>
-                        <td />
+                        <td>
+                          <table
+                            align="center"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 14px; padding: 0px 0px; font-weight: 300; background-color: rgb(0, 113, 189); color: rgb(255, 255, 255); text-align: center;"
+                            width="100%"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    U.S. Centers for Medicare & Medicaid Services
+                                  </p>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    © 
+                                    2023
+                                     | 7500 Security Boulevard, Baltimore, MD 21244
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -11389,7 +11534,36 @@ exports[`Initial Submission State Email Snapshot Test > renders a Chipspa Previe
                 >
                   <tbody>
                     <tr>
-                      <td />
+                      <td>
+                        <table
+                          align="center"
+                          border="0"
+                          cellpadding="0"
+                          cellspacing="0"
+                          role="presentation"
+                          style="font-size: 14px; padding: 0px 0px; font-weight: 300; background-color: rgb(0, 113, 189); color: rgb(255, 255, 255); text-align: center;"
+                          width="100%"
+                        >
+                          <tbody>
+                            <tr>
+                              <td>
+                                <p
+                                  style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                >
+                                  U.S. Centers for Medicare & Medicaid Services
+                                </p>
+                                <p
+                                  style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                >
+                                  © 
+                                  2023
+                                   | 7500 Security Boulevard, Baltimore, MD 21244
+                                </p>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
                     </tr>
                   </tbody>
                 </table>
@@ -12270,7 +12444,36 @@ exports[`Initial Submission State Email Snapshot Test > renders a Initial Capita
                   >
                     <tbody>
                       <tr>
-                        <td />
+                        <td>
+                          <table
+                            align="center"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 14px; padding: 0px 0px; font-weight: 300; background-color: rgb(0, 113, 189); color: rgb(255, 255, 255); text-align: center;"
+                            width="100%"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    U.S. Centers for Medicare & Medicaid Services
+                                  </p>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    © 
+                                    2023
+                                     | 7500 Security Boulevard, Baltimore, MD 21244
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -12695,7 +12898,36 @@ exports[`Initial Submission State Email Snapshot Test > renders a Initial Capita
                   >
                     <tbody>
                       <tr>
-                        <td />
+                        <td>
+                          <table
+                            align="center"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 14px; padding: 0px 0px; font-weight: 300; background-color: rgb(0, 113, 189); color: rgb(255, 255, 255); text-align: center;"
+                            width="100%"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    U.S. Centers for Medicare & Medicaid Services
+                                  </p>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    © 
+                                    2023
+                                     | 7500 Security Boulevard, Baltimore, MD 21244
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -15130,7 +15362,36 @@ exports[`Initial Submission State Email Snapshot Test > renders a Initial Contra
                   >
                     <tbody>
                       <tr>
-                        <td />
+                        <td>
+                          <table
+                            align="center"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 14px; padding: 0px 0px; font-weight: 300; background-color: rgb(0, 113, 189); color: rgb(255, 255, 255); text-align: center;"
+                            width="100%"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    U.S. Centers for Medicare & Medicaid Services
+                                  </p>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    © 
+                                    2023
+                                     | 7500 Security Boulevard, Baltimore, MD 21244
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -15555,7 +15816,36 @@ exports[`Initial Submission State Email Snapshot Test > renders a Initial Contra
                   >
                     <tbody>
                       <tr>
-                        <td />
+                        <td>
+                          <table
+                            align="center"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 14px; padding: 0px 0px; font-weight: 300; background-color: rgb(0, 113, 189); color: rgb(255, 255, 255); text-align: center;"
+                            width="100%"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    U.S. Centers for Medicare & Medicaid Services
+                                  </p>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    © 
+                                    2023
+                                     | 7500 Security Boulevard, Baltimore, MD 21244
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -19498,7 +19788,36 @@ exports[`Initial Submission State Email Snapshot Test > renders a Medicaid Spa P
                   >
                     <tbody>
                       <tr>
-                        <td />
+                        <td>
+                          <table
+                            align="center"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 14px; padding: 0px 0px; font-weight: 300; background-color: rgb(0, 113, 189); color: rgb(255, 255, 255); text-align: center;"
+                            width="100%"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    U.S. Centers for Medicare & Medicaid Services
+                                  </p>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    © 
+                                    2023
+                                     | 7500 Security Boulevard, Baltimore, MD 21244
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -19923,7 +20242,36 @@ exports[`Initial Submission State Email Snapshot Test > renders a Medicaid Spa P
                   >
                     <tbody>
                       <tr>
-                        <td />
+                        <td>
+                          <table
+                            align="center"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 14px; padding: 0px 0px; font-weight: 300; background-color: rgb(0, 113, 189); color: rgb(255, 255, 255); text-align: center;"
+                            width="100%"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    U.S. Centers for Medicare & Medicaid Services
+                                  </p>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    © 
+                                    2023
+                                     | 7500 Security Boulevard, Baltimore, MD 21244
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -20349,7 +20697,36 @@ exports[`Initial Submission State Email Snapshot Test > renders a Medicaid Spa P
                 >
                   <tbody>
                     <tr>
-                      <td />
+                      <td>
+                        <table
+                          align="center"
+                          border="0"
+                          cellpadding="0"
+                          cellspacing="0"
+                          role="presentation"
+                          style="font-size: 14px; padding: 0px 0px; font-weight: 300; background-color: rgb(0, 113, 189); color: rgb(255, 255, 255); text-align: center;"
+                          width="100%"
+                        >
+                          <tbody>
+                            <tr>
+                              <td>
+                                <p
+                                  style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                >
+                                  U.S. Centers for Medicare & Medicaid Services
+                                </p>
+                                <p
+                                  style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                >
+                                  © 
+                                  2023
+                                   | 7500 Security Boulevard, Baltimore, MD 21244
+                                </p>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
                     </tr>
                   </tbody>
                 </table>
@@ -21230,7 +21607,36 @@ exports[`Initial Submission State Email Snapshot Test > renders a Renewal Capita
                   >
                     <tbody>
                       <tr>
-                        <td />
+                        <td>
+                          <table
+                            align="center"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 14px; padding: 0px 0px; font-weight: 300; background-color: rgb(0, 113, 189); color: rgb(255, 255, 255); text-align: center;"
+                            width="100%"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    U.S. Centers for Medicare & Medicaid Services
+                                  </p>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    © 
+                                    2023
+                                     | 7500 Security Boulevard, Baltimore, MD 21244
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -21655,7 +22061,36 @@ exports[`Initial Submission State Email Snapshot Test > renders a Renewal Capita
                   >
                     <tbody>
                       <tr>
-                        <td />
+                        <td>
+                          <table
+                            align="center"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 14px; padding: 0px 0px; font-weight: 300; background-color: rgb(0, 113, 189); color: rgb(255, 255, 255); text-align: center;"
+                            width="100%"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    U.S. Centers for Medicare & Medicaid Services
+                                  </p>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    © 
+                                    2023
+                                     | 7500 Security Boulevard, Baltimore, MD 21244
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -24584,7 +25019,36 @@ exports[`Initial Submission State Email Snapshot Test > renders a Renewal Contra
                   >
                     <tbody>
                       <tr>
-                        <td />
+                        <td>
+                          <table
+                            align="center"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 14px; padding: 0px 0px; font-weight: 300; background-color: rgb(0, 113, 189); color: rgb(255, 255, 255); text-align: center;"
+                            width="100%"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    U.S. Centers for Medicare & Medicaid Services
+                                  </p>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    © 
+                                    2023
+                                     | 7500 Security Boulevard, Baltimore, MD 21244
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -25009,7 +25473,36 @@ exports[`Initial Submission State Email Snapshot Test > renders a Renewal Contra
                   >
                     <tbody>
                       <tr>
-                        <td />
+                        <td>
+                          <table
+                            align="center"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 14px; padding: 0px 0px; font-weight: 300; background-color: rgb(0, 113, 189); color: rgb(255, 255, 255); text-align: center;"
+                            width="100%"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    U.S. Centers for Medicare & Medicaid Services
+                                  </p>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    © 
+                                    2023
+                                     | 7500 Security Boulevard, Baltimore, MD 21244
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -29433,7 +29926,36 @@ exports[`Initial Submission State Email Snapshot Test > renders a TempExt Previe
                   >
                     <tbody>
                       <tr>
-                        <td />
+                        <td>
+                          <table
+                            align="center"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 14px; padding: 0px 0px; font-weight: 300; background-color: rgb(0, 113, 189); color: rgb(255, 255, 255); text-align: center;"
+                            width="100%"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    U.S. Centers for Medicare & Medicaid Services
+                                  </p>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    © 
+                                    2023
+                                     | 7500 Security Boulevard, Baltimore, MD 21244
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -29858,7 +30380,36 @@ exports[`Initial Submission State Email Snapshot Test > renders a TempExt Previe
                   >
                     <tbody>
                       <tr>
-                        <td />
+                        <td>
+                          <table
+                            align="center"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 14px; padding: 0px 0px; font-weight: 300; background-color: rgb(0, 113, 189); color: rgb(255, 255, 255); text-align: center;"
+                            width="100%"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    U.S. Centers for Medicare & Medicaid Services
+                                  </p>
+                                  <p
+                                    style="font-size: 14px; line-height: 24px; margin: 8px; color: rgb(255, 255, 255);"
+                                  >
+                                    © 
+                                    2023
+                                     | 7500 Security Boulevard, Baltimore, MD 21244
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
                       </tr>
                     </tbody>
                   </table>


### PR DESCRIPTION
## 🎫 Linked Ticket

https://jiraent.cms.gov/browse/OY2-33300?filter=-1

## 💬 Description / Notes

1. Add blue banner/footer to the Medicaid and CHIP SPA initial submission email notifications (displaying the CMS address)

## 🛠 Changes

Env - VAL
Login as a state user and submit a Medicaid SPA in mako.
Both State and CMS users should receive the notification.
Minor verbiage issue for the State user notification (everywhere we deleted that specific text but confluence still has this text for this notification
