### PR TITLE
chore(refactor): cleaning up imports

### DIFF
--- a/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/temporary-extension.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/temporary-extension.ts
@@ -1,16 +1,15 @@
-import omit from "lodash/omit";
 import { events } from "shared-types";
 
 export const transform = () => {
   return events["legacy-event"].legacyEventSchema.transform((data) => {
-    const cleanData = omit(data, ["parentId"]);
+    const { parentId, ...cleanData } = data;
     return {
       ...cleanData,
       cmsStatus: "Requested",
       stateStatus: "Submitted",
       authority: data.temporaryExtensionType ?? "1915(b)",
       actionType: "Extend",
-      originalWaiverNumber: data.parentId,
+      originalWaiverNumber: parentId,
     };
   });
 };

--- a/lib/packages/shared-types/opensearch/main/transforms/seatool.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/seatool.ts
@@ -1,9 +1,8 @@
-import { SEATOOL_AUTHORITIES } from "shared-types";
-
 import {
   finalDispositionStatuses,
   getStatus,
   SeaTool,
+  SEATOOL_AUTHORITIES,
   SEATOOL_SPW_STATUS,
   SEATOOL_STATUS,
   SeatoolOfficer,

--- a/lib/packages/shared-types/package.json
+++ b/lib/packages/shared-types/package.json
@@ -2,19 +2,37 @@
   "name": "shared-types",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "license": "MIT",
-  "devDependencies": {
-    "base-64": "^1.0.0",
-    "eslint": "^8.38.0",
-    "eslint-config-custom-server": "*",
-    "zod": "^3.22.3"
+  "exports": {
+    ".": "./index.ts",
+    "./actions": "./actions.ts",
+    "./authority": "./authority.ts",
+    "./events": "./events/index.ts",
+    "./events/legacy-event": "./events/legacy-event.ts",
+    "./events/legacy-user": "./events/legacy-user.ts",
+    "./events/temporary-extension": "./events/temporary-extension.ts",
+    "./forms": "./forms.ts",
+    "./opensearch": "./opensearch/index.ts",
+    "./opensearch/changelog": "./opensearch/changelog/index.ts",
+    "./opensearch/main": "./opensearch/main/index.ts",
+    "./opensearch/main/transforms/legacy-transforms": "./opensearch/main/transforms/legacy-transforms/index.ts",
+    "./states": "./states.ts",
+    "./uploads": "./uploads.ts",
+    "./user": "./user.ts"
   },
   "scripts": {
     "test": "vitest",
     "test:coverage": "vitest run --coverage.enabled true",
     "test:ui": "vitest --ui"
   },
+  "devDependencies": {
+    "eslint": "^8.38.0",
+    "eslint-config-custom-server": "*"
+  },
   "dependencies": {
-    "s3-url-parser": "^1.0.3"
+    "base-64": "^1.0.0",
+    "s3-url-parser": "^1.0.3",
+    "zod": "^3.22.3"
   }
 }

--- a/lib/packages/shared-utils/package.json
+++ b/lib/packages/shared-utils/package.json
@@ -2,20 +2,29 @@
   "name": "shared-utils",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "license": "MIT",
+  "exports": {
+    ".": "./index.ts",
+    "./regex": "./regex.ts",
+    "./retry": "./retry.ts",
+    "./s3-url-parser": "./s3-url-parser.ts",
+    "./seatool-date-helper": "./seatool-date-helper.ts"
+  },
   "scripts": {
     "test": "vitest",
     "test:coverage": "vitest run --coverage.enabled.true",
     "test:ui": "vitest --ui"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "eslint-config-custom-server": "*",
+    "eslint-config-custom": "*"
+  },
   "dependencies": {
     "@18f/us-federal-holidays": "^4.0.0",
     "@date-fns/tz": "1.2.0",
     "@date-fns/utc": "2.1.0",
     "date-fns": "^4.1.0",
-    "shared-types": "*",
-    "eslint-config-custom-server": "*",
-    "eslint-config-custom": "*"
+    "shared-types": "*"
   }
 }

--- a/mocks/data/cpocs.ts
+++ b/mocks/data/cpocs.ts
@@ -106,4 +106,4 @@ const cpocs: Record<number, TestCpocsItemResult> = {
 
 export default cpocs;
 
-export const cpocsList = Object.values(cpocs);
+export const cpocsList: TestCpocsItemResult[] = Object.values(cpocs);

--- a/mocks/data/users/index.ts
+++ b/mocks/data/users/index.ts
@@ -1,7 +1,7 @@
-import { convertUserAttributes } from "mocks/handlers/auth.utils";
 import { CognitoUserAttributes } from "shared-types";
 import { UserRole } from "shared-types/events/legacy-user";
 
+import { convertUserAttributes } from "../../handlers/auth.utils";
 import type { TestUserDataWithRole } from "../../index.d";
 import { makoReviewer, reviewers, superReviewer } from "./cmsReviewer";
 import { helpDeskUser, helpDeskUsers } from "./helpDeskUsers";

--- a/mocks/handlers/aws/cloudFormation.ts
+++ b/mocks/handlers/aws/cloudFormation.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from "msw";
 
 import { CLOUDFORMATION_NOTIFICATION_DOMAIN } from "../../consts";
-import exports from "../../data/cloudFormationsExports";
+import exportsList from "../../data/cloudFormationsExports";
 
 const defaultCloudFormationHandler = http.post(
   `https://cloudformation.us-east-1.amazonaws.com/`,
@@ -13,7 +13,7 @@ const defaultCloudFormationHandler = http.post(
     <Exports>
   `;
 
-    xmlResponse += exports
+    xmlResponse += exportsList
       .map(
         (val) => `
       <member>

--- a/mocks/handlers/aws/cognito.ts
+++ b/mocks/handlers/aws/cognito.ts
@@ -1,4 +1,4 @@
-import jwt from "jsonwebtoken";
+import * as jwt from "jsonwebtoken";
 import { http, HttpResponse, passthrough, PathParams } from "msw";
 import { APIGatewayEventRequestContext } from "shared-types";
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   test: {
     globals: true,
     include: ["**/*.test.{ts,tsx}"],
-    exclude: ["**/node_modules/**", "test/e2e/**", "**/*.spec.ts"],
+    exclude: ["**/node_modules/**", "test/**", "**/*.spec.{ts,tsx}"],
     server: {
       deps: {
         cacheDir: ".vitest/cache",


### PR DESCRIPTION
## 💬 Description / Notes

Cleaning up a couple of smaller issues

## 🛠 Changes

- removed lodash from a transform
- merged imports
- added type module and explicity exports from shared-types and shared-utils
- added type to cpocs in mocks
- changed import name in cloudFormation in mocks
- change import of jwt in cognito mocks
- excluding all of `test/` from the vitest tests


