### PR TITLE
fix(timestamps-in-dashboard-to-et): change times in dashboard to et

### DIFF
--- a/react-app/src/components/Tabs/index.tsx
+++ b/react-app/src/components/Tabs/index.tsx
@@ -28,7 +28,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center px-3 py-1.5 text-2xl bg-neutral-100 rounded-xs ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus:outline-none disabled:pointer-events-none disabled:opacity-50 border-b-4 border-b-transparent data-[state=active]:border-b-primary data-[state=active]:bg-blue-50 data-[state=active]:text-primary data-[state=active]:font-bold",
+      "inline-flex items-center justify-center px-3 py-1.5 text-xl bg-neutral-100 rounded-xs ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus:outline-none disabled:pointer-events-none disabled:opacity-50 border-b-4 border-b-transparent data-[state=active]:border-b-primary data-[state=active]:bg-blue-50 data-[state=active]:text-primary data-[state=active]:font-bold",
       className,
     )}
     {...props}

--- a/react-app/src/features/dashboard/Lists/renderCells/index.tsx
+++ b/react-app/src/features/dashboard/Lists/renderCells/index.tsx
@@ -2,14 +2,14 @@ import { EllipsisVerticalIcon } from "@heroicons/react/24/outline";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Link } from "react-router";
 import { Authority, CognitoUserAttributes, opensearch } from "shared-types";
-import { formatSeatoolDate, getAvailableActions } from "shared-utils";
+import { formatDateToET, formatSeatoolDate, getAvailableActions } from "shared-utils";
 
 import { DASHBOARD_ORIGIN, mapActionLabel, ORIGIN } from "@/utils";
 
 export const renderCellDate = (key: keyof opensearch.main.Document) =>
   function Cell(data: opensearch.main.Document) {
     if (!data[key]) return null;
-    return formatSeatoolDate(data[key] as string);
+    return formatDateToET(data[key] as string, "MM/dd/yyyy", false);
   };
 
 export type CellIdLinkProps = {

--- a/react-app/src/features/dashboard/Lists/renderCells/index.tsx
+++ b/react-app/src/features/dashboard/Lists/renderCells/index.tsx
@@ -2,7 +2,7 @@ import { EllipsisVerticalIcon } from "@heroicons/react/24/outline";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Link } from "react-router";
 import { Authority, CognitoUserAttributes, opensearch } from "shared-types";
-import { formatDateToET, formatSeatoolDate, getAvailableActions } from "shared-utils";
+import { formatDateToET, getAvailableActions } from "shared-utils";
 
 import { DASHBOARD_ORIGIN, mapActionLabel, ORIGIN } from "@/utils";
 

