### PR TITLE
Fix(ui): fix RAI response date 

### DIFF
--- a/lib/lambda/sinkMainProcessors.test.ts
+++ b/lib/lambda/sinkMainProcessors.test.ts
@@ -634,6 +634,7 @@ describe("insertOneMacRecordsFromKafkaIntoMako", () => {
         submitterName: "Tester",
         initialIntakeNeeded: true,
         raiWithdrawEnabled: false,
+        raiReceivedDate: null,
         cmsStatus: statusToDisplayToCmsUser[SEATOOL_STATUS.SUBMITTED],
         stateStatus: statusToDisplayToStateUser[SEATOOL_STATUS.SUBMITTED],
         seatoolStatus: SEATOOL_STATUS.SUBMITTED,

--- a/lib/packages/shared-types/events/legacy-event.ts
+++ b/lib/packages/shared-types/events/legacy-event.ts
@@ -23,6 +23,7 @@ export const legacyEventSchema = legacySharedSchema
       parentId: z.string().nullish(),
       temporaryExtensionType: z.string().nullish(),
       attachments: z.array(legacyAttachmentSchema).nullish(),
+      latestRaiResponseTimestamp: z.number().nullish(),
     }),
   )
   .transform((data) => {
@@ -56,6 +57,9 @@ export const legacyEventSchema = legacySharedSchema
       submitterEmail: data.submitterEmail,
       submitterName: data.submitterName,
       initialIntakeNeeded: true,
+      raiReceivedDate: data.latestRaiResponseTimestamp
+        ? new Date(data.latestRaiResponseTimestamp).toISOString()
+        : null,
     };
   });
 


### PR DESCRIPTION
🎫 Linked Ticket
https://jiraent.cms.gov/secure/RapidBoard.jspa?rapidView=6701&projectKey=OY2&view=planning&selectedIssue=OY2-33882&quickFilter=39527&issueLimit=100#

💬 Description / Notes
The RAI Response date field is empty in mako (might be because the Package Activity is empty) when compared to legacy
