### PR TITLE
feat(ui) prevent files of same name

### DIFF
--- a/react-app/src/components/Inputs/upload.test.tsx
+++ b/react-app/src/components/Inputs/upload.test.tsx
@@ -92,7 +92,23 @@ describe("Upload", () => {
       expect(screen.getByText(`File "${file.name}" has an invalid type.`)).toBeInTheDocument();
     });
   });
+  it("displays an error for a file that is too large", async () => {
+    renderWithQueryClient(<Upload {...defaultProps} />);
 
+    const dropzone = screen.getByRole("presentation");
+    const file = new File(["file contents"], "file.txt", { type: "application/x-msdownload" });
+    Object.defineProperty(file, "size", { value: 80 * 1024 * 1024 + 1 });
+    Object.defineProperty(dropzone, "files", {
+      value: [file],
+      writable: false,
+    });
+
+    fireEvent.drop(dropzone);
+
+    await waitFor(() => {
+      expect(screen.getByText(`File "file.txt" is too large to upload.`)).toBeInTheDocument();
+    });
+  });
   it("does not display the dropzone when uploading", async () => {
     renderWithQueryClient(<Upload {...defaultProps} />);
 

--- a/react-app/src/components/Inputs/upload.test.tsx
+++ b/react-app/src/components/Inputs/upload.test.tsx
@@ -11,26 +11,28 @@ const defaultProps = {
   setFiles: vi.fn(),
   setErrorMessage: vi.fn(),
 };
-
+const FILE_1 = "file-1";
+const FILE_2 = "file-2";
+const FILE_REMOVE = "file-to-remove";
 const files = [
   {
-    key: "file-1",
-    title: "file-1.txt",
-    filename: "file-1.txt",
+    key: FILE_1,
+    title: `${FILE_1}.txt`,
+    filename: `${FILE_1}.txt`,
     bucket: "bucket-1",
     uploadDate: Date.now(),
   },
   {
-    key: "file-to-remove",
-    title: "file-to-remove.txt",
-    filename: "file-to-remove.txt",
+    key: FILE_REMOVE,
+    title: `${FILE_REMOVE}.txt`,
+    filename: `${FILE_REMOVE}.txt`,
     bucket: "bucket-1",
     uploadDate: Date.now(),
   },
   {
-    key: "file-2",
-    title: "file-2.txt",
-    filename: "file-2.txt",
+    key: FILE_2,
+    title: `${FILE_2}.txt`,
+    filename: `${FILE_2}.txt`,
     bucket: "bucket-1",
     uploadDate: Date.now(),
   },
@@ -96,7 +98,7 @@ describe("Upload", () => {
     renderWithQueryClient(<Upload {...defaultProps} />);
 
     const dropzone = screen.getByRole("presentation");
-    const file = new File(["file contents"], "file.txt", { type: "application/x-msdownload" });
+    const file = new File(["file contents"], "file.txt", { type: "text/plain" });
     Object.defineProperty(file, "size", { value: 80 * 1024 * 1024 + 1 });
     Object.defineProperty(dropzone, "files", {
       value: [file],
@@ -107,6 +109,25 @@ describe("Upload", () => {
 
     await waitFor(() => {
       expect(screen.getByText(`File "file.txt" is too large to upload.`)).toBeInTheDocument();
+    });
+  });
+  it("displays an error for a file that already is uploaded", async () => {
+    const mockSetFiles = vi.fn();
+    renderWithQueryClient(<Upload {...defaultProps} files={files} setFiles={mockSetFiles} />);
+
+    const dropzone = screen.getByRole("presentation");
+    const file = new File(["file contents"], `${FILE_1}.txt`, { type: "text/plain" });
+    Object.defineProperty(dropzone, "files", {
+      value: [file],
+      writable: false,
+    });
+
+    fireEvent.drop(dropzone);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(`File with name "${FILE_1}.txt" already exists.`),
+      ).toBeInTheDocument();
     });
   });
   it("does not display the dropzone when uploading", async () => {
@@ -134,12 +155,12 @@ describe("Upload", () => {
     renderWithQueryClient(<Upload {...defaultProps} files={files} setFiles={mockSetFiles} />);
 
     // Simulate the event (e.g., a click on the remove button)
-    const removeButton = screen.getByTestId("upload-component-remove-file-file-to-remove.txt"); // Ensure your component uses this testId
+    const removeButton = screen.getByTestId(`upload-component-remove-file-${FILE_REMOVE}.txt`); // Ensure your component uses this testId
     fireEvent.click(removeButton);
 
     // Assert that setFiles was called with the updated files array
     expect(mockSetFiles).toHaveBeenCalledWith(
-      files.filter((file) => file.filename !== "file-to-remove.txt"),
+      files.filter((file) => file.filename !== `${FILE_REMOVE}.txt`),
     );
   });
 });

--- a/react-app/src/components/Inputs/upload.test.tsx
+++ b/react-app/src/components/Inputs/upload.test.tsx
@@ -89,9 +89,7 @@ describe("Upload", () => {
     fireEvent.drop(dropzone);
 
     await waitFor(() => {
-      expect(
-        screen.getByText("Selected file(s) is too large or of a disallowed file type."),
-      ).toBeInTheDocument();
+      expect(screen.getByText(`File "${file.name}" has an invalid type.`)).toBeInTheDocument();
     });
   });
 

--- a/react-app/src/components/Inputs/upload.test.tsx
+++ b/react-app/src/components/Inputs/upload.test.tsx
@@ -94,6 +94,7 @@ describe("Upload", () => {
       expect(screen.getByText(`File "${file.name}" has an invalid type.`)).toBeInTheDocument();
     });
   });
+
   it("displays an error for a file that is too large", async () => {
     renderWithQueryClient(<Upload {...defaultProps} />);
 
@@ -111,6 +112,7 @@ describe("Upload", () => {
       expect(screen.getByText(`File "file.txt" is too large to upload.`)).toBeInTheDocument();
     });
   });
+
   it("displays an error for a file that already is uploaded", async () => {
     const mockSetFiles = vi.fn();
     renderWithQueryClient(<Upload {...defaultProps} files={files} setFiles={mockSetFiles} />);
@@ -130,6 +132,7 @@ describe("Upload", () => {
       ).toBeInTheDocument();
     });
   });
+
   it("does not display the dropzone when uploading", async () => {
     renderWithQueryClient(<Upload {...defaultProps} />);
 

--- a/react-app/src/components/Inputs/upload.tsx
+++ b/react-app/src/components/Inputs/upload.tsx
@@ -67,8 +67,8 @@ export const Upload = ({ maxFiles, files, setFiles, dataTestId }: UploadProps) =
     }
     if (file.size > MAX_FILE_SIZE) {
       return {
-        code: "file-too-large",
-        message: `Selected file(s) is too large.`,
+        code: "file-too-big",
+        message: `File "${file.name}" is too large to upload.`,
       };
     }
     // The error message by default for drop zone is really wordy so this will replace that.  We filter it on the output
@@ -158,7 +158,7 @@ export const Upload = ({ maxFiles, files, setFiles, dataTestId }: UploadProps) =
         <span className="text-red-500">
           {fileRejections.flatMap(({ file, errors }) =>
             errors
-              .filter((e) => e.code !== "file-invalid-type")
+              .filter((e) => e.code !== "file-invalid-type" && e.code !== "file-too-large")
               .map((e) => <p key={`${file.name}-${e.code}`}>{e.message}</p>),
           )}
         </span>

--- a/react-app/src/components/Inputs/upload.tsx
+++ b/react-app/src/components/Inputs/upload.tsx
@@ -1,6 +1,6 @@
 import { X } from "lucide-react";
 import { useCallback, useState } from "react";
-import { Accept, FileRejection, useDropzone } from "react-dropzone";
+import { FileRejection, useDropzone } from "react-dropzone";
 import { attachmentSchema } from "shared-types";
 import { FILE_TYPES } from "shared-types/uploads";
 import { v4 as uuidv4 } from "uuid";
@@ -46,9 +46,9 @@ type UploadProps = {
  */
 export const Upload = ({ maxFiles, files, setFiles, dataTestId }: UploadProps) => {
   const [isUploading, setIsUploading] = useState(false); // New state for tracking upload status
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [fileUploadError, setFileUploadError] = useState<string | null>(null);
   const uniqueId = uuidv4();
-  const MAX_FILE_SIZE = 80 * 1024 * 1024;
+  const MAX_FILE_SIZE = 80 * 1024 * 1024; //80 MB
   const accept = FILE_TYPES.reduce(
     (acc, { mime, extension }) => {
       acc[mime] = acc[mime] ? [...acc[mime], extension] : [extension];
@@ -56,6 +56,7 @@ export const Upload = ({ maxFiles, files, setFiles, dataTestId }: UploadProps) =
     },
     {} as Record<string, string[]>,
   );
+
   const existingFileNames = files.map((file) => file.filename);
 
   const validateFile = (file: File) => {
@@ -82,7 +83,7 @@ export const Upload = ({ maxFiles, files, setFiles, dataTestId }: UploadProps) =
   const onDrop = useCallback(
     async (acceptedFiles: File[], fileRejections: FileRejection[]) => {
       if (fileRejections.length === 0) {
-        setErrorMessage(null);
+        setFileUploadError(null);
         setIsUploading(true); // Set uploading to true
 
         const processedFiles = await Promise.all(
@@ -100,8 +101,8 @@ export const Upload = ({ maxFiles, files, setFiles, dataTestId }: UploadProps) =
                 uploadDate: Date.now(),
               };
               return attachment;
-            } catch (error) {
-              setErrorMessage("Failed to upload one or more files.");
+            } catch {
+              setFileUploadError("Failed to upload one or more files.");
               return null;
             }
           }),
@@ -153,7 +154,7 @@ export const Upload = ({ maxFiles, files, setFiles, dataTestId }: UploadProps) =
           ))}
         </div>
       )}
