### PR TITLE
feat(api): revamp how we set legacy event types so that subsequent submission works

### DIFF
--- a/lib/packages/shared-types/opensearch/changelog/index.ts
+++ b/lib/packages/shared-types/opensearch/changelog/index.ts
@@ -72,7 +72,6 @@ export type Document = Omit<AppkDocument, "event"> &
       | "contracting-initial"
       | "contracting-renewal"
       | "legacy-admin-change"
-      | "new-legacy-submission"
       | "new-chip-submission"
       | "new-medicaid-submission"
       | "respond-to-rai"

--- a/lib/packages/shared-types/opensearch/changelog/transforms/legacy-event.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/legacy-event.ts
@@ -6,7 +6,7 @@ import { ONEMAC_LEGACY_ORIGIN } from "../../main/transforms/legacy-transforms";
 export const transform = () => {
   return legacyEventSchema.transform((data) => {
     // Resolve the action type based on the GSI1pk
-    const eventType = getLegacyEventType(data?.GSI1pk);
+    const eventType = getLegacyEventType(data?.GSI1pk, data.waiverAuthority);
 
     // Return if the actionType is unhandled
     if (eventType === undefined) return undefined;

--- a/lib/packages/shared-utils/legacy-event-type.test.ts
+++ b/lib/packages/shared-utils/legacy-event-type.test.ts
@@ -13,9 +13,54 @@ describe("getLegacyEventType", () => {
     expect(legacyEvent).toBe(undefined);
   });
 
-  it("should return 'new-chip-submission' if GSI1pk is an initial submission type", () => {
+  it("should return 'new-chip-submission' if GSI1pk is an chip spa submission type", () => {
     const legacyEvent = getLegacyEventType("OneMAC#submitchipspa");
     expect(legacyEvent).toEqual("new-chip-submission");
+  });
+
+  it("should return 'new-medicaid-submission' if GSI1pk is a medicaid spa submission type", () => {
+    const legacyEvent = getLegacyEventType("OneMAC#medicaidspa");
+    expect(legacyEvent).toEqual("new-medicaid-submission");
+  });
+
+  it("should return 'capitated-amendment' if is a 1915(b) ammendment submission type", () => {
+    const legacyEvent = getLegacyEventType("OneMAC#waiveramendment");
+    expect(legacyEvent).toEqual("capitated-amendment");
+  });
+
+  it("should return 'contracting-amendment' if is a 1915(b)(4) ammendment submission type", () => {
+    const legacyEvent = getLegacyEventType("OneMAC#waiveramendment");
+    expect(legacyEvent).toEqual("contracting-amendment");
+  });
+
+  it("should return 'app-k' if is an waiver app k submission type", () => {
+    const legacyEvent = getLegacyEventType("OneMAC#waiverappk");
+    expect(legacyEvent).toEqual("app-k");
+  });
+
+  it("should return 'temporary-extension' if GSI1pk is an waiver extension submission type", () => {
+    const legacyEvent = getLegacyEventType("OneMAC#waiverextension");
+    expect(legacyEvent).toEqual("temporary-extension");
+  });
+
+  it("should return 'capitated-initial' if is a 1915(b) initial submission type", () => {
+    const legacyEvent = getLegacyEventType("OneMAC#waivernew", "1915(b)");
+    expect(legacyEvent).toEqual("capitated-initial");
+  });
+
+  it("should return 'contracting-initial' if is a 1915(b)(4) initial submission type", () => {
+    const legacyEvent = getLegacyEventType("OneMAC#waivernew", "1915(b)(4)");
+    expect(legacyEvent).toEqual("contracting-initial");
+  });
+
+  it("should return 'capitated-renewal' if is a 1915(b) renewal submission type", () => {
+    const legacyEvent = getLegacyEventType("OneMAC#waiverrenewal");
+    expect(legacyEvent).toEqual("capitated-renewal");
+  });
+
+  it("should return 'contracting-renewal' if is a 1915(b)(4) renewal submission type", () => {
+    const legacyEvent = getLegacyEventType("OneMAC#waiverrenewal", "1915(b)(4)");
+    expect(legacyEvent).toEqual("contracting-renewal");
   });
 
   it("should return 'respond-to-rai' if GSI1pk is an RAI response submission type", () => {

--- a/lib/packages/shared-utils/legacy-event-type.test.ts
+++ b/lib/packages/shared-utils/legacy-event-type.test.ts
@@ -13,9 +13,9 @@ describe("getLegacyEventType", () => {
     expect(legacyEvent).toBe(undefined);
   });
 
-  it("should return 'new-legacy-submission' if GSI1pk is an initial submission type", () => {
+  it("should return 'new-chip-submission' if GSI1pk is an initial submission type", () => {
     const legacyEvent = getLegacyEventType("OneMAC#submitchipspa");
-    expect(legacyEvent).toEqual("new-legacy-submission");
+    expect(legacyEvent).toEqual("new-chip-submission");
   });
 
   it("should return 'respond-to-rai' if GSI1pk is an RAI response submission type", () => {

--- a/lib/packages/shared-utils/legacy-event-type.test.ts
+++ b/lib/packages/shared-utils/legacy-event-type.test.ts
@@ -19,47 +19,47 @@ describe("getLegacyEventType", () => {
   });
 
   it("should return 'new-medicaid-submission' if GSI1pk is a medicaid spa submission type", () => {
-    const legacyEvent = getLegacyEventType("OneMAC#medicaidspa");
+    const legacyEvent = getLegacyEventType("OneMAC#submitmedicaidspa");
     expect(legacyEvent).toEqual("new-medicaid-submission");
   });
 
   it("should return 'capitated-amendment' if is a 1915(b) ammendment submission type", () => {
-    const legacyEvent = getLegacyEventType("OneMAC#waiveramendment");
+    const legacyEvent = getLegacyEventType("OneMAC#submitwaiveramendment", "1915(b)");
     expect(legacyEvent).toEqual("capitated-amendment");
   });
 
   it("should return 'contracting-amendment' if is a 1915(b)(4) ammendment submission type", () => {
-    const legacyEvent = getLegacyEventType("OneMAC#waiveramendment");
+    const legacyEvent = getLegacyEventType("OneMAC#submitwaiveramendment", "1915(b)(4)");
     expect(legacyEvent).toEqual("contracting-amendment");
   });
 
   it("should return 'app-k' if is an waiver app k submission type", () => {
-    const legacyEvent = getLegacyEventType("OneMAC#waiverappk");
+    const legacyEvent = getLegacyEventType("OneMAC#submitwaiverappk");
     expect(legacyEvent).toEqual("app-k");
   });
 
   it("should return 'temporary-extension' if GSI1pk is an waiver extension submission type", () => {
-    const legacyEvent = getLegacyEventType("OneMAC#waiverextension");
+    const legacyEvent = getLegacyEventType("OneMAC#submitwaiverextension");
     expect(legacyEvent).toEqual("temporary-extension");
   });
 
   it("should return 'capitated-initial' if is a 1915(b) initial submission type", () => {
-    const legacyEvent = getLegacyEventType("OneMAC#waivernew", "1915(b)");
+    const legacyEvent = getLegacyEventType("OneMAC#submitwaivernew", "1915(b)");
     expect(legacyEvent).toEqual("capitated-initial");
   });
 
   it("should return 'contracting-initial' if is a 1915(b)(4) initial submission type", () => {
-    const legacyEvent = getLegacyEventType("OneMAC#waivernew", "1915(b)(4)");
+    const legacyEvent = getLegacyEventType("OneMAC#submitwaivernew", "1915(b)(4)");
     expect(legacyEvent).toEqual("contracting-initial");
   });
 
   it("should return 'capitated-renewal' if is a 1915(b) renewal submission type", () => {
-    const legacyEvent = getLegacyEventType("OneMAC#waiverrenewal");
+    const legacyEvent = getLegacyEventType("OneMAC#submitwaiverrenewal", "1915(b)");
     expect(legacyEvent).toEqual("capitated-renewal");
   });
 
   it("should return 'contracting-renewal' if is a 1915(b)(4) renewal submission type", () => {
-    const legacyEvent = getLegacyEventType("OneMAC#waiverrenewal", "1915(b)(4)");
+    const legacyEvent = getLegacyEventType("OneMAC#submitwaiverrenewal", "1915(b)(4)");
     expect(legacyEvent).toEqual("contracting-renewal");
   });
 

--- a/lib/packages/shared-utils/legacy-event-type.ts
+++ b/lib/packages/shared-utils/legacy-event-type.ts
@@ -1,7 +1,7 @@
 import { Action } from "shared-types";
 
 // Resolve the action type based on the GSI1pk
-export const getLegacyEventType = (gsi1pk: string) => {
+export const getLegacyEventType = (gsi1pk: string, waiverAuthority?: string | null | undefined) => {
   if (gsi1pk === "") {
     return undefined;
   }
@@ -9,15 +9,21 @@ export const getLegacyEventType = (gsi1pk: string) => {
 
   switch (submitType) {
     case "chipspa":
+      return "new-chip-submission";
     case "medicaidspa":
+      return "new-medicaid-submission";
     case "waiveramendment":
+      return waiverAuthority === "1915(b)" ? "capitated-amendment" : "contracting-amendment"; //legacy uses 1915(b) for capitated and 1915(b)(4) for contracting
     case "waiverappk":
+      return "app-k";
     case "waiverextension":
     case "waiverextensionb":
     case "waiverextensionc":
+      return "temporary-extension";
     case "waivernew":
+      return waiverAuthority === "1915(b)" ? "capitated-initial" : "contracting-initial"; //legacy uses 1915(b) for capitated and 1915(b)(4) for contracting
     case "waiverrenewal":
-      return "new-legacy-submission";
+      return waiverAuthority === "1915(b)" ? "capitated-renewal" : "contracting-renewal"; //legacy uses 1915(b) for capitated and 1915(b)(4) for contracting
     case "chipsparai":
     case "medicaidsparai":
     case "waiveramendmentrai":

--- a/react-app/src/features/package/package-activity/index.tsx
+++ b/react-app/src/features/package/package-activity/index.tsx
@@ -99,7 +99,6 @@ const PackageActivity = ({ packageActivity }: PackageActivityProps) => {
       case "new-medicaid-submission":
       case "temporary-extension":
       case "app-k":
-      case "new-legacy-submission":
         return "Initial Package Submitted";
 
       case "withdraw-package":


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[OY2-33820](https://jiraent.cms.gov/browse/OY2-33820)

## 💬 Description / Notes

Originally the legacy items were imported under distinct legacy event types. This worked fine for importing and display but impacted the ability to do a subsequent submission action as that aciton relies on the original event type in order to determine what attachments are allowed on the subsequent submission form. Therefore this change will determine the legacy type and translate to the mako event type. Due to this the legacy event type was removed as it is no longer needed/used.

## 🛠 Changes

- Updated legacy changelog ingestion logic to determine appropriate mako event type
- Removed usage of new-legacy-submission event type

