### PR TITLE
fix(legacy): fixing legacy date ingestion logic such that empty dates are not interpreted as epoch start date

### DIFF
--- a/lib/lambda/sinkMainProcessors.test.ts
+++ b/lib/lambda/sinkMainProcessors.test.ts
@@ -665,6 +665,63 @@ describe("insertOneMacRecordsFromKafkaIntoMako", () => {
       ]);
     },
   );
+  it("should set date fields to null for legacy records when timestamps are 0", async () => {
+    const record = {
+      pk: "MD-00000",
+      sk: "Package",
+      GSI1pk: "OneMAC#spa",
+      componentId: "MD-00000",
+      additionalInformation: "info",
+      lastEventTimestamp: 0,
+      submissionTimestamp: 0,
+      proposedEffectiveDate: "2025-03-10T00:00:00Z",
+      submitterEmail: "tester@example.com",
+      submitterName: "Tester",
+      currentStatus: "Submitted",
+      subStatus: "Normal",
+      componentType: "medicaidspa",
+    };
+
+    const kafkaRecord = createKafkaRecord({
+      topic: TOPIC,
+      key: "some-key",
+      value: convertObjToBase64({
+        ...record,
+        origin: "OneMACLegacy",
+        submitterName: "Tester",
+        submitterEmail: "tester@example.com",
+        timestamp: TIMESTAMP,
+      }),
+      headers: [{ source: [111, 110, 101, 109, 97, 99] }], // "onemac"
+    });
+
+    await insertOneMacRecordsFromKafkaIntoMako([kafkaRecord], TOPIC);
+
+    const expectedRecord = {
+      additionalInformation: "info",
+      changedDate: null, // due to lastEventTimestamp === 0
+      description: null,
+      id: "MD-00000",
+      makoChangedDate: null, // due to lastEventTimestamp === 0
+      origin: "OneMACLegacy",
+      proposedDate: "2025-03-10T00:00:00Z",
+      subject: null,
+      submissionDate: null, // due to submissionTimestamp === 0
+      submitterEmail: "tester@example.com",
+      submitterName: "Tester",
+      initialIntakeNeeded: true,
+      authority: "Medicaid SPA", // as defined in medicaid-spa transform
+      cmsStatus: statusToDisplayToCmsUser[SEATOOL_STATUS.SUBMITTED],
+      seatoolStatus: SEATOOL_STATUS.SUBMITTED,
+      state: "MD",
+      stateStatus: statusToDisplayToStateUser[SEATOOL_STATUS.SUBMITTED],
+      statusDate: null, // due to lastEventTimestamp === 0
+    };
+
+    expect(bulkUpdateDataSpy).toBeCalledWith(OPENSEARCH_DOMAIN, OPENSEARCH_INDEX, [
+      expect.objectContaining(expectedRecord),
+    ]);
+  });
 });
 
 describe("insertNewSeatoolRecordsFromKafkaIntoMako", () => {

--- a/lib/packages/shared-types/events/legacy-event.ts
+++ b/lib/packages/shared-types/events/legacy-event.ts
@@ -1,4 +1,3 @@
-import { time } from "console";
 import { z } from "zod";
 
 import { getStatus, SEATOOL_STATUS } from "..";

--- a/lib/packages/shared-types/events/legacy-event.ts
+++ b/lib/packages/shared-types/events/legacy-event.ts
@@ -1,3 +1,4 @@
+import { time } from "console";
 import { z } from "zod";
 
 import { getStatus, SEATOOL_STATUS } from "..";
@@ -28,36 +29,43 @@ export const legacyEventSchema = legacySharedSchema
   .transform((data) => {
     const seatoolStatus = getSeaToolStatusFromLegacyStatus(data.currentStatus);
     const { stateStatus, cmsStatus } = getStatus(seatoolStatus);
-    const lastEventTimestampDate = new Date(data.lastEventTimestamp);
-    const submissionTimestampDate = new Date(data.submissionTimestamp);
+    const lastEventIsoDate = getIsoDateFromTimestamp(data.lastEventTimestamp);
+    const submissionIsoDate = getIsoDateFromTimestamp(data.submissionTimestamp);
     const isRaiResponseWithdrawEnabled = data.subStatus === "Withdraw Formal RAI Response Enabled";
 
     return {
       ...data,
       proposedEffectiveDate: null, // blank out the value that will be transformed, we handle it below
       additionalInformation: data.additionalInformation,
-      changedDate: lastEventTimestampDate.toISOString(), // eventTimestamp as ISO string
+      changedDate: lastEventIsoDate, // eventTimestamp as ISO string
       cmsStatus, // Derived status
       description: null, // Not provided in legacy, set to null
       id: data.pk, // pk becomes id
-      makoChangedDate: lastEventTimestampDate.toISOString(),
+      makoChangedDate: lastEventIsoDate,
       origin: ONEMAC_LEGACY_ORIGIN,
       raiWithdrawEnabled: isRaiResponseWithdrawEnabled,
       seatoolStatus,
       state: data.pk?.slice(0, 2), // Extract state from pk
       stateStatus,
-      statusDate: lastEventTimestampDate.toISOString(),
+      statusDate: lastEventIsoDate,
       proposedDate:
         data.proposedEffectiveDate && !isNaN(new Date(data.proposedEffectiveDate).getTime())
           ? data.proposedEffectiveDate
           : null,
       subject: null,
-      submissionDate: submissionTimestampDate.toISOString(),
+      submissionDate: submissionIsoDate,
       submitterEmail: data.submitterEmail,
       submitterName: data.submitterName,
       initialIntakeNeeded: true,
     };
   });
+
+function getIsoDateFromTimestamp(timestamp: number | null | undefined) {
+  if (!timestamp || timestamp === 0) {
+    return null;
+  }
+  return new Date(timestamp).toISOString();
+}
 
 function getSeaToolStatusFromLegacyStatus(legacyStatus: string | null | undefined) {
   if (!legacyStatus) {


### PR DESCRIPTION
## 🎫 Linked Ticket

[OY2-32338](https://jiraent.cms.gov/browse/OY2-32338)

https://d1ds2ig1a2kif1.cloudfront.net/

## 💬 Description / Notes

Some legacy dates that are missing are being ingested as epoch start date. This change is to update the ingestion of those dates such that they are null rather than the epoch start date

## 🛠 Changes

In the legacy transform of `LegacyEvent` add some logic to determine if the date is missing before converting to ISO date. This will prevent missing dates from being interpreted as 0 and tranformed to epoch start date.

