### PR TITLE
fix(lambda): legacy temporary extensions in mako

### DIFF
--- a/lib/lambda/sinkMainProcessors.test.ts
+++ b/lib/lambda/sinkMainProcessors.test.ts
@@ -545,10 +545,11 @@ describe("insertOneMacRecordsFromKafkaIntoMako", () => {
       {
         originalWaiverNumber: "W-12345",
         actionType: "Extend",
-        cmsStatus: "Submitted - Intake Needed",
+        cmsStatus: "Requested",
         stateStatus: "Submitted",
         currentStatus: "TE Requested",
         seatoolStatus: "Submitted",
+        state: "MD",
       },
     ],
     [
@@ -558,7 +559,7 @@ describe("insertOneMacRecordsFromKafkaIntoMako", () => {
       {
         originalWaiverNumber: "W-12345",
         actionType: "Extend",
-        cmsStatus: "Submitted - Intake Needed",
+        cmsStatus: "Requested",
         stateStatus: "Submitted",
         currentStatus: "TE Requested",
         seatoolStatus: "Submitted",
@@ -571,7 +572,7 @@ describe("insertOneMacRecordsFromKafkaIntoMako", () => {
       {
         originalWaiverNumber: "W-12345",
         actionType: "Extend",
-        cmsStatus: "Submitted - Intake Needed",
+        cmsStatus: "Requested",
         stateStatus: "Submitted",
         currentStatus: "TE Requested",
         seatoolStatus: "Submitted",
@@ -626,6 +627,7 @@ describe("insertOneMacRecordsFromKafkaIntoMako", () => {
         description: null,
         id: "MD-12345",
         makoChangedDate: new Date(TIMESTAMP).toISOString(),
+        state: "MD",
         origin: "OneMACLegacy",
         proposedDate: "2025-03-10T00:00:00Z",
         subject: null,

--- a/lib/lambda/sinkMainProcessors.test.ts
+++ b/lib/lambda/sinkMainProcessors.test.ts
@@ -563,6 +563,7 @@ describe("insertOneMacRecordsFromKafkaIntoMako", () => {
         stateStatus: "Submitted",
         currentStatus: "TE Requested",
         seatoolStatus: "Submitted",
+        state: "MD",
       },
     ],
     [
@@ -576,6 +577,7 @@ describe("insertOneMacRecordsFromKafkaIntoMako", () => {
         stateStatus: "Submitted",
         currentStatus: "TE Requested",
         seatoolStatus: "Submitted",
+        state: "MD",
       },
     ],
   ])(
@@ -613,11 +615,12 @@ describe("insertOneMacRecordsFromKafkaIntoMako", () => {
 
       await insertOneMacRecordsFromKafkaIntoMako([kafkaRecord], TOPIC);
 
-      // Build the expected base transformation (common to all)
-      const baseExpected = {
+      // Build the expected transformation
+      const expectedRecord = {
         pk: "MD-12345",
         GSI1pk: "OneMAC#spa",
         componentId: "MD-12345",
+        authority: expectedAuthority,
         additionalInformation: "info",
         lastEventTimestamp: TIMESTAMP,
         submissionTimestamp: TIMESTAMP,
@@ -636,31 +639,12 @@ describe("insertOneMacRecordsFromKafkaIntoMako", () => {
         submitterName: "Tester",
         initialIntakeNeeded: true,
         raiWithdrawEnabled: false,
+        cmsStatus: statusToDisplayToCmsUser[SEATOOL_STATUS.SUBMITTED],
+        stateStatus: statusToDisplayToStateUser[SEATOOL_STATUS.SUBMITTED],
+        seatoolStatus: SEATOOL_STATUS.SUBMITTED,
+        statusDate: new Date(TIMESTAMP).toISOString(),
+        ...expectedExtras,
       };
-
-      // Build expected outcome conditionally based on the transform type.
-      let expectedRecord;
-      if (componentType.startsWith("waiverextension")) {
-        expectedRecord = {
-          ...baseExpected,
-          authority: expectedAuthority,
-          // For temporary extension, we expect the transform to override some status fields.
-          cmsStatus: "Requested",
-          stateStatus: "Submitted",
-          ...expectedExtras,
-        };
-      } else {
-        expectedRecord = {
-          ...baseExpected,
-          authority: expectedAuthority,
-          cmsStatus: statusToDisplayToCmsUser[SEATOOL_STATUS.SUBMITTED],
-          seatoolStatus: SEATOOL_STATUS.SUBMITTED,
-          state: "MD",
-          stateStatus: statusToDisplayToStateUser[SEATOOL_STATUS.SUBMITTED],
-          statusDate: new Date(TIMESTAMP).toISOString(),
-          ...expectedExtras,
-        };
-      }
 
       expect(bulkUpdateDataSpy).toBeCalledWith(OPENSEARCH_DOMAIN, OPENSEARCH_INDEX, [
         expectedRecord,

--- a/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/temporary-extension.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/temporary-extension.ts
@@ -3,9 +3,11 @@ import { events } from "shared-types";
 
 export const transform = () => {
   return events["legacy-event"].legacyEventSchema.transform((data) => {
-    const cleanData = omit(data, ["statusDate", "state", "parentId"]);
+    const cleanData = omit(data, ["parentId"]);
     return {
       ...cleanData,
+      cmsStatus: "Requested",
+      stateStatus: "Submitted",
       authority: data.temporaryExtensionType ?? "1915(b)",
       actionType: "Extend",
       originalWaiverNumber: data.parentId,

--- a/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/temporary-extension.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/temporary-extension.ts
@@ -3,7 +3,7 @@ import { events } from "shared-types";
 
 export const transform = () => {
   return events["legacy-event"].legacyEventSchema.transform((data) => {
-    const cleanData = omit(data, ["parentId"]);
+    const cleanData = omit(data, ["parentId", "statusDate"]);
     return {
       ...cleanData,
       cmsStatus: "Requested",

--- a/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/temporary-extension.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/temporary-extension.ts
@@ -3,7 +3,7 @@ import { events } from "shared-types";
 
 export const transform = () => {
   return events["legacy-event"].legacyEventSchema.transform((data) => {
-    const cleanData = omit(data, ["parentId", "statusDate"]);
+    const cleanData = omit(data, ["parentId"]);
     return {
       ...cleanData,
       cmsStatus: "Requested",


### PR DESCRIPTION
## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[OY2-33879](https://jiraent.cms.gov/browse/OY2-33879)

## 💬 Description / Notes

State was not being populated for Temporary Extension types. Causing these packages to not be available to the corresponding state users.

## 🛠 Changes

Updated the TE transform for legacy so that it no longer erases the state property and set custom statuses as TE is unique.

