### PR TITLE
Second clock not display

### DIFF
--- a/react-app/src/features/package/package-status/index.tsx
+++ b/react-app/src/features/package/package-status/index.tsx
@@ -17,15 +17,14 @@ export const PackageStatusCard = ({ submission }: PackageStatusCardProps) => {
   // specifically in seatool that will invalidate the raiWithdrawEnabled flag such as the two statuses
   // below (Pending Approval, and Pending Concurrence). In the future we should build logic into the
   // seatool sink that allows us to simply clear these flags
-  const isInRAIWithdrawEnabledSubStatus = submission.raiWithdrawEnabled;
+  const isInRAIWithdrawEnabledSubStatus =
+    submission.raiWithdrawEnabled &&
+    submission.seatoolStatus !== SEATOOL_STATUS.PENDING_APPROVAL &&
+    submission.seatoolStatus !== SEATOOL_STATUS.PENDING_CONCURRENCE;
 
   // Similar to the above check their are certain things that occur in seatool that invalidate the secondClock
   // flag. Additionally second clock sub status only displays for CMS users
-  const isInActiveSecondClockStatus =
-    isCmsUser(user.user) &&
-    submission.secondClock &&
-    submission.seatoolStatus !== SEATOOL_STATUS.PENDING_APPROVAL &&
-    submission.seatoolStatus !== SEATOOL_STATUS.PENDING_CONCURRENCE;
+  const isInActiveSecondClockStatus = isCmsUser(user.user) && submission.secondClock;
 
   return (
     <DetailCardWrapper title="Status">

--- a/react-app/src/features/package/package-status/index.tsx
+++ b/react-app/src/features/package/package-status/index.tsx
@@ -24,7 +24,12 @@ export const PackageStatusCard = ({ submission }: PackageStatusCardProps) => {
 
   // Similar to the above check their are certain things that occur in seatool that invalidate the secondClock
   // flag. Additionally second clock sub status only displays for CMS users
-  const isInActiveSecondClockStatus = isCmsUser(user.user) && submission.secondClock;
+  const isInActiveSecondClockStatus =
+    isCmsUser(user.user) &&
+    submission.secondClock &&
+    [SEATOOL_STATUS.PENDING_APPROVAL, SEATOOL_STATUS.PENDING_CONCURRENCE].includes(
+      submission.seatoolStatus,
+    );
 
   return (
     <DetailCardWrapper title="Status">

--- a/react-app/src/features/package/package-status/index.tsx
+++ b/react-app/src/features/package/package-status/index.tsx
@@ -17,10 +17,7 @@ export const PackageStatusCard = ({ submission }: PackageStatusCardProps) => {
   // specifically in seatool that will invalidate the raiWithdrawEnabled flag such as the two statuses
   // below (Pending Approval, and Pending Concurrence). In the future we should build logic into the
   // seatool sink that allows us to simply clear these flags
-  const isInRAIWithdrawEnabledSubStatus =
-    submission.raiWithdrawEnabled &&
-    submission.seatoolStatus !== SEATOOL_STATUS.PENDING_APPROVAL &&
-    submission.seatoolStatus !== SEATOOL_STATUS.PENDING_CONCURRENCE;
+  const isInRAIWithdrawEnabledSubStatus = submission.raiWithdrawEnabled;
 
   // Similar to the above check their are certain things that occur in seatool that invalidate the secondClock
   // flag. Additionally second clock sub status only displays for CMS users

--- a/react-app/src/features/package/package-status/index.tsx
+++ b/react-app/src/features/package/package-status/index.tsx
@@ -24,12 +24,7 @@ export const PackageStatusCard = ({ submission }: PackageStatusCardProps) => {
 
   // Similar to the above check their are certain things that occur in seatool that invalidate the secondClock
   // flag. Additionally second clock sub status only displays for CMS users
-  const isInActiveSecondClockStatus =
-    isCmsUser(user.user) &&
-    submission.secondClock &&
-    [SEATOOL_STATUS.PENDING_APPROVAL, SEATOOL_STATUS.PENDING_CONCURRENCE].includes(
-      submission.seatoolStatus,
-    );
+  const isInActiveSecondClockStatus = isCmsUser(user.user) && submission.secondClock;
 
   return (
     <DetailCardWrapper title="Status">


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[[Ticket to close](link-to-ticket)](https://jiraent.cms.gov/browse/OY2-34661)

## 💬 Description / Notes

Secondclock status is not appearing for Pending Occurence or Pending approval.  Logic on the front end for some reason excluded it.  We already calculate the secondclock stuff on the backend for the package in the processor with:
`const isInSecondClock = (
  raiReceivedDate: any,
  raiWithdrawnDate: any,
  seatoolStatus: any,
  authority: any,
) => {
  if (
    authority !== "CHIP SPA" && // if it's not a chip
    [
      SEATOOL_STATUS.PENDING,
      SEATOOL_STATUS.PENDING_CONCURRENCE,
      SEATOOL_STATUS.PENDING_APPROVAL,
    ].includes(seatoolStatus) && // if it's in pending
    raiReceivedDate // if its latest rai has a received date
  ) {
    return true; // then we're in second clock
  }
  return false; // otherwise, we're not
};`

Just removed the bad logic on the front end since it was unnecessary to recalculate.

## 🛠 Changes

<!-- List your code changes made to implement the solution -->

## 📸 Screenshots / Demo

<!-- ### Before -->

<!-- ### After -->
