### PR TITLE
Oy2 33876

### DIFF
--- a/react-app/src/components/Inputs/upload.test.tsx
+++ b/react-app/src/components/Inputs/upload.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { renderWithQueryClient } from "@/utils/test-helpers";
@@ -174,11 +175,12 @@ describe("Upload", () => {
 
   it("removes file after confirmation", async () => {
     const mockSetFiles = vi.fn();
+    const user = userEvent.setup();
 
     renderWithQueryClient(<Upload {...defaultProps} files={files} setFiles={mockSetFiles} />);
 
     const removeButton = screen.getByTestId(`upload-component-remove-file-${FILE_REMOVE}.txt`);
-    fireEvent.click(removeButton);
+    user.click(removeButton);
 
     // Confirm dialog appears
     expect(await screen.findByText("Delete Attachment?")).toBeInTheDocument();

--- a/react-app/src/components/Inputs/upload.test.tsx
+++ b/react-app/src/components/Inputs/upload.test.tsx
@@ -189,7 +189,7 @@ describe("Upload", () => {
 
     expect(userPromptSpy).toBeCalledWith({
       header: "Delete Attachment?",
-      body: "`Are you sure you want to delete ${FILE_REMOVE}.txt?`",
+      body: `Are you sure you want to delete ${FILE_REMOVE}.txt?`,
       acceptButtonText: "Yes, delete",
       onAccept: onAcceptMock,
     });

--- a/react-app/src/components/Inputs/upload.test.tsx
+++ b/react-app/src/components/Inputs/upload.test.tsx
@@ -185,7 +185,7 @@ describe("Upload", () => {
     renderWithQueryClient(<Upload {...defaultProps} files={files} setFiles={mockSetFiles} />);
 
     const removeButton = screen.getByTestId(`upload-component-remove-file-${FILE_REMOVE}.txt`);
-    user.click(removeButton);
+    await user.click(removeButton);
 
     expect(userPromptSpy).toBeCalledWith({
       header: "Delete Attachment?",

--- a/react-app/src/components/Inputs/upload.tsx
+++ b/react-app/src/components/Inputs/upload.tsx
@@ -57,12 +57,6 @@ export const Upload = ({ maxFiles, files, setFiles, dataTestId }: UploadProps) =
     },
     {} as Record<string, string[]>,
   );
-  const promptOnDelete = {
-    header: "Delete Attachment?",
-    body: "Are you sure you want to delete this attachment?",
-    acceptButtonText: "Yes, delete",
-    cancelButtonText: "Cancel",
-  };
 
   const existingFileNames = files.map((file) => file.filename);
 
@@ -158,7 +152,9 @@ export const Upload = ({ maxFiles, files, setFiles, dataTestId }: UploadProps) =
               <I.Button
                 onClick={() =>
                   userPrompt({
-                    ...promptOnDelete,
+                    header: "Delete Attachment?",
+                    body: `Are you sure you want to delete ${file.filename}?`,
+                    acceptButtonText: "Yes, delete",
                     onAccept: () => {
                       setRejectedFiles([]);
                       setFiles(files.filter((a) => a.filename !== file.filename));

--- a/react-app/src/components/Inputs/upload.tsx
+++ b/react-app/src/components/Inputs/upload.tsx
@@ -6,6 +6,7 @@ import { FILE_TYPES } from "shared-types/uploads";
 import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
 
+import { userPrompt } from "@/components";
 import * as I from "@/components/Inputs";
 import { LoadingSpinner } from "@/components/LoadingSpinner"; // Import your LoadingSpinner component
 import { cn } from "@/utils";
@@ -56,6 +57,12 @@ export const Upload = ({ maxFiles, files, setFiles, dataTestId }: UploadProps) =
     },
     {} as Record<string, string[]>,
   );
+  const promptOnDelete = {
+    header: "Delete Attachment?",
+    body: "Are you sure you want to delete this attachment?",
+    acceptButtonText: "Yes, delete",
+    cancelButtonText: "Cancel",
+  };
 
   const existingFileNames = files.map((file) => file.filename);
 
@@ -149,11 +156,15 @@ export const Upload = ({ maxFiles, files, setFiles, dataTestId }: UploadProps) =
             >
               <span className="text-sky-700">{file.filename}</span>
               <I.Button
-                onClick={(e) => {
-                  e.preventDefault();
-                  setRejectedFiles([]);
-                  setFiles(files.filter((a) => a.filename !== file.filename));
-                }}
+                onClick={() =>
+                  userPrompt({
+                    ...promptOnDelete,
+                    onAccept: () => {
+                      setRejectedFiles([]);
+                      setFiles(files.filter((a) => a.filename !== file.filename));
+                    },
+                  })
+                }
                 variant="ghost"
                 className="p-0 h-0"
                 data-testid={`${dataTestId}-remove-file-${file.filename}`}


### PR DESCRIPTION

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[OY2-33876](https://jiraent.cms.gov/browse/OY2-33876)

## 💬 Description / Notes

Per feedback during the end of sprint review, CMS requested that a "delete confirmation" modal be added when a user selects the delete icon to remove an attachment. 

## 🛠 Changes

Use `UserPrompt` component for onclick event of file removal from the upload component. Title, body, buttons are per story ACs. On accept do original action which is to remove the file from the upload list.

## 📸 Screenshots / Demo

<img width="742" alt="image" src="https://github.com/user-attachments/assets/9fa6e77c-a916-4c12-b63c-f9789edb109b" />
