### PR TITLE
bug(fix): close banner bug

### DIFF
--- a/react-app/src/api/useGetSystemNotifs.ts
+++ b/react-app/src/api/useGetSystemNotifs.ts
@@ -5,8 +5,38 @@ import { BannerNotification, ReactQueryApiError } from "shared-types";
 
 import { useGetUser } from "@/api";
 
+export type Notification = {
+  notifId: string;
+  body: string;
+  header: string;
+  pubDate: string;
+  expDate: string;
+  buttonLink: string;
+  buttonText: string;
+  disabled?: boolean;
+};
+
+const mapNotifications = (notifications: any): Notification[] => {
+  return notifications.flatMap((notification) => {
+    if (Array.isArray(notification.body)) {
+      return notification.body.map((entry: any, index: any) => ({
+        notifId: `${notification.notifId}-${index}`,
+        body: `${entry.date}: ${entry.title} - ${entry.description}`,
+        header: notification.header,
+        pubDate: notification.pubDate,
+        expDate: notification.expDate,
+        buttonText: notification.buttonText,
+        buttonLink: notification.buttonLink || "",
+        disabled: notification.disabled ?? false,
+      }));
+    }
+    return notification;
+  });
+};
 export const getSystemNotifs = async (): Promise<BannerNotification[]> => {
-  return await API.get("os", "/systemNotifs", {});
+  const notifications = await API.get("os", "/systemNotifs", {});
+  const mappedNotifications = mapNotifications(notifications);
+  return mappedNotifications;
 };
 
 export const useGetSystemNotifs = () => {

--- a/react-app/src/api/useGetSystemNotifs.ts
+++ b/react-app/src/api/useGetSystemNotifs.ts
@@ -24,8 +24,7 @@ const mapNotifications = (notifications: any): BannerNotification[] => {
 };
 export const getSystemNotifs = async (): Promise<BannerNotification[]> => {
   const notifications = await API.get("os", "/systemNotifs", {});
-  const mappedNotifications = mapNotifications(notifications);
-  return mappedNotifications;
+  return mapNotifications(notifications);
 };
 
 export const useGetSystemNotifs = () => {

--- a/react-app/src/api/useGetSystemNotifs.ts
+++ b/react-app/src/api/useGetSystemNotifs.ts
@@ -5,18 +5,7 @@ import { BannerNotification, ReactQueryApiError } from "shared-types";
 
 import { useGetUser } from "@/api";
 
-export type Notification = {
-  notifId: string;
-  body: string;
-  header: string;
-  pubDate: string;
-  expDate: string;
-  buttonLink: string;
-  buttonText: string;
-  disabled?: boolean;
-};
-
-const mapNotifications = (notifications: any): Notification[] => {
+const mapNotifications = (notifications: any): BannerNotification[] => {
   return notifications.flatMap((notification) => {
     if (Array.isArray(notification.body)) {
       return notification.body.map((entry: any, index: any) => ({


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[[Ticket to close](link-to-ticket)](https://jiraent.cms.gov/browse/OY2-33741)

## 💬 Description / Notes

Whenever the top banner is closed  it breaks after it gets passed the first message.  this was due to an inconsistent data structure provided by the AWS secret that stored the value.  We are adding a type for notification in typescript and using a flat map to make it work with whatever data that comes in.

I'll add unit test for this in a different PR but this is a critical bug so getting this in fast matters more to me.

## 🛠 Changes

<!-- List your code changes made to implement the solution -->

## 📸 Screenshots / Demo

<!-- ### Before -->

<!-- ### After -->
