### PR TITLE
fix(user-roles): User Management page views

### DIFF
--- a/lib/lambda/user-management/getRoleRequests.test.ts
+++ b/lib/lambda/user-management/getRoleRequests.test.ts
@@ -111,8 +111,7 @@ describe("getRoleRequests", () => {
     // remove the cmsRoleApprover roles
     const filteredRoles = roleDocs.filter(
       (roleObj) =>
-        !["cmsroleapprover", "systemadmin"].includes(roleObj?.role) &&
-        roleObj?.email !== CMS_ROLE_APPROVER_EMAIL,
+        roleObj?.role === "statesystemadmin" && roleObj?.email !== CMS_ROLE_APPROVER_EMAIL,
     );
     expect(roles.length).toEqual(filteredRoles.length);
   });

--- a/lib/lambda/user-management/getRoleRequests.ts
+++ b/lib/lambda/user-management/getRoleRequests.ts
@@ -66,11 +66,8 @@ export const getRoleRequests = async (event: APIGatewayEvent) => {
       // get all of the role requests
       roleRequests = await getAllUserRoles();
 
-      // filter out other cmsroleapprovers and systemadmins
-      // cmsroleapprovers cannot approve those role requests
-      roleRequests = roleRequests.filter(
-        (roleObj) => !["cmsroleapprover", "systemadmin"].includes(roleObj?.role),
-      );
+      // cmsroleapprovers can only see state admin requests
+      roleRequests = roleRequests.filter((roleObj) => roleObj?.role === "statesystemadmin");
     } else if (stateSystemAdmin?.territory) {
       roleRequests = await getAllUserRolesByState(stateSystemAdmin?.territory);
 

--- a/lib/lambda/user-management/getRoleRequests.ts
+++ b/lib/lambda/user-management/getRoleRequests.ts
@@ -58,26 +58,24 @@ export const getRoleRequests = async (event: APIGatewayEvent) => {
     const stateSystemAdmin = getActiveRole(approverRoles, "statesystemadmin");
 
     let roleRequests: StateAccess[] = [];
+    console.log(stateSystemAdmin, "STATE SYSTEM ADMIN");
 
     if (systemAdmin || helpDesk) {
-      // get all of the role requests
       roleRequests = await getAllUserRoles();
     } else if (cmsRoleApprover) {
-      // get all of the role requests
       roleRequests = await getAllUserRoles();
 
-      // cmsroleapprovers can only see state admin requests
+      // cmsroleapprovers can only see statesystemadmin requests
       roleRequests = roleRequests.filter((roleObj) => roleObj?.role === "statesystemadmin");
     } else if (stateSystemAdmin?.territory) {
+      console.log("IN HERE");
       roleRequests = await getAllUserRolesByState(stateSystemAdmin?.territory);
 
-      // filter out other statesystemadmins
-      // statesystemadmins cannot approve those role requests
+      // statesystemadmins cannot update other statesystemadmin requests
       roleRequests = roleRequests.filter((roleObj) => roleObj?.role !== "statesystemadmin");
     }
 
-    // remove the user from the role requests
-    // the user cannot approve their own role requests
+    // filter out the current user from the role requests
     roleRequests = roleRequests.filter((adminRole) => adminRole?.email !== email);
 
     const roleRequestsWithName = await getUserRolesWithNames(roleRequests);

--- a/lib/lambda/user-management/getRoleRequests.ts
+++ b/lib/lambda/user-management/getRoleRequests.ts
@@ -58,7 +58,6 @@ export const getRoleRequests = async (event: APIGatewayEvent) => {
     const stateSystemAdmin = getActiveRole(approverRoles, "statesystemadmin");
 
     let roleRequests: StateAccess[] = [];
-    console.log(stateSystemAdmin?.territory, "STATE SYSTEM ADMIN TERRITORY");
 
     if (systemAdmin || helpDesk) {
       roleRequests = await getAllUserRoles();
@@ -71,7 +70,6 @@ export const getRoleRequests = async (event: APIGatewayEvent) => {
     }
 
     if (stateSystemAdmin) {
-      console.log("IN HERE");
       roleRequests = await getAllUserRolesByState(stateSystemAdmin?.territory);
 
       // statesystemadmins cannot update other statesystemadmin requests

--- a/lib/lambda/user-management/getRoleRequests.ts
+++ b/lib/lambda/user-management/getRoleRequests.ts
@@ -58,16 +58,19 @@ export const getRoleRequests = async (event: APIGatewayEvent) => {
     const stateSystemAdmin = getActiveRole(approverRoles, "statesystemadmin");
 
     let roleRequests: StateAccess[] = [];
-    console.log(stateSystemAdmin, "STATE SYSTEM ADMIN");
+    console.log(stateSystemAdmin?.territory, "STATE SYSTEM ADMIN TERRITORY");
 
     if (systemAdmin || helpDesk) {
       roleRequests = await getAllUserRoles();
-    } else if (cmsRoleApprover) {
-      roleRequests = await getAllUserRoles();
+    }
 
+    if (cmsRoleApprover) {
+      roleRequests = await getAllUserRoles();
       // cmsroleapprovers can only see statesystemadmin requests
       roleRequests = roleRequests.filter((roleObj) => roleObj?.role === "statesystemadmin");
-    } else if (stateSystemAdmin?.territory) {
+    }
+
+    if (stateSystemAdmin) {
       console.log("IN HERE");
       roleRequests = await getAllUserRolesByState(stateSystemAdmin?.territory);
 


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[OY2-34756](https://jiraent.cms.gov/browse/OY2-34756)

## 💬 Description / Notes

<!-- Briefly describe the background of the issue -->
<!-- If you feel the original ticket lacks important details, this would be the place to share them -->
- State system admins are only allowed to see and update state submitters within their territory in the User Management page.
- CMS Role Approvers are only allowed to see and update state system admin requests in the User Management page.

## 🛠 Changes

<!-- List your code changes made to implement the solution -->

## 📸 Screenshots / Demo

<!-- ### Before -->

<!-- ### After -->
