### PR TITLE
Fix(email): Footer missing and minor verbiage issue for Medicaid/CHIP SPAs initial submission notification.

### DIFF
--- a/lib/libs/email/content/newSubmission/emailTemplates/ChipSpaCMS.tsx
+++ b/lib/libs/email/content/newSubmission/emailTemplates/ChipSpaCMS.tsx
@@ -6,8 +6,6 @@ import {
   Attachments,
 } from "../../email-components";
 import { BaseEmailTemplate } from "../../email-templates";
-import { Link, Text } from "@react-email/components";
-import { styles } from "../../email-styles";
 
 export const ChipSpaCMSEmail = ({
   variables,
@@ -34,14 +32,6 @@ export const ChipSpaCMSEmail = ({
         }}
       />
       <Attachments attachments={variables.attachments} />
-      <Text style={{ ...styles.text.base, marginTop: "16px" }}>
-        {" "}
-        If the contents of this email seem suspicious, do not open them, and instead forward this
-        email to{" "}
-        <Link href={`mailto:SPAM@CMS.HHS.gov`} style={{ textDecoration: "underline" }}>
-          CHIPSPASubmissionMailBox@CMS.HHS.gov
-        </Link>
-      </Text>
     </BaseEmailTemplate>
   );
 };

--- a/lib/libs/email/preview/InitialSubmissions/CMS/__snapshots__/InitialSubmissionCMS.test.tsx.snap
+++ b/lib/libs/email/preview/InitialSubmissions/CMS/__snapshots__/InitialSubmissionCMS.test.tsx.snap
@@ -1461,20 +1461,6 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a Amendment Waiver
                       </tbody>
                     </table>
                     <p
-                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
-                    >
-                       
-                      If the contents of this email seem suspicious, do not open them, and instead forward this email to
-                       
-                      <a
-                        href="mailto:SPAM@CMS.HHS.gov"
-                        style="color: rgb(6, 125, 247); text-decoration: underline;"
-                        target="_blank"
-                      >
-                        CHIPSPASubmissionMailBox@CMS.HHS.gov
-                      </a>
-                    </p>
-                    <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >
                       Thank you.
@@ -7100,20 +7086,6 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a Amendment Waiver
                         </tr>
                       </tbody>
                     </table>
-                    <p
-                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
-                    >
-                       
-                      If the contents of this email seem suspicious, do not open them, and instead forward this email to
-                       
-                      <a
-                        href="mailto:SPAM@CMS.HHS.gov"
-                        style="color: rgb(6, 125, 247); text-decoration: underline;"
-                        target="_blank"
-                      >
-                        CHIPSPASubmissionMailBox@CMS.HHS.gov
-                      </a>
-                    </p>
                     <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >
@@ -15602,20 +15574,6 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a Chipspa Preview 
                       </tbody>
                     </table>
                     <p
-                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
-                    >
-                       
-                      If the contents of this email seem suspicious, do not open them, and instead forward this email to
-                       
-                      <a
-                        href="mailto:SPAM@CMS.HHS.gov"
-                        style="color: rgb(6, 125, 247); text-decoration: underline;"
-                        target="_blank"
-                      >
-                        CHIPSPASubmissionMailBox@CMS.HHS.gov
-                      </a>
-                    </p>
-                    <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >
                       Thank you.
@@ -16544,20 +16502,6 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a Chipspa Preview 
                       </tr>
                     </tbody>
                   </table>
-                  <p
-                    style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
-                  >
-                     
-                    If the contents of this email seem suspicious, do not open them, and instead forward this email to
-                     
-                    <a
-                      href="mailto:SPAM@CMS.HHS.gov"
-                      style="color: rgb(6, 125, 247); text-decoration: underline;"
-                      target="_blank"
-                    >
-                      CHIPSPASubmissionMailBox@CMS.HHS.gov
-                    </a>
-                  </p>
                   <p
                     style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                   >
@@ -18129,20 +18073,6 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a Initial Waiver C
                         </tr>
                       </tbody>
                     </table>
