### PR TITLE
fix(terminated-legacy-status): increase size for status filters to account for more than 10

### DIFF
--- a/react-app/src/components/Opensearch/main/useOpensearch.ts
+++ b/react-app/src/components/Opensearch/main/useOpensearch.ts
@@ -130,7 +130,7 @@ export const useOsAggregate = () => {
                 ? "cmsStatus.keyword"
                 : "stateStatus.keyword",
             type: "terms",
-            size: 10,
+            size: 20,
           },
           {
             field: "leadAnalystName.keyword",


### PR DESCRIPTION
## 🎫 Linked Ticket
https://jiraent.cms.gov/browse/OY2-33883

## 💬 Description / Notes
Increased from a max 10 filters to 20. Can Increase to a different number, felt that the number was a bit arbitrary. We only had a max of 10 so additional statuses were being hidden.

## 📸 Screenshots / Demo

<!-- ### Before -->
![Screen Shot 2025-03-28 at 8 55 06 AM](https://github.com/user-attachments/assets/01e874e9-c131-4e0b-ab0d-b9dc19cbe658)

<!-- ### After -->
![Screen Shot 2025-03-28 at 8 55 16 AM](https://github.com/user-attachments/assets/57a4b68c-afd7-4937-bb4d-471d06407ad6)
