### PR TITLE
fix(ui): Update text on download attachment buttons

### DIFF
--- a/react-app/src/features/package/package-activity/index.test.tsx
+++ b/react-app/src/features/package/package-activity/index.test.tsx
@@ -39,10 +39,10 @@ describe("Package Activity", () => {
 
     expect(screen.getByText("Package Activity (0)"));
     expect(screen.getByText("No package activity recorded"));
-    expect(screen.queryByText("Download all documents")).not.toBeInTheDocument();
+    expect(screen.queryByText("Download all attachments")).not.toBeInTheDocument();
   });
 
-  it("displays the correct title with changelog length, a changelog entry, and the 'Download all documents' button", async () => {
+  it("displays the correct title with changelog length, a changelog entry, and the 'Download all attachments' button", async () => {
     await renderFormWithPackageSectionAsync(
       <PackageActivities
         id={WITHDRAWN_CHANGELOG_ITEM_ID}
@@ -53,11 +53,11 @@ describe("Package Activity", () => {
 
     expect(screen.getByText("Package Activity (7)"));
     expect(screen.getByText("Initial Package Submitted"));
-    expect(screen.getByText("Download all documents"));
+    expect(screen.getByText("Download all attachments"));
     expect(screen.getByText("Contract Amendment"));
   });
 
-  it("calls 'Download all documents' with onZip and the correct attachment arguments", async () => {
+  it("calls 'Download all attachments' with onZip and the correct attachment arguments", async () => {
     const spiedOnZip = vi.fn();
 
     // @ts-expect-error
@@ -75,8 +75,8 @@ describe("Package Activity", () => {
       WITHDRAWN_CHANGELOG_ITEM_ID,
     );
 
-    const downloadAllDocumentsBtn = screen.getByText("Download all documents");
-    await user.click(downloadAllDocumentsBtn);
+    const downloadAllAttachmentsBtn = screen.getByText("Download all attachments");
+    await user.click(downloadAllAttachmentsBtn);
 
     expect(spiedOnZip).toBeCalledWith([
       {
@@ -124,7 +124,7 @@ describe("Package Activity", () => {
     ]);
   });
 
-  it("calls 'Download documents' with onZip and the correct attachment arguments", async () => {
+  it("calls 'Download section attachments' with onZip and the correct attachment arguments", async () => {
     const spiedOnZip = vi.fn();
 
     // @ts-expect-error
@@ -142,8 +142,8 @@ describe("Package Activity", () => {
       WITHDRAWN_CHANGELOG_ITEM_ID,
     );
 
-    const downloadDocumentsBtn = screen.getByText("Download documents");
-    await user.click(downloadDocumentsBtn);
+    const downloadAttachmentsBtn = screen.getByText("Download section attachments");
+    await user.click(downloadAttachmentsBtn);
 
     expect(spiedOnZip).toBeCalledWith([
       {

--- a/react-app/src/features/package/package-activity/index.tsx
+++ b/react-app/src/features/package/package-activity/index.tsx
@@ -70,7 +70,7 @@ const Submission = ({ packageActivity }: SubmissionProps) => {
           loading={loading}
           onClick={() => onZip(attachments)}
         >
-          Download documents
+          Download section attachments
         </Table.Button>
       )}
 
@@ -164,7 +164,7 @@ const DownloadAllButton = ({ packageId, submissionChangelog }: DownloadAllButton
 
   return (
     <Table.Button loading={loading} onClick={onDownloadAll} variant="outline">
-      Download all documents
+      Download all attachments
     </Table.Button>
   );
 };


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->
[OY2-33529](https://jiraent.cms.gov/browse/OY2-33529)

## 💬 Description / Notes

<!-- Briefly describe the background of the issue -->
<!-- If you feel the original ticket lacks important details, this would be the place to share them -->
The download document button text in the package activity section should be changed from "Download all documents" to "Download all attachments"

## 🛠 Changes

<!-- List your code changes made to implement the solution -->
"Document" has been changed to "attachment" and tests have been edited to accomodate for this change.
## 📸 Screenshots / Demo

<!-- ### Before -->

<!-- ### After -->
<img width="972" alt="Screen Shot 2025-03-17 at 2 53 42 PM" src="https://github.com/user-attachments/assets/36043883-9a50-418d-a51e-8bd0456325e9" />
<img width="934" alt="Screen Shot 2025-03-17 at 2 54 14 PM" src="https://github.com/user-attachments/assets/3d4d8868-443b-4271-927d-8e28572dd49c" />