-      {errorMessage && <span className="text-red-500">{errorMessage}</span>}
+      {fileUploadError && <span className="text-red-500">{fileUploadError}</span>}
       {fileRejections.length > 0 && (
         <span className="text-red-500">
           {fileRejections.flatMap(({ file, errors }) =>

--- a/react-app/src/components/Inputs/upload.tsx
+++ b/react-app/src/components/Inputs/upload.tsx
@@ -121,7 +121,7 @@ export const Upload = ({ maxFiles, files, setFiles, dataTestId }: UploadProps) =
     [files, setFiles],
   );
 
-  const { getRootProps, getInputProps, isDragActive, fileRejections } = useDropzone({
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
     accept,
     validator: validateFile,

--- a/react-app/src/components/Inputs/upload.tsx
+++ b/react-app/src/components/Inputs/upload.tsx
@@ -47,6 +47,7 @@ type UploadProps = {
 export const Upload = ({ maxFiles, files, setFiles, dataTestId }: UploadProps) => {
   const [isUploading, setIsUploading] = useState(false); // New state for tracking upload status
   const [fileUploadError, setFileUploadError] = useState<string | null>(null);
+  const [rejectedFiles, setRejectedFiles] = useState<FileRejection[]>([]);
   const uniqueId = uuidv4();
   const MAX_FILE_SIZE = 80 * 1024 * 1024; //80 MB
   const accept = FILE_TYPES.reduce(
@@ -82,6 +83,7 @@ export const Upload = ({ maxFiles, files, setFiles, dataTestId }: UploadProps) =
   };
   const onDrop = useCallback(
     async (acceptedFiles: File[], fileRejections: FileRejection[]) => {
+      setRejectedFiles(fileRejections);
       if (fileRejections.length === 0) {
         setFileUploadError(null);
         setIsUploading(true); // Set uploading to true
@@ -142,6 +144,7 @@ export const Upload = ({ maxFiles, files, setFiles, dataTestId }: UploadProps) =
               <I.Button
                 onClick={(e) => {
                   e.preventDefault();
+                  setRejectedFiles([]);
                   setFiles(files.filter((a) => a.filename !== file.filename));
                 }}
                 variant="ghost"
@@ -187,9 +190,9 @@ export const Upload = ({ maxFiles, files, setFiles, dataTestId }: UploadProps) =
       {fileUploadError && (
         <span className="text-[0.8rem] font-medium text-destructive">{fileUploadError}</span>
       )}
-      {fileRejections.length > 0 && (
+      {rejectedFiles.length > 0 && (
         <span className="text-[0.8rem] font-medium text-destructive">
-          {fileRejections.flatMap(({ file, errors }) =>
+          {rejectedFiles.flatMap(({ file, errors }) =>
             errors
               .filter((e) => e.code !== "file-invalid-type" && e.code !== "file-too-large")
               .map((e) => <p key={`${file.name}-${e.code}`}>{e.message}</p>),

--- a/react-app/src/components/Inputs/upload.tsx
+++ b/react-app/src/components/Inputs/upload.tsx
@@ -154,16 +154,7 @@ export const Upload = ({ maxFiles, files, setFiles, dataTestId }: UploadProps) =
           ))}
         </div>
       )}
-      {fileUploadError && <span className="text-red-500">{fileUploadError}</span>}
-      {fileRejections.length > 0 && (
-        <span className="text-red-500">
-          {fileRejections.flatMap(({ file, errors }) =>
-            errors
-              .filter((e) => e.code !== "file-invalid-type" && e.code !== "file-too-large")
-              .map((e) => <p key={`${file.name}-${e.code}`}>{e.message}</p>),
-          )}
-        </span>
-      )}
+
       {isUploading ? (
         <LoadingSpinner /> // Render the loading spinner when uploading
       ) : (
@@ -192,6 +183,18 @@ export const Upload = ({ maxFiles, files, setFiles, dataTestId }: UploadProps) =
             data-testid={`${dataTestId}-upload`}
           />
         </div>
+      )}
+      {fileUploadError && (
+        <span className="text-[0.8rem] font-medium text-destructive">{fileUploadError}</span>
+      )}
+      {fileRejections.length > 0 && (
+        <span className="text-[0.8rem] font-medium text-destructive">
+          {fileRejections.flatMap(({ file, errors }) =>
+            errors
+              .filter((e) => e.code !== "file-invalid-type" && e.code !== "file-too-large")
+              .map((e) => <p key={`${file.name}-${e.code}`}>{e.message}</p>),
+          )}
+        </span>
       )}
     </>
   );

--- a/react-app/src/components/Inputs/uploadUtilities.test.ts
+++ b/react-app/src/components/Inputs/uploadUtilities.test.ts
@@ -1,10 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import * as utilities from "@/components/Inputs/upload.utilities";
+import {
+  extractBucketAndKeyFromUrl,
+  getPresignedUrl,
+  uploadToS3,
+} from "@/components/Inputs/uploadUtilities";
 
 describe("getPresignedUrl", () => {
   beforeEach(() => {
-    vi.unmock("@/components/Inputs/upload.utilities");
+    vi.unmock("@/components/Inputs/uploadUtilities");
     vi.mock("aws-amplify", () => ({
       API: {
         post: vi.fn(async () => ({ url: "https://example.com/test-url" })),
@@ -14,26 +18,25 @@ describe("getPresignedUrl", () => {
 
   it("gets a presigned URL from the API", async () => {
     const fileName = "file.pdf";
-    const url = await utilities.getPresignedUrl(fileName);
+    const url = await getPresignedUrl(fileName);
     expect(url).toBe("https://example.com/test-url");
   });
 });
 
 describe("uploadToS3", () => {
   beforeEach(() => {
-    vi.unmock("@/components/Inputs/upload.utilities");
+    vi.unmock("@/components/Inputs/uploadUtilities");
   });
 
   it("uploads a file to S3", async () => {
     const file = new File(["file contents"], "file.pdf", { type: "application/pdf" });
     const url = "https://s3.us-east-1.amazonaws.com/hello/world";
 
-    // Mock fetch
-    const mockFetch = vi.fn().mockResolvedValue({});
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
     global.fetch = mockFetch;
 
     // Call the function
-    await utilities.uploadToS3(file, url);
+    await uploadToS3(file, url);
 
     // Assertion
     expect(mockFetch).toHaveBeenCalledWith(url, {
@@ -41,15 +44,23 @@ describe("uploadToS3", () => {
       method: "PUT",
     });
   });
+  it("fails to upload a file to S3", async () => {
+    const file = new File(["file contents"], "file.pdf", { type: "application/pdf" });
+    const url = "https://s3.us-east-1.amazonaws.com/hello/world";
 
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false });
+    global.fetch = mockFetch;
+
+    await expect(() => uploadToS3(file, url)).rejects.toThrowError();
+  });
   describe("extractBucketAndKeyFromUrl", () => {
     beforeEach(() => {
-      vi.unmock("@/components/Inputs/upload.utilities");
+      vi.unmock("@/components/Inputs/uploadUtilities");
     });
 
     it("extracts the bucket and key from a URL", () => {
       const url = "https://hello.s3.us-east-1.amazonaws.com/world";
-      const { bucket, key } = utilities.extractBucketAndKeyFromUrl(url);
+      const { bucket, key } = extractBucketAndKeyFromUrl(url);
 
       expect(bucket).toBe("hello");
       expect(key).toBe("world");
@@ -59,10 +70,8 @@ describe("uploadToS3", () => {
       const url = "invalid-url";
       const consoleSpy = vi.spyOn(console, "error");
 
-      const { bucket, key } = utilities.extractBucketAndKeyFromUrl(url);
+      expect(() => extractBucketAndKeyFromUrl(url)).toThrowError("Invalid URL format:");
 
-      expect(bucket).toBeNull();
-      expect(key).toBeNull();
       expect(consoleSpy).toHaveBeenCalled();
       expect(consoleSpy).toHaveBeenCalledWith("Invalid URL format:", expect.any(Error));
     });

--- a/react-app/src/components/Inputs/uploadUtilities.test.ts
+++ b/react-app/src/components/Inputs/uploadUtilities.test.ts
@@ -44,6 +44,7 @@ describe("uploadToS3", () => {
       method: "PUT",
     });
   });
+
   it("fails to upload a file to S3", async () => {
     const file = new File(["file contents"], "file.pdf", { type: "application/pdf" });
     const url = "https://s3.us-east-1.amazonaws.com/hello/world";

--- a/react-app/src/components/Inputs/uploadUtilities.ts
+++ b/react-app/src/components/Inputs/uploadUtilities.ts
@@ -4,14 +4,20 @@ export const getPresignedUrl = async (fileName: string): Promise<string> => {
   const response = await API.post("os", "/getUploadUrl", {
     body: { fileName },
   });
-  return response.url;
+  if (response.url) {
+    return response.url;
+  }
+  throw new Error(response);
 };
 
 export const uploadToS3 = async (file: File, url: string): Promise<void> => {
-  await fetch(url, {
+  const response = await fetch(url, {
     body: file,
     method: "PUT",
   });
+  if (!response.ok) {
+    throw new Error();
+  }
 };
 
 export const extractBucketAndKeyFromUrl = (
@@ -37,6 +43,6 @@ export const extractBucketAndKeyFromUrl = (
     return { bucket, key };
   } catch (error) {
     console.error("Invalid URL format:", error);
-    return { bucket: null, key: null };
+    throw new Error("Invalid URL format:", error);
   }
 };

--- a/react-app/vitest.setup.ts
+++ b/react-app/vitest.setup.ts
@@ -67,7 +67,7 @@ beforeAll(() => {
     v4: vi.fn(() => "mocked-uuid-1234"),
   }));
   if (process.env.MOCK_API_REFINES) {
-    vi.mock("@/components/Inputs/upload.utilities", () => ({
+    vi.mock("@/components/Inputs/uploadUtilities", () => ({
       getPresignedUrl: vi.fn(async () => "hello world"),
       uploadToS3: vi.fn(async () => {}),
       extractBucketAndKeyFromUrl: vi.fn(() => ({


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[[Ticket to close](link-to-ticket)](https://jiraent.cms.gov/browse/OY2-33460)

## 💬 Description / Notes

Currently nothing prevents a user from uploading a file with the exact same file name causing issues when chips are deleted.  Logic is introduced to prevent the user from uploading files with the same name into a single react dropzone.

Logic was also changed for the error messages on when a file is too large or if it is a bad format.

upload.utilities was renamed to uploadUtilities for proper naming conventions.  The const within that file now throw exceptions as opposed to just throwing out happy responses in the event of failure.


## 🛠 Changes

Removed logic from ondrop and moved it to a custom validator to make sure files are correct.

By doing this there would have been duplicate error message since we have the react component make sure it cant take a too large file or improper type, but the error messages provided by that are not very clear.

Modified the uploadUtilities to throw exceptions instead of just acting like everything is working great.

Modified unit test.

## 📸 Screenshots / Demo

<!-- ### Before -->

<!-- ### After -->
