### PR TITLE
fix(email): All email addresses should be in the "To" field

### DIFF
--- a/lib/libs/email/content/respondToRai/index.tsx
+++ b/lib/libs/email/content/respondToRai/index.tsx
@@ -31,7 +31,7 @@ export const respondToRai: AuthoritiesWithUserTypesTemplate = {
       return {
         to: [
           `${variables.submitterName} <${variables.submitterEmail}>`,
-          // Remove submitter from cc list:
+          // Prevent submitter from being added twice:
           ...(variables.allStateUsersEmails ?? []).filter(
             (email) => email !== variables.submitterEmail,
           ),
@@ -62,7 +62,7 @@ export const respondToRai: AuthoritiesWithUserTypesTemplate = {
       return {
         to: [
           `${variables.submitterName} <${variables.submitterEmail}>`,
-          // Remove submitter from cc list:
+          // Prevent submitter from being added twice:
           ...(variables.allStateUsersEmails ?? []).filter(
             (email) => email !== variables.submitterEmail,
           ),
@@ -93,7 +93,7 @@ export const respondToRai: AuthoritiesWithUserTypesTemplate = {
       return {
         to: [
           `${variables.submitterName} <${variables.submitterEmail}>`,
-          // Remove submitter from cc list:
+          // Prevent submitter from being added twice:
           ...(variables.allStateUsersEmails ?? []).filter(
             (email) => email !== variables.submitterEmail,
           ),
@@ -124,7 +124,7 @@ export const respondToRai: AuthoritiesWithUserTypesTemplate = {
       return {
         to: [
           `${variables.submitterName} <${variables.submitterEmail}>`,
-          // Remove submitter from cc list:
+          // Prevent submitter from being added twice:
           ...(variables.allStateUsersEmails ?? []).filter(
             (email) => email !== variables.submitterEmail,
           ),

--- a/lib/libs/email/content/respondToRai/index.tsx
+++ b/lib/libs/email/content/respondToRai/index.tsx
@@ -29,8 +29,13 @@ export const respondToRai: AuthoritiesWithUserTypesTemplate = {
       variables: Events["RespondToRai"] & CommonEmailVariables & { emails: EmailAddresses },
     ) => {
       return {
-        to: [`${variables.submitterName} <${variables.submitterEmail}>`],
-        cc: variables.allStateUsersEmails ?? [],
+        to: [
+          `${variables.submitterName} <${variables.submitterEmail}>`,
+          // Remove submitter from cc list:
+          ...(variables.allStateUsersEmails ?? []).filter(
+            (email) => email !== variables.submitterEmail,
+          ),
+        ],
         subject: `Your Medicaid SPA RAI Response for ${variables.id} has been submitted to CMS`,
         body: await render(<MedSpaStateEmail variables={variables} />),
       };
@@ -55,8 +60,13 @@ export const respondToRai: AuthoritiesWithUserTypesTemplate = {
       variables: Events["RespondToRai"] & CommonEmailVariables & { emails: EmailAddresses },
     ) => {
       return {
-        to: [`${variables.submitterName} <${variables.submitterEmail}>`],
-        cc: variables.allStateUsersEmails ?? [],
+        to: [
+          `${variables.submitterName} <${variables.submitterEmail}>`,
+          // Remove submitter from cc list:
+          ...(variables.allStateUsersEmails ?? []).filter(
+            (email) => email !== variables.submitterEmail,
+          ),
+        ],
         subject: `Your CHIP SPA RAI Response for ${variables.id} has been submitted to CMS`,
         body: await render(<ChipSpaStateEmail variables={variables} />),
       };
@@ -81,8 +91,13 @@ export const respondToRai: AuthoritiesWithUserTypesTemplate = {
       variables: Events["RespondToRai"] & CommonEmailVariables & { emails: EmailAddresses },
     ) => {
       return {
-        to: [`${variables.submitterName} <${variables.submitterEmail}>`],
-        cc: variables.allStateUsersEmails ?? [],
+        to: [
+          `${variables.submitterName} <${variables.submitterEmail}>`,
+          // Remove submitter from cc list:
+          ...(variables.allStateUsersEmails ?? []).filter(
+            (email) => email !== variables.submitterEmail,
+          ),
+        ],
         subject: `Your 1915(b) RAI Response for ${variables.id} has been submitted to CMS`,
         body: await render(<WaiverStateEmail variables={variables} />),
       };
@@ -107,8 +122,13 @@ export const respondToRai: AuthoritiesWithUserTypesTemplate = {
       variables: Events["RespondToRai"] & CommonEmailVariables & { emails: EmailAddresses },
     ) => {
       return {
-        to: [`${variables.submitterName} <${variables.submitterEmail}>`],
-        cc: variables.allStateUsersEmails ?? [],
+        to: [
+          `${variables.submitterName} <${variables.submitterEmail}>`,
+          // Remove submitter from cc list:
+          ...(variables.allStateUsersEmails ?? []).filter(
+            (email) => email !== variables.submitterEmail,
+          ),
+        ],
         subject: `Your 1915(c) RAI Response for ${variables.id} has been submitted to CMS`,
         body: await render(<WaiverStateEmail variables={variables} />),
       };


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->
https://jiraent.cms.gov/browse/OY2-33444

## 💬 Description / Notes

<!-- Briefly describe the background of the issue -->
<!-- If you feel the original ticket lacks important details, this would be the place to share them -->
This PR is for a change requested during QA. All state user email addresses for "Respond to RAI" messages should be in the "To" field, and none should be in the "cc" field.

## 🛠 Changes

<!-- List your code changes made to implement the solution -->
In `lib/libs/email/content/respondToRai/index.tsx`, the state user email addresses in `variables.allStateUsersEmails` are now added to the `to` field instead of the `cc` field. Additionally, we now filter out the submitter's email address from `variables.allStateUsersEmails` to avoid appearing twice in the `to` field.