### PR TITLE
chore(ui): move aria-live="polite" to button element

### DIFF
--- a/react-app/src/components/Opensearch/main/Settings/Visibility.tsx
+++ b/react-app/src/components/Opensearch/main/Settings/Visibility.tsx
@@ -42,7 +42,7 @@ export const VisiblityItem = <T extends UI.OsTableColumn>(props: T & { onClick: 
   });
 
   return (
-    <li aria-live="assertive" aria-atomic="true">
+    <li>
       <DropdownMenu.Item
         asChild
         onSelect={(e) => {
@@ -57,6 +57,7 @@ export const VisiblityItem = <T extends UI.OsTableColumn>(props: T & { onClick: 
           })}
           type="button"
           aria-label={`${props.label}, toggle visibility, currently ${props.hidden ? "hidden" : "visible"}`}
+          aria-live="polite"
         >
           {props.hidden ? (
             <EyeOffIcon className={eyeStyles} aria-hidden focusable={false} />


### PR DESCRIPTION
- Chrome isn't announcing the changes correctly, so moving the announcement attribute closer to the element seems to do the trick