### PR TITLE
bug(update) Make strict for typing on banner objects

### DIFF
--- a/lib/packages/shared-types/notification.ts
+++ b/lib/packages/shared-types/notification.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 export interface BannerNotification {
   notifId: string;
   header: string;
@@ -8,3 +10,14 @@ export interface BannerNotification {
   expDate?: string;
   disabled?: boolean;
 }
+export const BannerNotificationSchema = z.object({
+  notifId: z.string(),
+  body: z.string(),
+  header: z.string(),
+  pubDate: z.string(),
+  expDate: z.string(),
+  buttonLink: z.string().optional().default(""),
+  buttonText: z.string().optional().default(""),
+  disabled: z.boolean().optional().default(false),
+});
+export type ValidBannerNotification = z.infer<typeof BannerNotificationSchema>;

--- a/mocks/handlers/api/notifications.ts
+++ b/mocks/handlers/api/notifications.ts
@@ -8,9 +8,22 @@ const defaultNotificationHandler = http.get<any, NotifRequestBody>(/\/systemNoti
     [
       {
         notifId: "testId",
-        body: "testBody",
         header: "testHeader",
+        body: "testBody",
+        buttonText: "button",
+        buttonLink: "link",
         pubDate: new Date().toISOString(),
+        expDate: new Date().toISOString(),
+        disabled: false,
+      },
+      {
+        header: "testHeader",
+        body: "testBody",
+        buttonText: "button",
+        buttonLink: "link",
+        pubDate: new Date().toISOString(),
+        expDate: new Date().toISOString(),
+        disabled: false,
       },
     ],
     { status: 200 },


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[Ticket to close](link-to-ticket)

## 💬 Description / Notes

I put type safety on the banner system banner page to prevent unallowed objects to try to display on the banner.  So if the body is the wrong type or missing, the banner wont appear

## 🛠 Changes

Add a zod object and type checked text.

## 📸 Screenshots / Demo

<!-- ### Before -->

<!-- ### After -->