-                    <p
-                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
-                    >
-                       
-                      If the contents of this email seem suspicious, do not open them, and instead forward this email to
-                       
-                      <a
-                        href="mailto:SPAM@CMS.HHS.gov"
-                        style="color: rgb(6, 125, 247); text-decoration: underline;"
-                        target="_blank"
-                      >
-                        CHIPSPASubmissionMailBox@CMS.HHS.gov
-                      </a>
-                    </p>
                     <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >
@@ -22635,20 +22565,6 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a Initial Waiver C
                         </tr>
                       </tbody>
                     </table>
-                    <p
-                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
-                    >
-                       
-                      If the contents of this email seem suspicious, do not open them, and instead forward this email to
-                       
-                      <a
-                        href="mailto:SPAM@CMS.HHS.gov"
-                        style="color: rgb(6, 125, 247); text-decoration: underline;"
-                        target="_blank"
-                      >
-                        CHIPSPASubmissionMailBox@CMS.HHS.gov
-                      </a>
-                    </p>
                     <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >
@@ -28820,20 +28736,6 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a Medicaid Spa Pre
                       </tbody>
                     </table>
                     <p
-                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
-                    >
-                       
-                      If the contents of this email seem suspicious, do not open them, and instead forward this email to
-                       
-                      <a
-                        href="mailto:SPAM@CMS.HHS.gov"
-                        style="color: rgb(6, 125, 247); text-decoration: underline;"
-                        target="_blank"
-                      >
-                        CHIPSPASubmissionMailBox@CMS.HHS.gov
-                      </a>
-                    </p>
-                    <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >
                       Thank you.
@@ -32889,20 +32791,6 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a Renewal Waiver C
                         </tr>
                       </tbody>
                     </table>
-                    <p
-                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
-                    >
-                       
-                      If the contents of this email seem suspicious, do not open them, and instead forward this email to
-                       
-                      <a
-                        href="mailto:SPAM@CMS.HHS.gov"
-                        style="color: rgb(6, 125, 247); text-decoration: underline;"
-                        target="_blank"
-                      >
-                        CHIPSPASubmissionMailBox@CMS.HHS.gov
-                      </a>
-                    </p>
                     <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >
@@ -38031,20 +37919,6 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a Renewal Waiver C
                         </tr>
                       </tbody>
                     </table>
-                    <p
-                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
-                    >
-                       
-                      If the contents of this email seem suspicious, do not open them, and instead forward this email to
-                       
-                      <a
-                        href="mailto:SPAM@CMS.HHS.gov"
-                        style="color: rgb(6, 125, 247); text-decoration: underline;"
-                        target="_blank"
-                      >
-                        CHIPSPASubmissionMailBox@CMS.HHS.gov
-                      </a>
-                    </p>
                     <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >
@@ -44759,20 +44633,6 @@ exports[`Initial Submission CMS Email Snapshot Test > renders a TempExt Preview 
                         </tr>
                       </tbody>
                     </table>
-                    <p
-                      style="font-size: 14px; line-height: 1.4; margin: 16px 0px 12px 0px; color: rgb(51, 51, 51);"
-                    >
-                       
-                      If the contents of this email seem suspicious, do not open them, and instead forward this email to
-                       
-                      <a
-                        href="mailto:SPAM@CMS.HHS.gov"
-                        style="color: rgb(6, 125, 247); text-decoration: underline;"
-                        target="_blank"
-                      >
-                        CHIPSPASubmissionMailBox@CMS.HHS.gov
-                      </a>
-                    </p>
                     <p
                       style="font-size: 14px; line-height: 1.4; margin: 12px 0px; color: rgb(51, 51, 51);"
                     >


### PR DESCRIPTION
## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

https://jiraent.cms.gov/browse/OY2-33300?filter=-1

## 💬 Description / Notes

1. Add blue banner/footer to the Medicaid and CHIP SPA initial submission email notifications (displaying the CMS address)

## 🛠 Changes

removed spam line from cms new submission email 