### PR TITLE
rai withdrawal placeholder fix

### DIFF
--- a/lib/lambda/search.test.ts
+++ b/lib/lambda/search.test.ts
@@ -30,7 +30,7 @@ describe("getSearchData Handler", () => {
     const body = JSON.parse(res.body);
     expect(body).toBeTruthy();
     expect(body?.hits?.hits).toBeTruthy();
-    expect(body?.hits?.hits?.length).toEqual(27);
+    expect(body?.hits?.hits?.length).toEqual(28);
   });
 
   it("should handle errors during processing", async () => {

--- a/lib/lambda/sinkMainProcessors.test.ts
+++ b/lib/lambda/sinkMainProcessors.test.ts
@@ -10,6 +10,7 @@ import {
   NOT_FOUND_ITEM_ID,
   OPENSEARCH_DOMAIN,
   OPENSEARCH_INDEX_NAMESPACE,
+  RAI_WITHDRAWAL_ID,
   SUBMITTED_RAI_ID,
   TEST_ITEM_ID,
   WITHDRAWAL_REQUESTED_ID,
@@ -51,6 +52,7 @@ const OPENSEARCH_INDEX = `${OPENSEARCH_INDEX_NAMESPACE}main`;
 const TEST_ITEM_KEY = Buffer.from(TEST_ITEM_ID).toString("base64");
 const WITHDRAWAL_REQUESTED_KEY = Buffer.from(WITHDRAWAL_REQUESTED_ID).toString("base64");
 const SUBMITTED_RAI_KEY = Buffer.from(SUBMITTED_RAI_ID).toString("base64");
+const RAI_WITHDRAWAL_KEY = Buffer.from(RAI_WITHDRAWAL_ID).toString("base64");
 const TIMESTAMP = 1732645041557;
 const ISO_DATETIME = "2024-11-26T18:17:21.557Z";
 const EARLIER_TIMESTAMP = 1722645041557;
@@ -1700,6 +1702,478 @@ describe("insertNewSeatoolRecordsFromKafkaIntoMako", () => {
         secondClock: false,
         state: "10",
         stateStatus: "Submitted",
+        statusDate: EARLIER_ISO_DATETIME,
+        subTypes: [
+          {
+            TYPE_ID: 1,
+            TYPE_NAME: "SubType X",
+          },
+        ],
+        subject: "Sample Title",
+        types: [
+          {
+            SPA_TYPE_ID: 1,
+            SPA_TYPE_NAME: "Type A",
+          },
+        ],
+      },
+    ]);
+  });
+  it("tries to tries to update a  package that requested a RAI to be withdrawn", async () => {
+    await insertNewSeatoolRecordsFromKafkaIntoMako(
+      [
+        createKafkaRecord({
+          topic: TOPIC,
+          key: RAI_WITHDRAWAL_KEY,
+          value: convertObjToBase64({
+            id: RAI_WITHDRAWAL_ID,
+            ACTION_OFFICERS: [
+              {
+                FIRST_NAME: "John",
+                LAST_NAME: "Doe",
+                EMAIL: "john.doe@medicaid.gov",
+                OFFICER_ID: 12345,
+                DEPARTMENT: "State Plan Review",
+                PHONE: "202-555-1234",
+              },
+              {
+                FIRST_NAME: "Emily",
+                LAST_NAME: "Rodriguez",
+                EMAIL: "emily.rodriguez@medicaid.gov",
+                OFFICER_ID: 12346,
+                DEPARTMENT: "Compliance Division",
+                PHONE: "202-555-5678",
+              },
+            ],
+            LEAD_ANALYST: [
+              {
+                FIRST_NAME: "Michael",
+                LAST_NAME: "Chen",
+                EMAIL: "michael.chen@cms.hhs.gov",
+                OFFICER_ID: 67890,
+                DEPARTMENT: "Medicaid Innovation Center",
+                PHONE: "202-555-9012",
+              },
+            ],
+            STATE_PLAN: {
+              PLAN_TYPE: 123,
+              SPW_STATUS_ID: SeatoolSpwStatusEnum.Pending,
+              APPROVED_EFFECTIVE_DATE: TIMESTAMP,
+              CHANGED_DATE: EARLIER_TIMESTAMP,
+              SUMMARY_MEMO: "Sample summary",
+              TITLE_NAME: "Sample Title",
+              STATUS_DATE: EARLIER_TIMESTAMP,
+              SUBMISSION_DATE: TIMESTAMP,
+              LEAD_ANALYST_ID: 67890,
+              ACTUAL_EFFECTIVE_DATE: null,
+              PROPOSED_DATE: null,
+              STATE_CODE: "10",
+            },
+            RAI: [
+              {
+                RAI_RECEIVED_DATE: null,
+                RAI_REQUESTED_DATE: 1675123200000,
+                RAI_WITHDRAWN_DATE: null,
+              },
+            ],
+            ACTIONTYPES: [
+              { ACTION_NAME: "Respond to Formal RAI", ACTION_ID: 1, PLAN_TYPE_ID: 123 },
+            ],
+            STATE_PLAN_SERVICETYPES: [{ SPA_TYPE_ID: 1, SPA_TYPE_NAME: "Type A" }],
+            STATE_PLAN_SERVICE_SUBTYPES: [{ TYPE_ID: 1, TYPE_NAME: "SubType X" }],
+          }),
+        }),
+      ],
+      TOPIC,
+    );
+
+    expect(bulkUpdateDataSpy).toBeCalledWith(OPENSEARCH_DOMAIN, OPENSEARCH_INDEX, [
+      {
+        actionType: "Respond to Formal RAI",
+        approvedEffectiveDate: ISO_DATETIME,
+        authority: "1915(c)",
+        changed_date: EARLIER_TIMESTAMP,
+        cmsStatus: "Formal RAI Response - Withdrawal Requested",
+        description: "Sample summary",
+        finalDispositionDate: null,
+        id: RAI_WITHDRAWAL_ID,
+        initialIntakeNeeded: false,
+        leadAnalystEmail: "michael.chen@cms.hhs.gov",
+        leadAnalystName: "Michael Chen",
+        leadAnalystOfficerId: 67890,
+        locked: false,
+        proposedDate: null,
+        raiRequestedDate: "2023-01-31T00:00:00.000Z",
+        raiWithdrawEnabled: undefined,
+        raiWithdrawnDate: null,
+        reviewTeam: [
+          {
+            email: "john.doe@medicaid.gov",
+            name: "John Doe",
+          },
+          {
+            email: "emily.rodriguez@medicaid.gov",
+            name: "Emily Rodriguez",
+          },
+        ],
+        seatoolStatus: "Formal RAI Response - Withdrawal Requested",
+        secondClock: false,
+        state: "10",
+        stateStatus: "Formal RAI Response - Withdrawal Requested",
+        statusDate: EARLIER_ISO_DATETIME,
+        subTypes: [
+          {
+            TYPE_ID: 1,
+            TYPE_NAME: "SubType X",
+          },
+        ],
+        subject: "Sample Title",
+        types: [
+          {
+            SPA_TYPE_ID: 1,
+            SPA_TYPE_NAME: "Type A",
+          },
+        ],
+      },
+    ]);
+  });
+  it("tries to tries to update a  package that requested a RAI to be withdrawn but was terminated", async () => {
+    await insertNewSeatoolRecordsFromKafkaIntoMako(
+      [
+        createKafkaRecord({
+          topic: TOPIC,
+          key: RAI_WITHDRAWAL_KEY,
+          value: convertObjToBase64({
+            id: RAI_WITHDRAWAL_ID,
+            ACTION_OFFICERS: [
+              {
+                FIRST_NAME: "John",
+                LAST_NAME: "Doe",
+                EMAIL: "john.doe@medicaid.gov",
+                OFFICER_ID: 12345,
+                DEPARTMENT: "State Plan Review",
+                PHONE: "202-555-1234",
+              },
+              {
+                FIRST_NAME: "Emily",
+                LAST_NAME: "Rodriguez",
+                EMAIL: "emily.rodriguez@medicaid.gov",
+                OFFICER_ID: 12346,
+                DEPARTMENT: "Compliance Division",
+                PHONE: "202-555-5678",
+              },
+            ],
+            LEAD_ANALYST: [
+              {
+                FIRST_NAME: "Michael",
+                LAST_NAME: "Chen",
+                EMAIL: "michael.chen@cms.hhs.gov",
+                OFFICER_ID: 67890,
+                DEPARTMENT: "Medicaid Innovation Center",
+                PHONE: "202-555-9012",
+              },
+            ],
+            STATE_PLAN: {
+              PLAN_TYPE: 123,
+              SPW_STATUS_ID: SeatoolSpwStatusEnum.Disapproved,
+              APPROVED_EFFECTIVE_DATE: TIMESTAMP,
+              CHANGED_DATE: EARLIER_TIMESTAMP,
+              SUMMARY_MEMO: "Sample summary",
+              TITLE_NAME: "Sample Title",
+              STATUS_DATE: EARLIER_TIMESTAMP,
+              SUBMISSION_DATE: TIMESTAMP,
+              LEAD_ANALYST_ID: 67890,
+              ACTUAL_EFFECTIVE_DATE: null,
+              PROPOSED_DATE: null,
+              STATE_CODE: "10",
+            },
+            RAI: [
+              {
+                RAI_RECEIVED_DATE: null,
+                RAI_REQUESTED_DATE: 1675123200000,
+                RAI_WITHDRAWN_DATE: null,
+              },
+            ],
+            ACTIONTYPES: [
+              { ACTION_NAME: "Respond to Formal RAI", ACTION_ID: 1, PLAN_TYPE_ID: 123 },
+            ],
+            STATE_PLAN_SERVICETYPES: [{ SPA_TYPE_ID: 1, SPA_TYPE_NAME: "Type A" }],
+            STATE_PLAN_SERVICE_SUBTYPES: [{ TYPE_ID: 1, TYPE_NAME: "SubType X" }],
+          }),
+        }),
+      ],
+      TOPIC,
+    );
+
+    expect(bulkUpdateDataSpy).toBeCalledWith(OPENSEARCH_DOMAIN, OPENSEARCH_INDEX, [
+      {
+        actionType: "Respond to Formal RAI",
+        approvedEffectiveDate: ISO_DATETIME,
+        authority: "1915(c)",
+        changed_date: EARLIER_TIMESTAMP,
+        cmsStatus: "Disapproved",
+        description: "Sample summary",
+        finalDispositionDate: "2024-08-03T00:30:41.557Z",
+        id: RAI_WITHDRAWAL_ID,
+        initialIntakeNeeded: false,
+        leadAnalystEmail: "michael.chen@cms.hhs.gov",
+        leadAnalystName: "Michael Chen",
+        leadAnalystOfficerId: 67890,
+        locked: false,
+        proposedDate: null,
+        raiRequestedDate: "2023-01-31T00:00:00.000Z",
+        raiWithdrawEnabled: false,
+        raiWithdrawnDate: null,
+        reviewTeam: [
+          {
+            email: "john.doe@medicaid.gov",
+            name: "John Doe",
+          },
+          {
+            email: "emily.rodriguez@medicaid.gov",
+            name: "Emily Rodriguez",
+          },
+        ],
+        seatoolStatus: "Disapproved",
+        secondClock: false,
+        state: "10",
+        stateStatus: "Disapproved",
+        statusDate: EARLIER_ISO_DATETIME,
+        subTypes: [
+          {
+            TYPE_ID: 1,
+            TYPE_NAME: "SubType X",
+          },
+        ],
+        subject: "Sample Title",
+        types: [
+          {
+            SPA_TYPE_ID: 1,
+            SPA_TYPE_NAME: "Type A",
+          },
+        ],
+      },
+    ]);
+  });
+  it("tries to tries to update a  package that requested a RAI to be withdrawn but was withdrawn completely", async () => {
+    await insertNewSeatoolRecordsFromKafkaIntoMako(
+      [
+        createKafkaRecord({
+          topic: TOPIC,
+          key: RAI_WITHDRAWAL_KEY,
+          value: convertObjToBase64({
+            id: RAI_WITHDRAWAL_ID,
+            ACTION_OFFICERS: [
+              {
+                FIRST_NAME: "John",
+                LAST_NAME: "Doe",
+                EMAIL: "john.doe@medicaid.gov",
+                OFFICER_ID: 12345,
+                DEPARTMENT: "State Plan Review",
+                PHONE: "202-555-1234",
+              },
+              {
+                FIRST_NAME: "Emily",
+                LAST_NAME: "Rodriguez",
+                EMAIL: "emily.rodriguez@medicaid.gov",
+                OFFICER_ID: 12346,
+                DEPARTMENT: "Compliance Division",
+                PHONE: "202-555-5678",
+              },
+            ],
+            LEAD_ANALYST: [
+              {
+                FIRST_NAME: "Michael",
+                LAST_NAME: "Chen",
+                EMAIL: "michael.chen@cms.hhs.gov",
+                OFFICER_ID: 67890,
+                DEPARTMENT: "Medicaid Innovation Center",
+                PHONE: "202-555-9012",
+              },
+            ],
+            STATE_PLAN: {
+              PLAN_TYPE: 123,
+              SPW_STATUS_ID: SeatoolSpwStatusEnum.Withdrawn,
+              APPROVED_EFFECTIVE_DATE: TIMESTAMP,
+              CHANGED_DATE: EARLIER_TIMESTAMP,
+              SUMMARY_MEMO: "Sample summary",
+              TITLE_NAME: "Sample Title",
+              STATUS_DATE: EARLIER_TIMESTAMP,
+              SUBMISSION_DATE: TIMESTAMP,
+              LEAD_ANALYST_ID: 67890,
+              ACTUAL_EFFECTIVE_DATE: null,
+              PROPOSED_DATE: null,
+              STATE_CODE: "10",
+            },
+            RAI: [
+              {
+                RAI_RECEIVED_DATE: null,
+                RAI_REQUESTED_DATE: 1675123200000,
+                RAI_WITHDRAWN_DATE: null,
+              },
+            ],
+            ACTIONTYPES: [
+              { ACTION_NAME: "Respond to Formal RAI", ACTION_ID: 1, PLAN_TYPE_ID: 123 },
+            ],
+            STATE_PLAN_SERVICETYPES: [{ SPA_TYPE_ID: 1, SPA_TYPE_NAME: "Type A" }],
+            STATE_PLAN_SERVICE_SUBTYPES: [{ TYPE_ID: 1, TYPE_NAME: "SubType X" }],
+          }),
+        }),
+      ],
+      TOPIC,
+    );
+
+    expect(bulkUpdateDataSpy).toBeCalledWith(OPENSEARCH_DOMAIN, OPENSEARCH_INDEX, [
+      {
+        actionType: "Respond to Formal RAI",
+        approvedEffectiveDate: ISO_DATETIME,
+        authority: "1915(c)",
+        changed_date: EARLIER_TIMESTAMP,
+        cmsStatus: "Package Withdrawn",
+        description: "Sample summary",
+        finalDispositionDate: "2024-08-03T00:30:41.557Z",
+        id: RAI_WITHDRAWAL_ID,
+        initialIntakeNeeded: false,
+        leadAnalystEmail: "michael.chen@cms.hhs.gov",
+        leadAnalystName: "Michael Chen",
+        leadAnalystOfficerId: 67890,
+        locked: false,
+        proposedDate: null,
+        raiRequestedDate: "2023-01-31T00:00:00.000Z",
+        raiWithdrawEnabled: false,
+        raiWithdrawnDate: null,
+        reviewTeam: [
+          {
+            email: "john.doe@medicaid.gov",
+            name: "John Doe",
+          },
+          {
+            email: "emily.rodriguez@medicaid.gov",
+            name: "Emily Rodriguez",
+          },
+        ],
+        seatoolStatus: "Withdrawn",
+        secondClock: false,
+        state: "10",
+        stateStatus: "Package Withdrawn",
+        statusDate: EARLIER_ISO_DATETIME,
+        subTypes: [
+          {
+            TYPE_ID: 1,
+            TYPE_NAME: "SubType X",
+          },
+        ],
+        subject: "Sample Title",
+        types: [
+          {
+            SPA_TYPE_ID: 1,
+            SPA_TYPE_NAME: "Type A",
+          },
+        ],
+      },
+    ]);
+  });
+  it("tries to tries to update a  package that requested a RAI to be withdrawn but was terminated", async () => {
+    await insertNewSeatoolRecordsFromKafkaIntoMako(
+      [
+        createKafkaRecord({
+          topic: TOPIC,
+          key: RAI_WITHDRAWAL_KEY,
+          value: convertObjToBase64({
+            id: RAI_WITHDRAWAL_ID,
+            ACTION_OFFICERS: [
+              {
+                FIRST_NAME: "John",
+                LAST_NAME: "Doe",
+                EMAIL: "john.doe@medicaid.gov",
+                OFFICER_ID: 12345,
+                DEPARTMENT: "State Plan Review",
+                PHONE: "202-555-1234",
+              },
+              {
+                FIRST_NAME: "Emily",
+                LAST_NAME: "Rodriguez",
+                EMAIL: "emily.rodriguez@medicaid.gov",
+                OFFICER_ID: 12346,
+                DEPARTMENT: "Compliance Division",
+                PHONE: "202-555-5678",
+              },
+            ],
+            LEAD_ANALYST: [
+              {
+                FIRST_NAME: "Michael",
+                LAST_NAME: "Chen",
+                EMAIL: "michael.chen@cms.hhs.gov",
+                OFFICER_ID: 67890,
+                DEPARTMENT: "Medicaid Innovation Center",
+                PHONE: "202-555-9012",
+              },
+            ],
+            STATE_PLAN: {
+              PLAN_TYPE: 123,
+              SPW_STATUS_ID: SeatoolSpwStatusEnum.Terminated,
+              APPROVED_EFFECTIVE_DATE: TIMESTAMP,
+              CHANGED_DATE: EARLIER_TIMESTAMP,
+              SUMMARY_MEMO: "Sample summary",
+              TITLE_NAME: "Sample Title",
+              STATUS_DATE: EARLIER_TIMESTAMP,
+              SUBMISSION_DATE: TIMESTAMP,
+              LEAD_ANALYST_ID: 67890,
+              ACTUAL_EFFECTIVE_DATE: null,
+              PROPOSED_DATE: null,
+              STATE_CODE: "10",
+            },
+            RAI: [
+              {
+                RAI_RECEIVED_DATE: null,
+                RAI_REQUESTED_DATE: 1675123200000,
+                RAI_WITHDRAWN_DATE: null,
+              },
+            ],
+            ACTIONTYPES: [
+              { ACTION_NAME: "Respond to Formal RAI", ACTION_ID: 1, PLAN_TYPE_ID: 123 },
+            ],
+            STATE_PLAN_SERVICETYPES: [{ SPA_TYPE_ID: 1, SPA_TYPE_NAME: "Type A" }],
+            STATE_PLAN_SERVICE_SUBTYPES: [{ TYPE_ID: 1, TYPE_NAME: "SubType X" }],
+          }),
+        }),
+      ],
+      TOPIC,
+    );
+
+    expect(bulkUpdateDataSpy).toBeCalledWith(OPENSEARCH_DOMAIN, OPENSEARCH_INDEX, [
+      {
+        actionType: "Respond to Formal RAI",
+        approvedEffectiveDate: ISO_DATETIME,
+        authority: "1915(c)",
+        changed_date: EARLIER_TIMESTAMP,
+        cmsStatus: "Terminated",
+        description: "Sample summary",
+        finalDispositionDate: "2024-08-03T00:30:41.557Z",
+        id: RAI_WITHDRAWAL_ID,
+        initialIntakeNeeded: false,
+        leadAnalystEmail: "michael.chen@cms.hhs.gov",
+        leadAnalystName: "Michael Chen",
+        leadAnalystOfficerId: 67890,
+        locked: false,
+        proposedDate: null,
+        raiRequestedDate: "2023-01-31T00:00:00.000Z",
+        raiWithdrawEnabled: false,
+        raiWithdrawnDate: null,
+        reviewTeam: [
+          {
+            email: "john.doe@medicaid.gov",
+            name: "John Doe",
+          },
+          {
+            email: "emily.rodriguez@medicaid.gov",
+            name: "Emily Rodriguez",
+          },
+        ],
+        seatoolStatus: "Terminated",
+        secondClock: false,
+        state: "10",
+        stateStatus: "Terminated",
         statusDate: EARLIER_ISO_DATETIME,
         subTypes: [
           {

--- a/lib/lambda/sinkMainProcessors.ts
+++ b/lib/lambda/sinkMainProcessors.ts
@@ -269,7 +269,7 @@ const oneMacSeatoolStatusCheck = async (seatoolRecord: Document) => {
   ) {
     if (
       seatoolStatus &&
-      ![
+      [
         SeatoolSpwStatusEnum.Withdrawn,
         SeatoolSpwStatusEnum.Terminated,
         SeatoolSpwStatusEnum.Disapproved,

--- a/lib/lambda/sinkMainProcessors.ts
+++ b/lib/lambda/sinkMainProcessors.ts
@@ -263,6 +263,23 @@ const oneMacSeatoolStatusCheck = async (seatoolRecord: Document) => {
       }
     }
   }
+  if (
+    oneMacStatus === SEATOOL_STATUS.RAI_RESPONSE_WITHDRAW_REQUESTED &&
+    seatoolStatus !== SeatoolSpwStatusEnum.PendingRAI
+  ) {
+    if (
+      seatoolStatus &&
+      ![
+        SeatoolSpwStatusEnum.Withdrawn,
+        SeatoolSpwStatusEnum.Terminated,
+        SeatoolSpwStatusEnum.Disapproved,
+      ].includes(seatoolStatus)
+    ) {
+      return seatoolStatus;
+    }
+    return SeatoolSpwStatusEnum.FormalRAIResponseWithdrawalRequested;
+  }
+
   return seatoolRecord.STATE_PLAN.SPW_STATUS_ID;
 };
 

--- a/mocks/data/items.ts
+++ b/mocks/data/items.ts
@@ -20,6 +20,7 @@ export const NOT_EXISTING_ITEM_ID = "MD-11-0000";
 export const TEST_ITEM_ID = "MD-0005.R01.00";
 export const WITHDRAWAL_REQUESTED_ID = "MD-0005.R01.05";
 export const SUBMITTED_RAI_ID = "MD-0005.R01.06";
+export const RAI_WITHDRAWAL_ID = "MD-0005.R01.07";
 export const TEST_SPA_ITEM_ID = "MD-11-2020";
 export const TEST_SPA_ITEM_RAI_ID = "MD-11-2022";
 export const TEST_PACKAGE_STATUS_ID = "MD-11-2021";
@@ -752,6 +753,40 @@ const items: Record<string, TestItemResult> = {
             ],
             additionalInformation: "Uncategorized file upload.",
             isAdminChange: false,
+          },
+        },
+      ],
+    },
+  },
+  [RAI_WITHDRAWAL_ID]: {
+    _id: RAI_WITHDRAWAL_ID,
+    found: true,
+    _source: {
+      id: RAI_WITHDRAWAL_ID,
+      seatoolStatus: SEATOOL_STATUS.RAI_RESPONSE_WITHDRAW_REQUESTED,
+      stateStatus: statusToDisplayToStateUser[SEATOOL_STATUS.RAI_RESPONSE_WITHDRAW_REQUESTED],
+      cmsStatus: statusToDisplayToCmsUser[SEATOOL_STATUS.RAI_RESPONSE_WITHDRAW_REQUESTED],
+      actionType: "Respond to Formal RAI",
+      authority: "CHIP SPA",
+      state: "MD",
+      origin: "OneMAC",
+      changelog: [
+        {
+          _id: `${RAI_WITHDRAWAL_ID}-0001`,
+          _source: {
+            packageId: RAI_WITHDRAWAL_ID,
+            id: `${RAI_WITHDRAWAL_ID}-0001`,
+            event: "respond-to-rai",
+            attachments: [
+              {
+                key: "rai001",
+                title: "Response to RAI",
+                filename: "rai_response.docx",
+                bucket: ATTACHMENT_BUCKET_NAME,
+              },
+            ],
+            additionalInformation: "Detailed response to the request for additional information.",
+            timestamp: 1675123200000, // Feb 1, 2023
           },
         },
       ],


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[[Ticket to close](link-to-ticket)](https://jiraent.cms.gov/browse/OY2-33871)

## 💬 Description / Notes

This is to prevent RAI withdrawal request to not disappear.  Only works for non-legacy

## 🛠 Changes

<!-- List your code changes made to implement the solution -->

Expanded on the functionality of checking placeholder statuses.  After it is in a pending rai withdrawal status only terminal statuses(withdrawn, terminated, or disapproved) can overwrite it.  Any other status that is not Pending-RAI will prevent it from changing as far as seatool is concerned.  

https://jiraent.cms.gov/secure/attachment/1484516/PlaceHolderFlow.drawio.pdf

<!-- ### Before -->

<!-- ### After -->
