### PR TITLE
fix(emails): filter out duplicate email addresses correctly

### DIFF
--- a/lib/libs/email/content/respondToRai/index.tsx
+++ b/lib/libs/email/content/respondToRai/index.tsx
@@ -33,7 +33,7 @@ export const respondToRai: AuthoritiesWithUserTypesTemplate = {
           `${variables.submitterName} <${variables.submitterEmail}>`,
           // Prevent submitter from being added twice:
           ...(variables.allStateUsersEmails ?? []).filter(
-            (email) => !email.includes("variables.submitterEmail"),
+            (email) => !email.includes(variables.submitterEmail),
           ),
         ],
         subject: `Your Medicaid SPA RAI Response for ${variables.id} has been submitted to CMS`,
@@ -64,7 +64,7 @@ export const respondToRai: AuthoritiesWithUserTypesTemplate = {
           `${variables.submitterName} <${variables.submitterEmail}>`,
           // Prevent submitter from being added twice:
           ...(variables.allStateUsersEmails ?? []).filter(
-            (email) => !email.includes("variables.submitterEmail"),
+            (email) => !email.includes(variables.submitterEmail),
           ),
         ],
         subject: `Your CHIP SPA RAI Response for ${variables.id} has been submitted to CMS`,
@@ -95,7 +95,7 @@ export const respondToRai: AuthoritiesWithUserTypesTemplate = {
           `${variables.submitterName} <${variables.submitterEmail}>`,
           // Prevent submitter from being added twice:
           ...(variables.allStateUsersEmails ?? []).filter(
-            (email) => !email.includes("variables.submitterEmail"),
+            (email) => !email.includes(variables.submitterEmail),
           ),
         ],
         subject: `Your 1915(b) RAI Response for ${variables.id} has been submitted to CMS`,
@@ -126,7 +126,7 @@ export const respondToRai: AuthoritiesWithUserTypesTemplate = {
           `${variables.submitterName} <${variables.submitterEmail}>`,
           // Prevent submitter from being added twice:
           ...(variables.allStateUsersEmails ?? []).filter(
-            (email) => !email.includes("variables.submitterEmail"),
+            (email) => !email.includes(variables.submitterEmail),
           ),
         ],
         subject: `Your 1915(c) RAI Response for ${variables.id} has been submitted to CMS`,

--- a/lib/libs/email/content/respondToRai/index.tsx
+++ b/lib/libs/email/content/respondToRai/index.tsx
@@ -33,7 +33,7 @@ export const respondToRai: AuthoritiesWithUserTypesTemplate = {
           `${variables.submitterName} <${variables.submitterEmail}>`,
           // Prevent submitter from being added twice:
           ...(variables.allStateUsersEmails ?? []).filter(
-            (email) => email !== variables.submitterEmail,
+            (email) => !email.includes("variables.submitterEmail"),
           ),
         ],
         subject: `Your Medicaid SPA RAI Response for ${variables.id} has been submitted to CMS`,
@@ -64,7 +64,7 @@ export const respondToRai: AuthoritiesWithUserTypesTemplate = {
           `${variables.submitterName} <${variables.submitterEmail}>`,
           // Prevent submitter from being added twice:
           ...(variables.allStateUsersEmails ?? []).filter(
-            (email) => email !== variables.submitterEmail,
+            (email) => !email.includes("variables.submitterEmail"),
           ),
         ],
         subject: `Your CHIP SPA RAI Response for ${variables.id} has been submitted to CMS`,
@@ -95,7 +95,7 @@ export const respondToRai: AuthoritiesWithUserTypesTemplate = {
           `${variables.submitterName} <${variables.submitterEmail}>`,
           // Prevent submitter from being added twice:
           ...(variables.allStateUsersEmails ?? []).filter(
-            (email) => email !== variables.submitterEmail,
+            (email) => !email.includes("variables.submitterEmail"),
           ),
         ],
         subject: `Your 1915(b) RAI Response for ${variables.id} has been submitted to CMS`,
@@ -126,7 +126,7 @@ export const respondToRai: AuthoritiesWithUserTypesTemplate = {
           `${variables.submitterName} <${variables.submitterEmail}>`,
           // Prevent submitter from being added twice:
           ...(variables.allStateUsersEmails ?? []).filter(
-            (email) => email !== variables.submitterEmail,
+            (email) => !email.includes("variables.submitterEmail"),
           ),
         ],
         subject: `Your 1915(c) RAI Response for ${variables.id} has been submitted to CMS`,


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->
https://jiraent.cms.gov/browse/OY2-32873

## 💬 Description / Notes

<!-- Briefly describe the background of the issue -->
<!-- If you feel the original ticket lacks important details, this would be the place to share them -->

This PR addresses [feedback from the QA phase in Val](https://jiraent.cms.gov/browse/OY2-33446). Previously, Padma was seeing her email address duplicated in the "To" field. These changes aim to resolve that issue by filtering out the "To" email addresses from the "CC" array.

This will need to be tested on Val by Padma with her email address to confirm that the fix works.

## 🛠 Changes

<!-- List your code changes made to implement the solution -->
Instead of looking for a string that exactly matches the email address, we filter out "CC" addresses that contain the "To" email address as a substring. This is because the email addresses are formatted in this format: "Firstname Lastname <email@address.com>".

By filtering out based on substring, we can skip any address lines that contain a duplicate email address, preventing duplicate email from being sent.