### PR TITLE
fix(legacy intake): upload subsequent document fix on legacy packages

### DIFF
--- a/lib/packages/shared-types/events/legacy-event.ts
+++ b/lib/packages/shared-types/events/legacy-event.ts
@@ -32,6 +32,14 @@ export const legacyEventSchema = legacySharedSchema
     const submissionIsoDate = getIsoDateFromTimestamp(data.submissionTimestamp);
     const isRaiResponseWithdrawEnabled = data.subStatus === "Withdraw Formal RAI Response Enabled";
 
+    if (["MD-25-1207-P", "MD-25-0186-P", "MD-25-0011-A"].includes(data.pk)) {
+      console.log("transform log", {
+        id: data.pk,
+        data: data,
+        status: { stateStatus, cmsStatus, seatoolStatus },
+      });
+    }
+
     return {
       ...data,
       proposedEffectiveDate: null, // blank out the value that will be transformed, we handle it below
@@ -55,7 +63,7 @@ export const legacyEventSchema = legacySharedSchema
       submissionDate: submissionIsoDate,
       submitterEmail: data.submitterEmail,
       submitterName: data.submitterName,
-      initialIntakeNeeded: true,
+      initialIntakeNeeded: true, //TODO: here
     };
   });
 

--- a/lib/packages/shared-types/events/legacy-event.ts
+++ b/lib/packages/shared-types/events/legacy-event.ts
@@ -31,14 +31,7 @@ export const legacyEventSchema = legacySharedSchema
     const lastEventIsoDate = getIsoDateFromTimestamp(data.lastEventTimestamp);
     const submissionIsoDate = getIsoDateFromTimestamp(data.submissionTimestamp);
     const isRaiResponseWithdrawEnabled = data.subStatus === "Withdraw Formal RAI Response Enabled";
-
-    if (["MD-25-1207-P", "MD-25-0186-P", "MD-25-0011-A"].includes(data.pk)) {
-      console.log("transform log", {
-        id: data.pk,
-        data: data,
-        status: { stateStatus, cmsStatus, seatoolStatus },
-      });
-    }
+    const initialIntakeNeeded = ![SEATOOL_STATUS.PENDING].includes(seatoolStatus);
 
     return {
       ...data,
@@ -63,7 +56,7 @@ export const legacyEventSchema = legacySharedSchema
       submissionDate: submissionIsoDate,
       submitterEmail: data.submitterEmail,
       submitterName: data.submitterName,
-      initialIntakeNeeded: true, //TODO: here
+      initialIntakeNeeded: initialIntakeNeeded,
     };
   });
 


### PR DESCRIPTION
## 🎫 Linked Ticket

[Ticket to close](https://jiraent.cms.gov/browse/OY2-33881)

## 💬 Description / Notes

Setting `initialIntakeNeeded` to true at all times removes the subsequent documents action from appropriate packages. Fix checks to see if status is the expected status for sub docs. Left it as an array check in case of missed status states for the subsequent documents/initial intake status. As far as I can tell `SEATOOL_STATUS.PENDING` is the only status that needs this value to be false, but waiting on word from QA to be sure. 

