### PR TITLE
fix(ui): expanding type and subtype textboxes

### DIFF
--- a/react-app/src/features/package/package-details/details.tsx
+++ b/react-app/src/features/package/package-details/details.tsx
@@ -83,14 +83,22 @@ export const getSubmissionDetails: GetLabelAndValueFromSubmission = (submission,
   {
     label: "Type",
     value: submission.types
-      ? submission.types.map((type) => <li key={type?.SPA_TYPE_ID}>{type?.SPA_TYPE_NAME}</li>)
+      ? submission.types.map((type) => (
+          <ul>
+            <li key={type?.SPA_TYPE_ID}>{type?.SPA_TYPE_NAME}</li>
+          </ul>
+        ))
       : BLANK_VALUE,
     canView: submission.actionType !== "Extend" && isStateUser(user) === false,
   },
   {
     label: "Subtype",
     value: submission.subTypes
-      ? submission.subTypes.map((T) => <li key={T?.TYPE_ID}>{T?.TYPE_NAME}test</li>)
+      ? submission.subTypes.map((T) => (
+          <ul>
+            <li key={T?.TYPE_ID}>{T?.TYPE_NAME}test</li>
+          </ul>
+        ))
       : BLANK_VALUE,
     canView: submission.actionType !== "Extend" && isStateUser(user) === false,
   },

--- a/react-app/src/features/package/package-details/details.tsx
+++ b/react-app/src/features/package/package-details/details.tsx
@@ -90,11 +90,7 @@ export const getSubmissionDetails: GetLabelAndValueFromSubmission = (submission,
   {
     label: "Subtype",
     value: submission.subTypes
-      ? submission.subTypes.map((T) => (
-          <ul>
-            <li key={T?.TYPE_ID}>{T?.TYPE_NAME}test</li>
-          </ul>
-        ))
+      ? submission.subTypes.map((T) => <li key={T?.TYPE_ID}>{T?.TYPE_NAME}test</li>)
       : BLANK_VALUE,
     canView: submission.actionType !== "Extend" && isStateUser(user) === false,
   },

--- a/react-app/src/features/package/package-details/details.tsx
+++ b/react-app/src/features/package/package-details/details.tsx
@@ -90,7 +90,7 @@ export const getSubmissionDetails: GetLabelAndValueFromSubmission = (submission,
   {
     label: "Subtype",
     value: submission.subTypes
-      ? submission.subTypes.map((T) => <p key={T?.TYPE_ID}>{T?.TYPE_NAME}test</p>)
+      ? submission.subTypes.map((T) => <ul key={T?.TYPE_ID}>{T?.TYPE_NAME}test</ul>)
       : BLANK_VALUE,
     canView: submission.actionType !== "Extend" && isStateUser(user) === false,
   },

--- a/react-app/src/features/package/package-details/details.tsx
+++ b/react-app/src/features/package/package-details/details.tsx
@@ -82,24 +82,29 @@ export const getSubmissionDetails: GetLabelAndValueFromSubmission = (submission,
   },
   {
     label: "Type",
-    value: submission.types
-      ? submission.types.map((type) => (
-          <ul>
-            <li key={type?.SPA_TYPE_ID}>{type?.SPA_TYPE_NAME}</li>
-          </ul>
-        ))
-      : BLANK_VALUE,
+    value: submission.types ? (
+      <ul>
+        {submission.types.map((type) => (
+          <li key={type?.SPA_TYPE_ID}>{type?.SPA_TYPE_NAME}</li>
+        ))}{" "}
+      </ul>
+    ) : (
+      BLANK_VALUE
+    ),
     canView: submission.actionType !== "Extend" && isStateUser(user) === false,
   },
+
   {
     label: "Subtype",
-    value: submission.subTypes
-      ? submission.subTypes.map((T) => (
-          <ul>
-            <li key={T?.TYPE_ID}>{T?.TYPE_NAME}test</li>
-          </ul>
-        ))
-      : BLANK_VALUE,
+    value: submission.subTypes ? (
+      <ul>
+        {submission.subTypes.map((T) => (
+          <li key={T?.TYPE_ID}>{T?.TYPE_NAME}</li>
+        ))}{" "}
+      </ul>
+    ) : (
+      BLANK_VALUE
+    ),
     canView: submission.actionType !== "Extend" && isStateUser(user) === false,
   },
   {

--- a/react-app/src/features/package/package-details/details.tsx
+++ b/react-app/src/features/package/package-details/details.tsx
@@ -90,7 +90,11 @@ export const getSubmissionDetails: GetLabelAndValueFromSubmission = (submission,
   {
     label: "Subtype",
     value: submission.subTypes
-      ? submission.subTypes.map((T) => <ul key={T?.TYPE_ID}>{T?.TYPE_NAME}test</ul>)
+      ? submission.subTypes.map((T) => (
+          <ul>
+            <li key={T?.TYPE_ID}>{T?.TYPE_NAME}test</li>
+          </ul>
+        ))
       : BLANK_VALUE,
     canView: submission.actionType !== "Extend" && isStateUser(user) === false,
   },

--- a/react-app/src/features/package/package-details/details.tsx
+++ b/react-app/src/features/package/package-details/details.tsx
@@ -90,7 +90,7 @@ export const getSubmissionDetails: GetLabelAndValueFromSubmission = (submission,
   {
     label: "Subtype",
     value: submission.subTypes
-      ? submission.subTypes.map((T) => <p key={T?.TYPE_ID}>{T?.TYPE_NAME}</p>)
+      ? submission.subTypes.map((T) => <p key={T?.TYPE_ID}>{T?.TYPE_NAME}test</p>)
       : BLANK_VALUE,
     canView: submission.actionType !== "Extend" && isStateUser(user) === false,
   },

--- a/react-app/src/features/package/package-details/details.tsx
+++ b/react-app/src/features/package/package-details/details.tsx
@@ -83,7 +83,7 @@ export const getSubmissionDetails: GetLabelAndValueFromSubmission = (submission,
   {
     label: "Type",
     value: submission.types
-      ? submission.types.map((type) => <p key={type?.SPA_TYPE_ID}>{type?.SPA_TYPE_NAME}</p>)
+      ? submission.types.map((type) => <li key={type?.SPA_TYPE_ID}>{type?.SPA_TYPE_NAME}</li>)
       : BLANK_VALUE,
     canView: submission.actionType !== "Extend" && isStateUser(user) === false,
   },


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[Ticket to close](https://jiraent.cms.gov/browse/OY2-33597)

## 💬 Description / Notes

<!-- Briefly describe the background of the issue -->
Per CMS feedback during the demo on 3.10.25, CMS would like the text boxes for multi-line text fields (i.e. Type and Subtype) to be expanded. Possibly add bullet points to distinguish the selections. 
<!-- If you feel the original ticket lacks important details, this would be the place to share them -->

## 🛠 Changes

<!-- List your code changes made to implement the solution -->

## 📸 Screenshots / Demo
Current state
![textboxes-current-state](https://github.com/user-attachments/assets/b1df9546-4a1e-4a05-986a-27d7efa1cf3b)

Proposed fix
![textboxes-proposed-fix](https://github.com/user-attachments/assets/7d15779c-ec6f-43fa-8bc6-a9c20743df6e)

<!-- ### Before -->

<!-- ### After -->
