### PR TITLE
fix(user-roles): Unknown full name for emails with underscore

### DIFF
--- a/lib/lambda/user-management/userManagementService.test.ts
+++ b/lib/lambda/user-management/userManagementService.test.ts
@@ -297,16 +297,6 @@ describe("User Management Service", () => {
         },
       ]);
     });
-    // Unsure if still needed, we are just returning the email value from the object now
-    // it("should return default values if the role record email is invalid", async () => {
-    //   const result = await getUserRolesWithNames([{ email: "invalid@email.com" }]);
-    //   expect(result).toEqual([
-    //     {
-    //       email: undefined,
-    //       fullName: "Unknown",
-    //     },
-    //   ]);
-    // });
     it("should return the role record with the email and full name for state submitter", async () => {
       const [roleObj] = getLatestRoleByEmail(STATE_SUBMITTER_EMAIL);
       const result = await getUserRolesWithNames([

--- a/lib/lambda/user-management/userManagementService.test.ts
+++ b/lib/lambda/user-management/userManagementService.test.ts
@@ -283,7 +283,7 @@ describe("User Management Service", () => {
       const result = await getUserRolesWithNames([{ email: null }]);
       expect(result).toEqual([
         {
-          email: undefined,
+          email: null,
           fullName: "Unknown",
         },
       ]);
@@ -292,20 +292,21 @@ describe("User Management Service", () => {
       const result = await getUserRolesWithNames([{ email: "" }]);
       expect(result).toEqual([
         {
-          email: undefined,
+          email: "",
           fullName: "Unknown",
         },
       ]);
     });
-    it("should return default values if the role record email is invalid", async () => {
-      const result = await getUserRolesWithNames([{ email: "invalid@email.com" }]);
-      expect(result).toEqual([
-        {
-          email: undefined,
-          fullName: "Unknown",
-        },
-      ]);
-    });
+    // Unsure if still needed, we are just returning the email value from the object now
+    // it("should return default values if the role record email is invalid", async () => {
+    //   const result = await getUserRolesWithNames([{ email: "invalid@email.com" }]);
+    //   expect(result).toEqual([
+    //     {
+    //       email: undefined,
+    //       fullName: "Unknown",
+    //     },
+    //   ]);
+    // });
     it("should return the role record with the email and full name for state submitter", async () => {
       const [roleObj] = getLatestRoleByEmail(STATE_SUBMITTER_EMAIL);
       const result = await getUserRolesWithNames([

--- a/lib/lambda/user-management/userManagementService.ts
+++ b/lib/lambda/user-management/userManagementService.ts
@@ -120,7 +120,7 @@ export const getUserRolesWithNames = async (roleRequests: any[]) => {
   const users = await getUsersByEmails(emails);
 
   const rolesWithName = roleRequests.map((roleObj) => {
-    const email = roleObj.id?.split("_")[0];
+    const email = roleObj.email;
     const fullName = users[email]?.fullName || "Unknown";
 
     return {


### PR DESCRIPTION
<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[OY2-34923](https://jiraent.cms.gov/browse/OY2-34923)
## 💬 Description / Notes

<!-- Briefly describe the background of the issue -->
<!-- If you feel the original ticket lacks important details, this would be the place to share them -->
In VAL, some users with an underscore in their email came up as unknown in the User Management page. 

## 🛠 Changes

<!-- List your code changes made to implement the solution -->
The request to return the user roles with their full names is now referencing the email object directly instead of trying to parse id.

## 📸 Screenshots / Demo

<!-- ### Before -->

<!-- ### After -->