--- a/react-app/src/features/dashboard/Lists/spas/consts.tsx
+++ b/react-app/src/features/dashboard/Lists/spas/consts.tsx
@@ -90,10 +90,11 @@ const getColumns = (props) => {
     {
       field: "submissionDate",
       label: "Initial Submission",
-      transform: (data) =>
-        data?.submissionDate
+      transform: (data) => {
+        return data?.submissionDate
           ? formatDateToET(data.submissionDate, "MM/dd/yyyy", false)
-          : BLANK_VALUE,
+          : BLANK_VALUE;
+      },
       cell: renderCellDate("submissionDate"),
     },
     {

--- a/react-app/src/features/dashboard/Lists/spas/consts.tsx
+++ b/react-app/src/features/dashboard/Lists/spas/consts.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { CMS_READ_ONLY_ROLES, SEATOOL_STATUS, UserRoles } from "shared-types";
-import { formatSeatoolDate } from "shared-utils";
+import { formatDateToET } from "shared-utils";
 
 import { useGetUser } from "@/api";
 import { OsTableColumn } from "@/components";
@@ -91,7 +91,9 @@ const getColumns = (props) => {
       field: "submissionDate",
       label: "Initial Submission",
       transform: (data) =>
-        data?.submissionDate ? formatSeatoolDate(data.submissionDate) : BLANK_VALUE,
+        data?.submissionDate
+          ? formatDateToET(data.submissionDate, "MM/dd/yyyy", false)
+          : BLANK_VALUE,
       cell: renderCellDate("submissionDate"),
     },
     {
@@ -99,14 +101,18 @@ const getColumns = (props) => {
       label: "Final Disposition",
       hidden: true,
       transform: (data) =>
-        data?.finalDispositionDate ? formatSeatoolDate(data.finalDispositionDate) : BLANK_VALUE,
+        data?.finalDispositionDate
+          ? formatDateToET(data.finalDispositionDate, "MM/dd/yyyy", false)
+          : BLANK_VALUE,
       cell: renderCellDate("finalDispositionDate"),
     },
     {
       field: "makoChangedDate",
       label: "Latest Package Activity",
       transform: (data) =>
-        data.makoChangedDate ? formatSeatoolDate(data.makoChangedDate) : BLANK_VALUE,
+        data.makoChangedDate
+          ? formatDateToET(data.makoChangedDate, "MM/dd/yyyy", false)
+          : BLANK_VALUE,
       cell: renderCellDate("makoChangedDate"),
     },
     {
@@ -114,7 +120,9 @@ const getColumns = (props) => {
       label: "Formal RAI Requested",
       hidden: true,
       transform: (data) => {
-        return data.raiRequestedDate ? formatSeatoolDate(data.raiRequestedDate) : BLANK_VALUE;
+        return data.raiRequestedDate
+          ? formatDateToET(data.raiRequestedDate, "MM/dd/yyyy", false)
+          : BLANK_VALUE;
       },
       cell: renderCellDate("raiRequestedDate"),
     },
@@ -122,7 +130,9 @@ const getColumns = (props) => {
       field: "raiReceivedDate",
       label: "Formal RAI Response",
       transform: (data) => {
-        return data.raiReceivedDate ? formatSeatoolDate(data.raiReceivedDate) : BLANK_VALUE;
+        return data.raiReceivedDate
+          ? formatDateToET(data.raiReceivedDate, "MM/dd/yyyy", false)
+          : BLANK_VALUE;
       },
       cell: renderCellDate("raiReceivedDate"),
     },

--- a/react-app/src/features/dashboard/Lists/spas/index.test.tsx
+++ b/react-app/src/features/dashboard/Lists/spas/index.test.tsx
@@ -332,8 +332,8 @@ describe("SpasList", () => {
         {
           hasActions,
           status: useCmsStatus ? pendingDoc.cmsStatus : pendingDoc.stateStatus,
-          submissionDate: "01/01/2024",
-          makoChangedDate: "02/01/2024",
+          submissionDate: "12/31/2023",
+          makoChangedDate: "01/31/2024",
         },
       ],
       [
@@ -342,9 +342,9 @@ describe("SpasList", () => {
         {
           hasActions,
           status: useCmsStatus ? raiRequestDoc.cmsStatus : raiRequestDoc.stateStatus,
-          submissionDate: "01/01/2024",
-          makoChangedDate: "02/01/2024",
-          raiRequestedDate: "03/01/2024",
+          submissionDate: "12/31/2023",
+          makoChangedDate: "01/31/2024",
+          raiRequestedDate: "02/29/2024",
         },
       ],
       [
@@ -353,10 +353,10 @@ describe("SpasList", () => {
         {
           hasActions,
           status: useCmsStatus ? raiReceivedDoc.cmsStatus : raiReceivedDoc.stateStatus,
-          submissionDate: "01/01/2024",
-          makoChangedDate: "02/01/2024",
-          raiRequestedDate: "03/01/2024",
-          raiReceivedDate: "04/01/2024",
+          submissionDate: "12/31/2023",
+          makoChangedDate: "01/31/2024",
+          raiRequestedDate: "02/29/2024",
+          raiReceivedDate: "03/31/2024",
         },
       ],
       [
@@ -365,10 +365,10 @@ describe("SpasList", () => {
         {
           hasActions,
           status: `${useCmsStatus ? withdrawEnabledDoc.cmsStatus : withdrawEnabledDoc.stateStatus}· Withdraw Formal RAI Response - Enabled`,
-          submissionDate: "01/01/2024",
-          makoChangedDate: "02/01/2024",
-          raiRequestedDate: "03/01/2024",
-          raiReceivedDate: "04/01/2024",
+          submissionDate: "12/31/2023",
+          makoChangedDate: "01/31/2024",
+          raiRequestedDate: "02/29/2024",
+          raiReceivedDate: "03/31/2024",
         },
       ],
       [
@@ -377,10 +377,10 @@ describe("SpasList", () => {
         {
           hasActions,
           status: useCmsStatus ? withdrawDisabledDoc.cmsStatus : withdrawDisabledDoc.stateStatus,
-          submissionDate: "01/01/2024",
-          makoChangedDate: "02/01/2024",
-          raiRequestedDate: "03/01/2024",
-          raiReceivedDate: "04/01/2024",
+          submissionDate: "12/31/2023",
+          makoChangedDate: "01/31/2024",
+          raiRequestedDate: "02/29/2024",
+          raiReceivedDate: "03/31/2024",
         },
       ],
       [
@@ -389,9 +389,9 @@ describe("SpasList", () => {
         {
           hasActions,
           status: useCmsStatus ? approvedDoc.cmsStatus : approvedDoc.stateStatus,
-          submissionDate: "01/01/2024",
-          makoChangedDate: "02/01/2024",
-          finalDispositionDate: "05/01/2024",
+          submissionDate: "12/31/2023",
+          makoChangedDate: "01/31/2024",
+          finalDispositionDate: "04/30/2024",
         },
       ],
       [

--- a/react-app/src/features/dashboard/Lists/waivers/consts.tsx
+++ b/react-app/src/features/dashboard/Lists/waivers/consts.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { CMS_READ_ONLY_ROLES, SEATOOL_STATUS, UserRoles } from "shared-types";
-import { formatActionType, formatSeatoolDate } from "shared-utils";
+import { formatActionType, formatDateToET } from "shared-utils";
 
 import { useGetUser } from "@/api";
 import { OsTableColumn } from "@/components";
@@ -94,7 +94,9 @@ const getColumns = (props) => {
       field: "submissionDate",
       label: "Initial Submission",
       transform: (data) =>
-        data?.submissionDate ? formatSeatoolDate(data.submissionDate) : BLANK_VALUE,
+        data?.submissionDate
+          ? formatDateToET(data.submissionDate, "MM/dd/yyyy", false)
+          : BLANK_VALUE,
       cell: renderCellDate("submissionDate"),
     },
     {
@@ -102,14 +104,18 @@ const getColumns = (props) => {
       label: "Final Disposition",
       hidden: true,
       transform: (data) =>
-        data?.finalDispositionDate ? formatSeatoolDate(data.finalDispositionDate) : BLANK_VALUE,
+        data?.finalDispositionDate
+          ? formatDateToET(data.finalDispositionDate, "MM/dd/yyyy", false)
+          : BLANK_VALUE,
       cell: renderCellDate("finalDispositionDate"),
     },
     {
       field: "makoChangedDate",
       label: "Latest Package Activity",
       transform: (data) =>
-        data.makoChangedDate ? formatSeatoolDate(data.makoChangedDate) : BLANK_VALUE,
+        data.makoChangedDate
+          ? formatDateToET(data.makoChangedDate, "MM/dd/yyyy", false)
+          : BLANK_VALUE,
       cell: renderCellDate("makoChangedDate"),
     },
     {
@@ -117,7 +123,9 @@ const getColumns = (props) => {
       label: "Formal RAI Requested",
       hidden: true,
       transform: (data) => {
-        return data.raiRequestedDate ? formatSeatoolDate(data.raiRequestedDate) : BLANK_VALUE;
+        return data.raiRequestedDate
+          ? formatDateToET(data.raiRequestedDate, "MM/dd/yyyy", false)
+          : BLANK_VALUE;
       },
       cell: renderCellDate("raiRequestedDate"),
     },
@@ -125,7 +133,9 @@ const getColumns = (props) => {
       field: "raiReceivedDate",
       label: "Formal RAI Response",
       transform: (data) => {
-        return data.raiReceivedDate ? formatSeatoolDate(data.raiReceivedDate) : BLANK_VALUE;
+        return data.raiReceivedDate
+          ? formatDateToET(data.raiReceivedDate, "MM/dd/yyyy", false)
+          : BLANK_VALUE;
       },
       cell: renderCellDate("raiReceivedDate"),
     },

--- a/react-app/src/features/dashboard/Lists/waivers/index.test.tsx
+++ b/react-app/src/features/dashboard/Lists/waivers/index.test.tsx
@@ -352,8 +352,8 @@ describe("WaiversList", () => {
         {
           hasActions,
           status: useCmsStatus ? pendingDoc.cmsStatus : pendingDoc.stateStatus,
-          submissionDate: "01/01/2024",
-          makoChangedDate: "02/01/2024",
+          submissionDate: "12/31/2023",
+          makoChangedDate: "01/31/2024",
         },
       ],
       [
@@ -362,9 +362,9 @@ describe("WaiversList", () => {
         {
           hasActions,
           status: useCmsStatus ? raiRequestDoc.cmsStatus : raiRequestDoc.stateStatus,
-          submissionDate: "01/01/2024",
-          makoChangedDate: "02/01/2024",
-          raiRequestedDate: "03/01/2024",
+          submissionDate: "12/31/2023",
+          makoChangedDate: "01/31/2024",
+          raiRequestedDate: "02/29/2024",
         },
       ],
       [
@@ -373,10 +373,10 @@ describe("WaiversList", () => {
         {
           hasActions,
           status: useCmsStatus ? raiReceivedDoc.cmsStatus : raiReceivedDoc.stateStatus,
-          submissionDate: "01/01/2024",
-          makoChangedDate: "02/01/2024",
-          raiRequestedDate: "03/01/2024",
-          raiReceivedDate: "04/01/2024",
+          submissionDate: "12/31/2023",
+          makoChangedDate: "01/31/2024",
+          raiRequestedDate: "02/29/2024",
+          raiReceivedDate: "03/31/2024",
         },
       ],
       [
@@ -385,10 +385,10 @@ describe("WaiversList", () => {
         {
           hasActions,
           status: `${useCmsStatus ? withdrawEnabledDoc.cmsStatus : withdrawEnabledDoc.stateStatus}· Withdraw Formal RAI Response - Enabled`,
-          submissionDate: "01/01/2024",
-          makoChangedDate: "02/01/2024",
-          raiRequestedDate: "03/01/2024",
-          raiReceivedDate: "04/01/2024",
+          submissionDate: "12/31/2023",
+          makoChangedDate: "01/31/2024",
+          raiRequestedDate: "02/29/2024",
+          raiReceivedDate: "03/31/2024",
         },
       ],
       [
@@ -397,10 +397,10 @@ describe("WaiversList", () => {
         {
           hasActions,
           status: useCmsStatus ? withdrawDisabledDoc.cmsStatus : withdrawDisabledDoc.stateStatus,
-          submissionDate: "01/01/2024",
-          makoChangedDate: "02/01/2024",
-          raiRequestedDate: "03/01/2024",
-          raiReceivedDate: "04/01/2024",
+          submissionDate: "12/31/2023",
+          makoChangedDate: "01/31/2024",
+          raiRequestedDate: "02/29/2024",
+          raiReceivedDate: "03/31/2024",
         },
       ],
       [
@@ -409,9 +409,9 @@ describe("WaiversList", () => {
         {
           hasActions,
           status: useCmsStatus ? approvedDoc.cmsStatus : approvedDoc.stateStatus,
-          submissionDate: "01/01/2024",
-          makoChangedDate: "02/01/2024",
-          finalDispositionDate: "05/01/2024",
+          submissionDate: "12/31/2023",
+          makoChangedDate: "01/31/2024",
+          finalDispositionDate: "04/30/2024",
         },
       ],
       [

--- a/react-app/src/utils/test-helpers/dashboard.tsx
+++ b/react-app/src/utils/test-helpers/dashboard.tsx
@@ -256,8 +256,8 @@ export const PENDING_SUBMITTED_ITEM = {
 
 export const PENDING_SUBMITTED_ITEM_EXPORT = {
   "Formal RAI Response": "-- --",
-  "Initial Submission": "01/01/2024",
-  "Latest Package Activity": "02/01/2024",
+  "Initial Submission": "12/31/2023",
+  "Latest Package Activity": "01/31/2024",
   State: PENDING_SUBMITTED_ITEM._source.state,
   "Submitted By": PENDING_SUBMITTED_ITEM._source.submitterName,
   "CPOC Name": PENDING_SUBMITTED_ITEM._source.leadAnalystName,
@@ -281,13 +281,13 @@ export const PENDING_RAI_REQUEST_ITEM = {
 
 export const PENDING_RAI_REQUEST_ITEM_EXPORT = {
   "Formal RAI Response": "-- --",
-  "Initial Submission": "01/01/2024",
-  "Latest Package Activity": "02/01/2024",
+  "Initial Submission": "12/31/2023",
+  "Latest Package Activity": "01/31/2024",
   State: PENDING_RAI_REQUEST_ITEM._source.state,
   "Submitted By": PENDING_RAI_REQUEST_ITEM._source.submitterName,
   "CPOC Name": PENDING_RAI_REQUEST_ITEM._source.leadAnalystName,
   "Final Disposition": "-- --",
-  "Formal RAI Requested": "03/01/2024",
+  "Formal RAI Requested": "02/29/2024",
 };
 
 export const PENDING_RAI_RECEIVED_ITEM = {
@@ -306,14 +306,14 @@ export const PENDING_RAI_RECEIVED_ITEM = {
 };
 
 export const PENDING_RAI_RECEIVED_ITEM_EXPORT = {
-  "Formal RAI Response": "04/01/2024",
-  "Initial Submission": "01/01/2024",
-  "Latest Package Activity": "02/01/2024",
+  "Formal RAI Response": "03/31/2024",
+  "Initial Submission": "12/31/2023",
+  "Latest Package Activity": "01/31/2024",
   State: PENDING_RAI_RECEIVED_ITEM._source.state,
   "Submitted By": PENDING_RAI_RECEIVED_ITEM._source.submitterName,
   "CPOC Name": PENDING_RAI_RECEIVED_ITEM._source.leadAnalystName,
   "Final Disposition": "-- --",
-  "Formal RAI Requested": "03/01/2024",
+  "Formal RAI Requested": "02/29/2024",
 };
 
 export const RAI_WITHDRAW_ENABLED_ITEM = {
@@ -333,14 +333,14 @@ export const RAI_WITHDRAW_ENABLED_ITEM = {
 };
 
 export const RAI_WITHDRAW_ENABLED_ITEM_EXPORT = {
-  "Formal RAI Response": "04/01/2024",
-  "Initial Submission": "01/01/2024",
-  "Latest Package Activity": "02/01/2024",
+  "Formal RAI Response": "03/31/2024",
+  "Initial Submission": "12/31/2023",
+  "Latest Package Activity": "01/31/2024",
   State: RAI_WITHDRAW_ENABLED_ITEM._source.state,
   "Submitted By": RAI_WITHDRAW_ENABLED_ITEM._source.submitterName,
   "CPOC Name": RAI_WITHDRAW_ENABLED_ITEM._source.leadAnalystName,
   "Final Disposition": "-- --",
-  "Formal RAI Requested": "03/01/2024",
+  "Formal RAI Requested": "02/29/2024",
 };
 
 export const RAI_WITHDRAW_DISABLED_ITEM = {
@@ -360,14 +360,14 @@ export const RAI_WITHDRAW_DISABLED_ITEM = {
 };
 
 export const RAI_WITHDRAW_DISABLED_ITEM_EXPORT = {
-  "Formal RAI Response": "04/01/2024",
-  "Initial Submission": "01/01/2024",
-  "Latest Package Activity": "02/01/2024",
+  "Formal RAI Response": "03/31/2024",
+  "Initial Submission": "12/31/2023",
+  "Latest Package Activity": "01/31/2024",
   State: RAI_WITHDRAW_DISABLED_ITEM._source.state,
   "Submitted By": RAI_WITHDRAW_DISABLED_ITEM._source.submitterName,
   "CPOC Name": RAI_WITHDRAW_DISABLED_ITEM._source.leadAnalystName,
   "Final Disposition": "-- --",
-  "Formal RAI Requested": "03/01/2024",
+  "Formal RAI Requested": "02/29/2024",
 };
 
 export const APPROVED_ITEM = {
@@ -386,12 +386,12 @@ export const APPROVED_ITEM = {
 
 export const APPROVED_ITEM_EXPORT = {
   "Formal RAI Response": "-- --",
-  "Initial Submission": "01/01/2024",
-  "Latest Package Activity": "02/01/2024",
+  "Initial Submission": "12/31/2023",
+  "Latest Package Activity": "01/31/2024",
   State: APPROVED_ITEM._source.state,
   "Submitted By": APPROVED_ITEM._source.submitterName,
   "CPOC Name": APPROVED_ITEM._source.leadAnalystName,
-  "Final Disposition": "05/01/2024",
+  "Final Disposition": "04/30/2024",
   "Formal RAI Requested": "-- --",
 };
 


### PR DESCRIPTION
This will resolve an issue where the timestamps were displaying inconsistantly between the dashboard and the package details page for record if the submission of a record was after 8 eastern

Ticket to Close:
https://jiraent.cms.gov/browse/OY2-34506
