### PR TITLE
fix(user-roles): Show all states for state signup

### DIFF
--- a/react-app/src/features/profile/me/index.tsx
+++ b/react-app/src/features/profile/me/index.tsx
@@ -40,7 +40,7 @@ export const MyProfile = () => {
   const [showAddState, setShowAddState] = useState<boolean>(true);
   const [requestedStates, setRequestedStates] = useState<StateCode[]>([]);
   const [pendingRequests, setPendingRequests] = useState<boolean>(false);
-  const statesToRequest: Option[] = useAvailableStates(userProfile?.stateAccess);
+  const statesToRequest: Option[] = useAvailableStates(userDetails?.role, userProfile?.stateAccess);
 
   const filteredStateAccess = useMemo(
     () => filterStateAccess(userDetails, userProfile),

--- a/react-app/src/features/sign-up/stateSignup.test.tsx
+++ b/react-app/src/features/sign-up/stateSignup.test.tsx
@@ -88,7 +88,7 @@ describe("StateSignup", () => {
     expect(screen.getByText("State System Admin")).toBeInTheDocument();
   });
 
-  it("should handle filling out the form", async () => {
+  it("should handle filling out the form as a statesubmitter", async () => {
     setMockUsername(osStateSubmitter);
     const { user } = await setup();
 

--- a/react-app/src/features/sign-up/stateSignup.test.tsx
+++ b/react-app/src/features/sign-up/stateSignup.test.tsx
@@ -107,6 +107,27 @@ describe("StateSignup", () => {
     await waitFor(() => expect(screen.getByText("Dashboard")).toBeInTheDocument());
   });
 
+  it("should handle cancelling the form", async () => {
+    setMockUsername(osStateSubmitter);
+    const { user } = await setup();
+
+    const submitButton = screen.getByRole("button", { name: "Submit" });
+    expect(submitButton).toBeDisabled();
+
+    await user.click(screen.getByRole("combobox", { name: /Select state/ }));
+    expect(submitButton).toBeDisabled();
+
+    await waitFor(() => expect(screen.getByText("Maine")).toBeInTheDocument());
+    await user.click(screen.getByText("Maine"));
+    expect(submitButton).toBeEnabled();
+
+    const cancelButton = screen.getByRole("button", { name: "Cancel" });
+
+    await user.click(cancelButton);
+
+    await waitFor(() => expect(screen.getByText("Registration: State Access")).toBeInTheDocument());
+  });
+
   it("should show an error if there was an error submitting the request", async () => {
     mockedServer.use(errorApiSubmitRoleRequestsHandler);
     setMockUsername(osStateSubmitter);

--- a/react-app/src/features/sign-up/stateSignup.test.tsx
+++ b/react-app/src/features/sign-up/stateSignup.test.tsx
@@ -12,6 +12,7 @@ import { describe, expect, it } from "vitest";
 
 import { renderWithQueryClientAndMemoryRouter } from "@/utils/test-helpers";
 
+import { SignUp } from "./sign-up";
 import { StateSignup } from "./stateSignup";
 
 describe("StateSignup", () => {
@@ -34,7 +35,7 @@ describe("StateSignup", () => {
         },
         {
           path: "/signup",
-          element: <div>Signup</div>,
+          element: <SignUp />,
         },
         {
           path: "/signup/state",
@@ -111,21 +112,17 @@ describe("StateSignup", () => {
     setMockUsername(osStateSubmitter);
     const { user } = await setup();
 
-    const submitButton = screen.getByRole("button", { name: "Submit" });
-    expect(submitButton).toBeDisabled();
-
-    await user.click(screen.getByRole("combobox", { name: /Select state/ }));
-    expect(submitButton).toBeDisabled();
-
-    await waitFor(() => expect(screen.getByText("Maine")).toBeInTheDocument());
-    await user.click(screen.getByText("Maine"));
-    expect(submitButton).toBeEnabled();
-
     const cancelButton = screen.getByRole("button", { name: "Cancel" });
 
     await user.click(cancelButton);
+    await waitFor(() =>
+      expect(screen.getByText("Changes you made will not be saved.")).toBeInTheDocument(),
+    );
 
-    await waitFor(() => expect(screen.getByText("Registration: State Access")).toBeInTheDocument());
+    const confirmButton = screen.getByRole("button", { name: "Confirm" });
+    await user.click(confirmButton);
+
+    expect(screen.getByText(/Registration: User Role/)).toBeInTheDocument();
   });
 
   it("should show an error if there was an error submitting the request", async () => {

--- a/react-app/src/features/sign-up/stateSignup.tsx
+++ b/react-app/src/features/sign-up/stateSignup.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Navigate, useNavigate } from "react-router";
-import { StateCode } from "shared-types";
+import { FULL_CENSUS_STATES, StateCode } from "shared-types";
 import { UserRole } from "shared-types/events/legacy-user";
 
 import { useGetUserDetails, useGetUserProfile, useSubmitRoleRequests } from "@/api";
@@ -18,8 +18,8 @@ import {
   SubNavHeader,
 } from "@/components";
 import { FilterableSelect, Option } from "@/components/Opensearch/main/Filtering/Drawer/Filterable";
-import { useAvailableStates } from "@/hooks/useAvailableStates";
 
+// import { useAvailableStates } from "@/hooks/useAvailableStates";
 import { userRoleMap } from "../profile";
 
 export const StateSignup = () => {
@@ -27,10 +27,12 @@ export const StateSignup = () => {
   const [showModal, setShowModal] = useState<boolean>(false);
   const navigate = useNavigate();
   const { mutateAsync: submitRequest, isLoading } = useSubmitRoleRequests();
-
   const { data: userDetails } = useGetUserDetails();
-  const { data: userProfile } = useGetUserProfile();
-  const statesToRequest: Option[] = useAvailableStates(userProfile?.stateAccess);
+
+  const statesToRequest: Option[] = FULL_CENSUS_STATES.map(({ label, value }) => ({
+    label,
+    value,
+  }));
 
   if (!userDetails) return <LoadingSpinner />;
 

--- a/react-app/src/features/sign-up/stateSignup.tsx
+++ b/react-app/src/features/sign-up/stateSignup.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
 import { Navigate, useNavigate } from "react-router";
-import { FULL_CENSUS_STATES, StateCode } from "shared-types";
+import { StateCode } from "shared-types";
 import { UserRole } from "shared-types/events/legacy-user";
 
-import { useGetUserDetails, useSubmitRoleRequests } from "@/api";
+import { useGetUserDetails, useGetUserProfile, useSubmitRoleRequests } from "@/api";
 import {
   banner,
   Button,
@@ -18,6 +18,7 @@ import {
   SubNavHeader,
 } from "@/components";
 import { FilterableSelect, Option } from "@/components/Opensearch/main/Filtering/Drawer/Filterable";
+import { useAvailableStates } from "@/hooks/useAvailableStates";
 
 import { userRoleMap } from "../profile";
 
@@ -27,11 +28,8 @@ export const StateSignup = () => {
   const navigate = useNavigate();
   const { mutateAsync: submitRequest, isLoading } = useSubmitRoleRequests();
   const { data: userDetails } = useGetUserDetails();
-
-  const statesToRequest: Option[] = FULL_CENSUS_STATES.map(({ label, value }) => ({
-    label,
-    value,
-  }));
+  const { data: userProfile } = useGetUserProfile();
+  const statesToRequest: Option[] = useAvailableStates(userDetails?.role, userProfile?.stateAccess);
 
   if (!userDetails) return <LoadingSpinner />;
 

--- a/react-app/src/features/sign-up/stateSignup.tsx
+++ b/react-app/src/features/sign-up/stateSignup.tsx
@@ -29,21 +29,7 @@ export const StateSignup = () => {
   const { mutateAsync: submitRequest, isLoading } = useSubmitRoleRequests();
   const { data: userDetails } = useGetUserDetails();
   const { data: userProfile } = useGetUserProfile();
-  const statesToRequest: Option[] = useAvailableStates(userDetails?.role, userProfile?.stateAccess);
-
-  if (!userDetails) return <LoadingSpinner />;
-
-  if (!userDetails?.role) return <Navigate to="/" />;
-
-  const currentRole = userDetails.role;
-
-  // Only state users can access this page
-  if (
-    currentRole !== "statesubmitter" &&
-    currentRole !== "statesystemadmin" &&
-    currentRole !== "norole"
-  )
-    return <Navigate to="/profile" />;
+  const currentRole = userDetails?.role;
 
   // Determine which role the user is allowed to request based on their current role
   const roleToRequestMap: Partial<Record<UserRole, UserRole>> = {
@@ -52,6 +38,19 @@ export const StateSignup = () => {
     statesystemadmin: "statesubmitter",
   };
   const roleToRequest = roleToRequestMap[currentRole];
+  const statesToRequest: Option[] = useAvailableStates(roleToRequest, userProfile?.stateAccess);
+
+  if (!userDetails) return <LoadingSpinner />;
+
+  if (!userDetails?.role) return <Navigate to="/" />;
+
+  // Only state users can access this page
+  if (
+    currentRole !== "statesubmitter" &&
+    currentRole !== "statesystemadmin" &&
+    currentRole !== "norole"
+  )
+    return <Navigate to="/profile" />;
 
   // Statesubmitters can request to be a statesystemadmin for 1 state
   const isRequestRoleAdmin = currentRole === "statesubmitter";

--- a/react-app/src/features/sign-up/stateSignup.tsx
+++ b/react-app/src/features/sign-up/stateSignup.tsx
@@ -3,7 +3,7 @@ import { Navigate, useNavigate } from "react-router";
 import { FULL_CENSUS_STATES, StateCode } from "shared-types";
 import { UserRole } from "shared-types/events/legacy-user";
 
-import { useGetUserDetails, useGetUserProfile, useSubmitRoleRequests } from "@/api";
+import { useGetUserDetails, useSubmitRoleRequests } from "@/api";
 import {
   banner,
   Button,
@@ -19,7 +19,6 @@ import {
 } from "@/components";
 import { FilterableSelect, Option } from "@/components/Opensearch/main/Filtering/Drawer/Filterable";
 
-// import { useAvailableStates } from "@/hooks/useAvailableStates";
 import { userRoleMap } from "../profile";
 
 export const StateSignup = () => {

--- a/react-app/src/hooks/useAvailableStates.ts
+++ b/react-app/src/hooks/useAvailableStates.ts
@@ -4,17 +4,16 @@ import { UserRole } from "shared-types/events/legacy-user";
 
 import { StateAccess } from "@/api";
 
-export function useAvailableStates(
-  currentRole: UserRole,
-  stateAccessList: StateAccess[] | undefined,
-) {
+// Get available states for the role to be requested
+// eslint-disable-next-line prettier/prettier
+export function useAvailableStates(roleToRequest: UserRole, stateAccessList: StateAccess[] | undefined) {
   return useMemo(() => {
     if (!stateAccessList) {
       return FULL_CENSUS_STATES.map(({ label, value }) => ({ label, value }));
     }
 
     const validAccess = stateAccessList.filter(
-      ({ role, territory }) => role === currentRole && territory !== "ZZ",
+      ({ role, territory }) => role !== roleToRequest && territory !== "ZZ",
     );
 
     const accessedStates = new Set(validAccess.map(({ territory }) => territory));
@@ -24,5 +23,5 @@ export function useAvailableStates(
     ).map(({ label, value }) => ({ label, value }));
 
     return availableStates;
-  }, [currentRole, stateAccessList]);
+  }, [roleToRequest, stateAccessList]);
 }

--- a/react-app/src/hooks/useAvailableStates.ts
+++ b/react-app/src/hooks/useAvailableStates.ts
@@ -11,11 +11,10 @@ export function useAvailableStates(roleToRequest: UserRole, stateAccessList: Sta
     if (!stateAccessList) {
       return FULL_CENSUS_STATES.map(({ label, value }) => ({ label, value }));
     }
-    console.log(roleToRequest, "ROLEEE");
+
     const validAccess = stateAccessList.filter(
       ({ role, territory }) => role === roleToRequest && territory !== "ZZ",
     );
-    console.log(validAccess, "VALID ACCESS");
     const accessedStates = new Set(validAccess.map(({ territory }) => territory));
 
     const availableStates = FULL_CENSUS_STATES.filter(

--- a/react-app/src/hooks/useAvailableStates.ts
+++ b/react-app/src/hooks/useAvailableStates.ts
@@ -11,11 +11,11 @@ export function useAvailableStates(roleToRequest: UserRole, stateAccessList: Sta
     if (!stateAccessList) {
       return FULL_CENSUS_STATES.map(({ label, value }) => ({ label, value }));
     }
-
+    console.log(roleToRequest, "ROLEEE");
     const validAccess = stateAccessList.filter(
-      ({ role, territory }) => role !== roleToRequest && territory !== "ZZ",
+      ({ role, territory }) => role === roleToRequest && territory !== "ZZ",
     );
-
+    console.log(validAccess, "VALID ACCESS");
     const accessedStates = new Set(validAccess.map(({ territory }) => territory));
 
     const availableStates = FULL_CENSUS_STATES.filter(

--- a/react-app/src/hooks/useAvailableStates.ts
+++ b/react-app/src/hooks/useAvailableStates.ts
@@ -1,15 +1,21 @@
 import { useMemo } from "react";
 import { FULL_CENSUS_STATES } from "shared-types";
+import { UserRole } from "shared-types/events/legacy-user";
 
 import { StateAccess } from "@/api";
 
-export function useAvailableStates(stateAccessList: StateAccess[] | undefined) {
+export function useAvailableStates(
+  currentRole: UserRole,
+  stateAccessList: StateAccess[] | undefined,
+) {
   return useMemo(() => {
     if (!stateAccessList) {
       return FULL_CENSUS_STATES.map(({ label, value }) => ({ label, value }));
     }
 
-    const validAccess = stateAccessList.filter(({ territory }) => territory !== "ZZ");
+    const validAccess = stateAccessList.filter(
+      ({ role, territory }) => role === currentRole && territory !== "ZZ",
+    );
 
     const accessedStates = new Set(validAccess.map(({ territory }) => territory));
 
@@ -18,5 +24,5 @@ export function useAvailableStates(stateAccessList: StateAccess[] | undefined) {
     ).map(({ label, value }) => ({ label, value }));
 
     return availableStates;
-  }, [stateAccessList]);
+  }, [currentRole, stateAccessList]);
 }


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->
[OY2-34772](https://jiraent.cms.gov/browse/OY2-34772)

## 💬 Description / Notes

<!-- Briefly describe the background of the issue -->
<!-- If you feel the original ticket lacks important details, this would be the place to share them -->
In the states dropdown, we are filtering any revoked/pending state regardless of the role. If a state submitter has access to a state and requested a role change of a state system admin, they would not see the state(s) they have access to.

## 🛠 Changes

<!-- List your code changes made to implement the solution -->
If a state submitter requests to be a state system admin, they will now see all states.

## 📸 Screenshots / Demo

<!-- ### Before -->

<!-- ### After -->
