### PR TITLE
Fix(text): The FAQ page should display as "Documents" instead of "Docs"

### DIFF
--- a/react-app/src/features/faq/content/oneMACFAQContent.tsx
+++ b/react-app/src/features/faq/content/oneMACFAQContent.tsx
@@ -731,7 +731,7 @@ export const oneMACFAQContent: FAQContent[] = [
                   </td>
                 </tr>
                 <tr>
-                  <td className="border border-gray-300 px-4 py-2">Budget Docs</td>
+                  <td className="border border-gray-300 px-4 py-2">Budget Documents</td>
                   <td className="border border-gray-300 px-4 py-2">
                     Updated 1-year budget if applicable of the State's planned expenditures if the
                     CHIP SPA submission has a significant impact on the approved budget
@@ -794,7 +794,7 @@ export const oneMACFAQContent: FAQContent[] = [
                   </td>
                 </tr>
                 <tr>
-                  <td className="border border-gray-300 px-4 py-2">Budget Docs</td>
+                  <td className="border border-gray-300 px-4 py-2">Budget Documents</td>
                   <td className="border border-gray-300 px-4 py-2">
                     Updated 1-year budget if applicable of the State’s planned expenditures if the
                     CHIP SPA submission has a significant impact on the approved budget


### PR DESCRIPTION
## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

https://jiraent.cms.gov/browse/OY2-33301?filter=-1

## 💬 Description / Notes

1. Update "Budget Docs" to " Budget Documents" on the FAQ page for the CHIP SPA attachments section

## 🛠 Changes

Paste the mako URL and click on FAQ tab.
Scroll down to CHIP SPA attachments section.
Issue - The FAQ page should display as "Documents" instead of "Docs" for CHIP SPA initial submission and RAI Response attachments.
