### PR TITLE
fix(remove-proposed-effective-from-indexing): Remove proposedEffectiveDate as a value that gets captured in opensearch

### DIFF
--- a/lib/lambda/sinkMainProcessors.test.ts
+++ b/lib/lambda/sinkMainProcessors.test.ts
@@ -620,7 +620,7 @@ describe("insertOneMacRecordsFromKafkaIntoMako", () => {
         additionalInformation: "info",
         lastEventTimestamp: TIMESTAMP,
         submissionTimestamp: TIMESTAMP,
-        proposedEffectiveDate: "2025-03-10T00:00:00Z",
+        proposedEffectiveDate: null,
         currentStatus: "Submitted",
         changedDate: new Date(TIMESTAMP).toISOString(),
         description: null,

--- a/lib/packages/shared-types/events/legacy-event.ts
+++ b/lib/packages/shared-types/events/legacy-event.ts
@@ -34,6 +34,7 @@ export const legacyEventSchema = legacySharedSchema
 
     return {
       ...data,
+      proposedEffectiveDate: null, // blank out the value that will be transformed, we handle it below
       additionalInformation: data.additionalInformation,
       changedDate: lastEventTimestampDate.toISOString(), // eventTimestamp as ISO string
       cmsStatus, // Derived status


### PR DESCRIPTION
Theory: Proposed Effective Date being capture causes issues during indexing into opensearch because this value is not always a date (sometimes it is "-- --") and this validation is already handled when we set it to proposedDate lower down in the transform.