### PR TITLE
fix(forms): Reorder contract renewal upload fields

### DIFF
--- a/lib/packages/shared-types/events/contracting-renewal.ts
+++ b/lib/packages/shared-types/events/contracting-renewal.ts
@@ -13,6 +13,12 @@ export const baseSchema = z.object({
     }),
   proposedEffectiveDate: z.number(),
   attachments: z.object({
+    b4WaiverApplication: z.object({
+      label: z
+        .string()
+        .default("1915(b)(4) FFS Selective Contracting (Streamlined) Waiver Application Pre-print"),
+      files: attachmentArraySchema(),
+    }),
     b4IndependentAssessment: z.object({
       label: z
         .string()
@@ -20,12 +26,6 @@ export const baseSchema = z.object({
           "1915(b)(4) FFS Selective Contracting (Streamlined) Independent Assessment (first two renewals only)",
         ),
       files: attachmentArraySchemaOptional(),
-    }),
-    b4WaiverApplication: z.object({
-      label: z
-        .string()
-        .default("1915(b)(4) FFS Selective Contracting (Streamlined) Waiver Application Pre-print"),
-      files: attachmentArraySchema(),
     }),
     tribalConsultation: z.object({
       label: z.string().default("Tribal Consultation"),

--- a/mocks/data/submit/changelog.ts
+++ b/mocks/data/submit/changelog.ts
@@ -90,8 +90,8 @@ export const contractingRenewal = {
   authority: "1915(b)",
   proposedEffectiveDate: 1700000000,
   attachments: {
-    ...attachments.b4IndependentAssessment,
     ...attachments.b4Waiver,
+    ...attachments.b4IndependentAssessment,
     ...attachments.tribalConsultation,
     ...attachments.other,
   },


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

https://jiraent.cms.gov/browse/OY2-32392

## 💬 Description / Notes

<!-- Briefly describe the background of the issue -->
<!-- If you feel the original ticket lacks important details, this would be the place to share them -->
Per QA feedback, there were two additional places where the upload components were out of order. Both places use `lib/packages/shared-types/events/contracting-renewal.ts` to determine this order, so the change was made there. `changelog.ts` was also updated with the change.