### PR TITLE
fix: alter how legacy admin changes are processed from kafka

### DIFF
--- a/lib/lambda/sinkChangelog.ts
+++ b/lib/lambda/sinkChangelog.ts
@@ -134,24 +134,21 @@ const processAndIndex = async ({
       }
 
       // If the event is a supported event, transform and push to docs array for indexing
-      if (kafkaSource === "onemac" && record.GSI1pk) {
+      if (kafkaSource === "onemac" && record.GSI1pk?.startsWith("OneMAC#submit")) {
         // This is a onemac legacy event
         record.event = "legacy-event";
         record.origin = "onemac";
       }
 
       const recordsToProcess: Array<(typeof transforms)[keyof typeof transforms]["Schema"]> = [];
-      if (record.reverseChrono?.length) {
-        // Focus on adminChange property in records with the reverseChrono property to avoid ingesting duplicates
-        if (record.adminChanges?.length) {
-          record.adminChanges.map((adminChange: LegacyAdminChange) =>
-            recordsToProcess.push({
-              ...record,
-              ...adminChange,
-              event: "legacy-admin-change",
-            }),
-          );
-        }
+      if (record.adminChanges?.length) {
+        record.adminChanges.map((adminChange: LegacyAdminChange) =>
+          recordsToProcess.push({
+            ...record,
+            ...adminChange,
+            event: "legacy-admin-change",
+          }),
+        );
       } else {
         recordsToProcess.push(record);
       }

--- a/lib/packages/shared-types/opensearch/changelog/transforms/legacy-admin-change.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/legacy-admin-change.ts
@@ -1,6 +1,6 @@
 import { Action, legacyAdminChangeSchema } from "../../..";
 
-export const transform = (id: string) => {
+export const transform = () => {
   return legacyAdminChangeSchema.transform((data) => {
     const transformedData = {
       // Timestamp is what makes admin changes unique; we add it to the id here, instead of the offset

--- a/lib/packages/shared-types/opensearch/changelog/transforms/legacy-admin-change.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/legacy-admin-change.ts
@@ -4,7 +4,7 @@ export const transform = (id: string) => {
   return legacyAdminChangeSchema.transform((data) => {
     const transformedData = {
       // Timestamp is what makes admin changes unique; we add it to the id here, instead of the offset
-      id: `${id}-legacy-admin-change-${data.changeTimestamp}`,
+      id: `${data.id}-legacy-admin-change-${data.changeTimestamp}`,
       packageId: data.id,
       timestamp: data.changeTimestamp,
       actionType: Action.LEGACY_ADMIN_CHANGE,


### PR DESCRIPTION
 

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[OY2-34452](https://jiraent.cms.gov/browse/OY2-34452)

## 💬 Description / Notes

Reworked how legacy admin changes are processed and stored from kafka. 2 real changes:


## 🛠 Changes

1. sinkChangelog.ts - Instead of reading from package record read only the event records
2. legacyAdminChange.ts - Dont use the kafka event id for the record prefix, use the package id

## 📸 Screenshots / Demo

<!-- ### Before -->
![image](https://github.com/user-attachments/assets/c5ee5431-c515-4538-b1df-d8b0993f4079)


<!-- ### After -->
![image](https://github.com/user-attachments/assets/20ebc2e9-ef01-41c9-8c70-2d4b2cb9be9a)
