### PR TITLE
fix(footer-default): Update default footer to not show

### DIFF
--- a/react-app/src/components/Footer/index.tsx
+++ b/react-app/src/components/Footer/index.tsx
@@ -16,7 +16,7 @@ type Props = {
   showNavLinks?: boolean;
 };
 
-export const Footer = ({ email, address, showNavLinks }: Props) => {
+export const Footer = ({ email, address, showNavLinks = false }: Props) => {
   const shouldShowNavLinks = showNavLinks ?? true;
   const { data: user } = useGetUser();
   const isStateHomepage = useFeatureFlag("STATE_HOMEPAGE_FLAG");

--- a/react-app/src/components/Footer/index.tsx
+++ b/react-app/src/components/Footer/index.tsx
@@ -16,8 +16,8 @@ type Props = {
   showNavLinks?: boolean;
 };
 
-export const Footer = ({ email, address, showNavLinks = false }: Props) => {
-  const shouldShowNavLinks = showNavLinks ?? true;
+export const Footer = ({ email, address, showNavLinks }: Props) => {
+  const shouldShowNavLinks = showNavLinks ?? false;
   const { data: user } = useGetUser();
   const isStateHomepage = useFeatureFlag("STATE_HOMEPAGE_FLAG");
 


### PR DESCRIPTION
## 💬 Description / Notes
Add logic to default additional footer to not show. More research needed to understand when this footer is needed, until that time lets default it to false.

## 📸 Screenshots / Demo

<!-- ### Before -->
![Screen Shot 2025-04-23 at 12 28 14 PM](https://github.com/user-attachments/assets/3ab8afd2-6e49-4a59-a977-71961d7cec69)

<!-- ### After -->
![Screen Shot 2025-04-23 at 12 28 25 PM](https://github.com/user-attachments/assets/10c2fcba-7710-40a8-8ef2-832cb6512457)
