### PR TITLE
chore(mocks): updating the exports of mocks to removed vi.fn() mocks from the main export

### DIFF
--- a/lib/lambda/checkConsumerLag.test.ts
+++ b/lib/lambda/checkConsumerLag.test.ts
@@ -1,6 +1,5 @@
 import { Context } from "aws-lambda";
 import {
-  mockedAdmin,
   TEST_FUNCTION_NAME,
   TEST_MISSING_CONSUMER_FUNCTION_NAME,
   TEST_MISSING_CONSUMER_TOPIC_NAME,
@@ -10,6 +9,7 @@ import {
   TEST_NONEXISTENT_TOPIC_NAME,
   TEST_TOPIC_NAME,
 } from "mocks";
+import { mockedAdmin } from "mocks/helpers/kafka.utils";
 import { describe, expect, it, vi } from "vitest";
 
 import { handler } from "./checkConsumerLag";

--- a/lib/lambda/sinkChangelog.test.ts
+++ b/lib/lambda/sinkChangelog.test.ts
@@ -2,9 +2,6 @@ import { Context } from "aws-lambda";
 import * as os from "libs/opensearch-lib";
 import * as sink from "libs/sink-lib";
 import {
-  convertObjToBase64,
-  createKafkaEvent,
-  createKafkaRecord,
   OPENSEARCH_DOMAIN,
   OPENSEARCH_INDEX_NAMESPACE,
   WITHDRAWN_CHANGELOG_ITEM_ID as TEST_ITEM_ID,
@@ -28,6 +25,7 @@ import {
   withdrawPackage,
   withdrawRai,
 } from "mocks/data/submit/changelog";
+import { convertObjToBase64, createKafkaEvent, createKafkaRecord } from "mocks/helpers/kafka.utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { handler } from "./sinkChangelog";

--- a/lib/lambda/sinkCpocs.test.ts
+++ b/lib/lambda/sinkCpocs.test.ts
@@ -2,15 +2,13 @@ import { Client } from "@opensearch-project/opensearch";
 import { Context } from "aws-lambda";
 import * as os from "libs/opensearch-lib";
 import {
-  convertObjToBase64,
-  createKafkaEvent,
-  createKafkaRecord,
   errorBulkUpdateDataHandler,
   OPENSEARCH_DOMAIN,
   OPENSEARCH_INDEX_NAMESPACE,
   rateLimitBulkUpdateDataHandler,
 } from "mocks";
 import cpocs, { MUHAMMAD_BASHAR_ID } from "mocks/data/cpocs";
+import { convertObjToBase64, createKafkaEvent, createKafkaRecord } from "mocks/helpers/kafka.utils";
 import { mockedServiceServer as mockedServer } from "mocks/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/lib/lambda/sinkInsights.test.ts
+++ b/lib/lambda/sinkInsights.test.ts
@@ -1,12 +1,7 @@
 import { Context } from "aws-lambda";
 import * as os from "libs/opensearch-lib";
-import {
-  convertObjToBase64,
-  createKafkaEvent,
-  createKafkaRecord,
-  OPENSEARCH_DOMAIN,
-  OPENSEARCH_INDEX_NAMESPACE,
-} from "mocks";
+import { OPENSEARCH_DOMAIN, OPENSEARCH_INDEX_NAMESPACE } from "mocks";
+import { convertObjToBase64, createKafkaEvent, createKafkaRecord } from "mocks/helpers/kafka.utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import * as sink from "../libs/sink-lib";

--- a/lib/lambda/sinkLegacyInsights.test.ts
+++ b/lib/lambda/sinkLegacyInsights.test.ts
@@ -1,12 +1,7 @@
 import { Context } from "aws-lambda";
 import * as os from "libs/opensearch-lib";
-import {
-  convertObjToBase64,
-  createKafkaEvent,
-  createKafkaRecord,
-  OPENSEARCH_DOMAIN,
-  OPENSEARCH_INDEX_NAMESPACE,
-} from "mocks";
+import { OPENSEARCH_DOMAIN, OPENSEARCH_INDEX_NAMESPACE } from "mocks";
+import { convertObjToBase64, createKafkaEvent, createKafkaRecord } from "mocks/helpers/kafka.utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import * as sink from "../libs/sink-lib";

--- a/lib/lambda/sinkMainProcessors.test.ts
+++ b/lib/lambda/sinkMainProcessors.test.ts
@@ -3,8 +3,6 @@ import { startOfDay } from "date-fns";
 import * as os from "libs/opensearch-lib";
 import * as sink from "libs/sink-lib";
 import {
-  convertObjToBase64,
-  createKafkaRecord,
   errorOSMainMultiDocumentHandler,
   EXISTING_ITEM_TEMPORARY_EXTENSION_ID,
   NOT_FOUND_ITEM_ID,
@@ -33,6 +31,7 @@ import {
   withdrawPackage,
   withdrawRai,
 } from "mocks/data/submit/base";
+import { convertObjToBase64, createKafkaRecord } from "mocks/helpers/kafka.utils";
 import { mockedServiceServer as mockedServer } from "mocks/server";
 import {
   SEATOOL_STATUS,

--- a/lib/lambda/sinkSubtypes.test.ts
+++ b/lib/lambda/sinkSubtypes.test.ts
@@ -1,13 +1,8 @@
 import { Context } from "aws-lambda";
 import * as os from "libs/opensearch-lib";
-import {
-  convertObjToBase64,
-  createKafkaEvent,
-  createKafkaRecord,
-  OPENSEARCH_DOMAIN,
-  OPENSEARCH_INDEX_NAMESPACE,
-} from "mocks";
+import { OPENSEARCH_DOMAIN, OPENSEARCH_INDEX_NAMESPACE } from "mocks";
 import { subtypes } from "mocks/data/types";
+import { convertObjToBase64, createKafkaEvent, createKafkaRecord } from "mocks/helpers/kafka.utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import * as sink from "../libs/sink-lib";

--- a/lib/lambda/sinkTypes.test.ts
+++ b/lib/lambda/sinkTypes.test.ts
@@ -1,13 +1,8 @@
 import { Context } from "aws-lambda";
 import * as os from "libs/opensearch-lib";
-import {
-  convertObjToBase64,
-  createKafkaEvent,
-  createKafkaRecord,
-  OPENSEARCH_DOMAIN,
-  OPENSEARCH_INDEX_NAMESPACE,
-} from "mocks";
+import { OPENSEARCH_DOMAIN, OPENSEARCH_INDEX_NAMESPACE } from "mocks";
 import { types } from "mocks/data/types";
+import { convertObjToBase64, createKafkaEvent, createKafkaRecord } from "mocks/helpers/kafka.utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import * as sink from "../libs/sink-lib";

--- a/lib/lambda/user-management/createUserProfile.test.ts
+++ b/lib/lambda/user-management/createUserProfile.test.ts
@@ -3,11 +3,11 @@ import {
   coStateSubmitter,
   getRequestContext,
   makoStateSubmitter,
-  mockedProducer,
   setDefaultStateSubmitter,
   setMockUsername,
   testNewStateSubmitter,
 } from "mocks";
+import { mockedProducer } from "mocks/helpers/kafka.utils";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { handler } from "./createUserProfile";

--- a/lib/lambda/user-management/requestBaseCMSAccess.test.ts
+++ b/lib/lambda/user-management/requestBaseCMSAccess.test.ts
@@ -5,10 +5,10 @@ import {
   coStateSubmitter,
   errorRoleSearchHandler,
   getRequestContext,
-  mockedProducer,
   setDefaultStateSubmitter,
   setMockUsername,
 } from "mocks";
+import { mockedProducer } from "mocks/helpers/kafka.utils";
 import { mockedServiceServer as mockedServer } from "mocks/server";
 import { beforeEach, describe, expect, it } from "vitest";
 

--- a/lib/lambda/user-management/submitGroupDivision.test.ts
+++ b/lib/lambda/user-management/submitGroupDivision.test.ts
@@ -1,10 +1,10 @@
 import {
   defaultCMSUser,
   errorRoleSearchHandler,
-  mockedProducer,
   setDefaultStateSubmitter,
   setMockUsername,
 } from "mocks";
+import { mockedProducer } from "mocks/helpers/kafka.utils";
 import { mockedServiceServer as mockedServer } from "mocks/server";
 import { beforeEach, describe, expect, it } from "vitest";
 

--- a/lib/lambda/user-management/submitRoleRequests.test.ts
+++ b/lib/lambda/user-management/submitRoleRequests.test.ts
@@ -3,7 +3,6 @@ import {
   errorRoleSearchHandler,
   getRequestContext,
   helpDeskUser,
-  mockedProducer,
   multiStateSubmitter,
   noStateSubmitter,
   osStateSystemAdmin,
@@ -11,6 +10,7 @@ import {
   setMockUsername,
   systemAdmin,
 } from "mocks";
+import { mockedProducer } from "mocks/helpers/kafka.utils";
 import { mockedServiceServer as mockedServer } from "mocks/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/lib/lambda/user-management/updateUserRoles.test.ts
+++ b/lib/lambda/user-management/updateUserRoles.test.ts
@@ -1,10 +1,6 @@
 import { APIGatewayEvent } from "aws-lambda";
-import {
-  errorRoleSearchHandler,
-  getRequestContext,
-  mockedProducer,
-  setDefaultStateSubmitter,
-} from "mocks";
+import { errorRoleSearchHandler, getRequestContext, setDefaultStateSubmitter } from "mocks";
+import { mockedProducer } from "mocks/helpers/kafka.utils";
 import { mockedServiceServer as mockedServer } from "mocks/server";
 import { beforeEach, describe, expect, it } from "vitest";
 

--- a/lib/libs/api/kafka.test.ts
+++ b/lib/libs/api/kafka.test.ts
@@ -1,4 +1,4 @@
-import { mockedProducer } from "mocks";
+import { mockedProducer } from "mocks/helpers/kafka.utils";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { getProducer, produceMessage } from "./kafka";

--- a/lib/libs/topics-lib.test.ts
+++ b/lib/libs/topics-lib.test.ts
@@ -1,4 +1,4 @@
-import { mockedAdmin, TOPIC_ONE, TOPIC_THREE } from "mocks";
+import { mockedAdmin, TOPIC_ONE, TOPIC_THREE } from "mocks/helpers/kafka.utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createTopics, deleteTopics } from "./topics-lib";

--- a/lib/vitest.setup.ts
+++ b/lib/vitest.setup.ts
@@ -7,7 +7,6 @@ import {
   BUCKET_REGION,
   IDENTITY_POOL_ID,
   KAFKA_BROKERS,
-  mockedKafka,
   OPENSEARCH_DOMAIN,
   OPENSEARCH_INDEX_NAMESPACE,
   PROJECT,
@@ -18,6 +17,7 @@ import {
   USER_POOL_CLIENT_ID,
   USER_POOL_ID,
 } from "mocks";
+import { mockedKafka } from "mocks/helpers/kafka.utils";
 import { mockedServiceServer as mockedServer } from "mocks/server";
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
 type CreateType<T> = T & { default: T };

--- a/mocks/helpers/index.ts
+++ b/mocks/helpers/index.ts
@@ -1,1 +1,0 @@
-export * from "./kafka.utils";

--- a/mocks/index.ts
+++ b/mocks/index.ts
@@ -1,7 +1,6 @@
 export * from "./consts";
 export * from "./data";
 export * from "./handlers";
-export * from "./helpers";
 export * from "./index.d";
 
 export { http, HttpResponse } from "msw";

--- a/mocks/package.json
+++ b/mocks/package.json
@@ -3,8 +3,21 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "description": "",
-  "main": "index.ts",
+  "exports": {
+    ".": "./index.ts",
+    "./server": "./server.ts",
+    "./data": "./data/index.ts",
+    "./data/cpocs": "./data/cpocs.ts",
+    "./data/forms/main": "./data/forms/main.ts",
+    "./data/items": "./data/items.ts",
+    "./data/secrets": "./data/secrets.ts",
+    "./data/submit/attachments": "./data/submit/attachments.ts",
+    "./data/submit/base": "./data/submit/base.ts",
+    "./data/submit/changelog": "./data/submit/changelog.ts",
+    "./data/types": "./data/types.ts",
+    "./handlers/auth.utils": "./handlers/auth.utils.ts",
+    "./helpers/kafka.utils": "./helpers/kafka.utils.ts"
+  },
   "scripts": {
     "build": "tsc"
   },


### PR DESCRIPTION
## 💬 Description / Notes

The mocks export a Kafka object mocked using vi.fn(). This was being imported by Playwright and causing the error

```sh
TypeError: Cannot redefine property: Symbol($$jest-matchers-object)
```

To get rid of this error, I removed the helpers from the main export and exported them separately. Then I updated all of the imports that use those to import the new helpers/kafka.utils export.

## 🛠 Changes

- updated `mocks/package.json` to explicitly list exports for all of the ways the other packages import from mocks
- added `./helpers/kafka.utils` and pointed it to the `kafka.utils.ts` file
- deleted `mocks/helpers/index.ts` and deleted the `export * from "./helpers"` from `mocks/index.ts`
- updated all the imports that use the kafka mocked object

