### PR TITLE
chore(refactor): removing circular imports from `shared-types`

### DIFF
--- a/lib/packages/shared-types/forms.ts
+++ b/lib/packages/shared-types/forms.ts
@@ -1,4 +1,5 @@
 import { Control, FieldArrayPath, FieldValues, RegisterOptions } from "react-hook-form";
+
 import {
   CalendarProps,
   InputProps,
@@ -7,7 +8,7 @@ import {
   SelectProps,
   SwitchProps,
   TextareaProps,
-} from "shared-types";
+} from "./index";
 
 export interface FormSchema {
   header: string;

--- a/lib/packages/shared-types/opensearch/changelog/transforms/app-k.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/app-k.ts
@@ -1,4 +1,5 @@
-import { events } from "shared-types";
+import { events } from "../../../index";
+
 export const transform = (offset: number) => {
   return events["app-k"].schema.transform((data) => {
     const attachments = data.attachments

--- a/lib/packages/shared-types/opensearch/changelog/transforms/capitated-amendment.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/capitated-amendment.ts
@@ -1,4 +1,5 @@
-import { events } from "shared-types";
+import { events } from "../../../index";
+
 export const transform = (offset: number) => {
   return events["capitated-amendment"].schema.transform((data) => {
     const attachments = data.attachments

--- a/lib/packages/shared-types/opensearch/changelog/transforms/capitated-initial.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/capitated-initial.ts
@@ -1,4 +1,5 @@
-import { events } from "shared-types";
+import { events } from "../../../index";
+
 export const transform = (offset: number) => {
   return events["capitated-initial"].schema.transform((data) => {
     const attachments = data.attachments

--- a/lib/packages/shared-types/opensearch/changelog/transforms/capitated-renewal.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/capitated-renewal.ts
@@ -1,4 +1,5 @@
-import { events } from "shared-types";
+import { events } from "../../../index";
+
 export const transform = (offset: number) => {
   return events["capitated-renewal"].schema.transform((data) => {
     const attachments = data.attachments

--- a/lib/packages/shared-types/opensearch/changelog/transforms/contracting-amendment.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/contracting-amendment.ts
@@ -1,4 +1,5 @@
-import { events } from "shared-types";
+import { events } from "../../../index";
+
 export const transform = (offset: number) => {
   return events["contracting-amendment"].schema.transform((data) => {
     const attachments = data.attachments

--- a/lib/packages/shared-types/opensearch/changelog/transforms/contracting-initial.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/contracting-initial.ts
@@ -1,4 +1,5 @@
-import { events } from "shared-types";
+import { events } from "../../../index";
+
 export const transform = (offset: number) => {
   return events["contracting-initial"].schema.transform((data) => {
     const attachments = data.attachments

--- a/lib/packages/shared-types/opensearch/changelog/transforms/contracting-renewal.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/contracting-renewal.ts
@@ -1,4 +1,5 @@
-import { events } from "shared-types";
+import { events } from "../../../index";
+
 export const transform = (offset: number) => {
   return events["contracting-renewal"].schema.transform((data) => {
     const attachments = data.attachments

--- a/lib/packages/shared-types/opensearch/changelog/transforms/new-chip-details-submission.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/new-chip-details-submission.ts
@@ -1,4 +1,4 @@
-import { events } from "shared-types";
+import { events } from "../../../index";
 
 export const transform = (offset: number) => {
   return events["new-chip-details-submission"].schema.transform((data) => {

--- a/lib/packages/shared-types/opensearch/changelog/transforms/new-chip-submission.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/new-chip-submission.ts
@@ -1,4 +1,4 @@
-import { events } from "shared-types";
+import { events } from "../../../index";
 
 export const transform = (offset: number) => {
   return events["new-chip-submission"].schema.transform((data) => {

--- a/lib/packages/shared-types/opensearch/changelog/transforms/new-medicaid-submission.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/new-medicaid-submission.ts
@@ -1,4 +1,5 @@
-import { events } from "shared-types";
+import { events } from "../../../index";
+
 export const transform = (offset: number) => {
   return events["new-medicaid-submission"].schema.transform((data) => {
     const attachments = data.attachments

--- a/lib/packages/shared-types/opensearch/changelog/transforms/respond-to-rai.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/respond-to-rai.ts
@@ -1,4 +1,5 @@
-import { events } from "shared-types";
+import { events } from "../../../index";
+
 export const transform = (offset: number) => {
   return events["respond-to-rai"].schema.transform((data) => {
     const attachments = data.attachments

--- a/lib/packages/shared-types/opensearch/changelog/transforms/temporary-extension.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/temporary-extension.ts
@@ -1,4 +1,5 @@
-import { events } from "shared-types";
+import { events } from "../../../index";
+
 export const transform = (offset: number) => {
   return events["temporary-extension"].schema.transform((data) => {
     const attachments = data.attachments

--- a/lib/packages/shared-types/opensearch/changelog/transforms/toggle-withdraw-rai.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/toggle-withdraw-rai.ts
@@ -1,4 +1,5 @@
-import { events } from "shared-types";
+import { events } from "../../../index";
+
 export const transform = (offset: number) => {
   return events["toggle-withdraw-rai"].schema.transform((data) => {
     return {

--- a/lib/packages/shared-types/opensearch/changelog/transforms/upload-subsequent-documents.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/upload-subsequent-documents.ts
@@ -1,4 +1,5 @@
-import { events } from "shared-types";
+import { events } from "../../../index";
+
 export const transform = (offset: number) => {
   return events["upload-subsequent-documents"].schema.transform((data) => {
     const attachments = data.attachments

--- a/lib/packages/shared-types/opensearch/changelog/transforms/withdraw-package.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/withdraw-package.ts
@@ -1,4 +1,5 @@
-import { events } from "shared-types";
+import { events } from "../../../index";
+
 export const transform = (offset: number) => {
   return events["withdraw-package"].schema.transform((data) => {
     const attachments = data.attachments

--- a/lib/packages/shared-types/opensearch/changelog/transforms/withdraw-rai.ts
+++ b/lib/packages/shared-types/opensearch/changelog/transforms/withdraw-rai.ts
@@ -1,4 +1,5 @@
-import { events } from "shared-types";
+import { events } from "../../../index";
+
 export const transform = (offset: number) => {
   return events["withdraw-rai"].schema.transform((data) => {
     const attachments = data.attachments

--- a/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/amendment-waiver.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/amendment-waiver.ts
@@ -1,4 +1,4 @@
-import { events } from "shared-types";
+import { events } from "../../../../index";
 
 export const transform = () => {
   return events["legacy-event"].legacyEventSchema.transform((data) => {

--- a/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/app-k.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/app-k.ts
@@ -1,4 +1,4 @@
-import { events } from "shared-types";
+import { events } from "../../../../index";
 
 export const transform = () => {
   return events["legacy-event"].legacyEventSchema.transform((data) => {

--- a/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/chip-spa.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/chip-spa.ts
@@ -1,4 +1,4 @@
-import { events } from "shared-types";
+import { events } from "../../../../index";
 
 export const transform = () => {
   return events["legacy-event"].legacyEventSchema.transform((data) => {

--- a/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/initial-waiver.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/initial-waiver.ts
@@ -1,4 +1,4 @@
-import { events } from "shared-types";
+import { events } from "../../../../index";
 
 export const transform = () => {
   return events["legacy-event"].legacyEventSchema.transform((data) => {

--- a/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/medicaid-spa.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/medicaid-spa.ts
@@ -1,4 +1,4 @@
-import { events } from "shared-types";
+import { events } from "../../../../index";
 
 export const transform = () => {
   return events["legacy-event"].legacyEventSchema.transform((data) => {

--- a/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/rai-response.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/rai-response.ts
@@ -1,4 +1,4 @@
-import { events, getStatus, SEATOOL_STATUS } from "shared-types";
+import { events, getStatus, SEATOOL_STATUS } from "../../../../index";
 
 export const transform = () => {
   return events["legacy-event"].legacyEventSchema.transform((data) => {

--- a/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/renewal-waiver.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/renewal-waiver.ts
@@ -1,4 +1,4 @@
-import { events } from "shared-types";
+import { events } from "../../../../index";
 
 export const transform = () => {
   return events["legacy-event"].legacyEventSchema.transform((data) => {

--- a/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/temporary-extension.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/legacy-transforms/temporary-extension.ts
@@ -1,5 +1,6 @@
 import omit from "lodash/omit";
-import { events } from "shared-types";
+
+import { events } from "../../../../index";
 
 export const transform = () => {
   return events["legacy-event"].legacyEventSchema.transform((data) => {

--- a/lib/packages/shared-types/opensearch/main/transforms/respond-to-rai.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/respond-to-rai.ts
@@ -1,4 +1,5 @@
-import { events, getStatus, SEATOOL_STATUS } from "shared-types";
+import { events, getStatus, SEATOOL_STATUS } from "../../../index";
+
 export const transform = () => {
   return events["respond-to-rai"].schema.transform((data) => {
     const { stateStatus, cmsStatus } = getStatus(SEATOOL_STATUS.SUBMITTED);

--- a/lib/packages/shared-types/opensearch/main/transforms/withdraw-package.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/withdraw-package.ts
@@ -1,4 +1,4 @@
-import { events, getStatus, SEATOOL_STATUS } from "shared-types";
+import { events, getStatus, SEATOOL_STATUS } from "../../../index";
 
 export const transform = () => {
   return events["withdraw-package"].schema.transform((data) => {

--- a/lib/packages/shared-types/opensearch/main/transforms/withdraw-rai-response.ts
+++ b/lib/packages/shared-types/opensearch/main/transforms/withdraw-rai-response.ts
@@ -1,4 +1,4 @@
-import { events, getStatus, SEATOOL_STATUS } from "shared-types";
+import { events, getStatus, SEATOOL_STATUS } from "../../../index";
 
 export const transform = () => {
   return events["withdraw-rai"].schema.transform((data) => {


### PR DESCRIPTION
## 💬 Description / Notes

Importing from the package inside the package causes issues with tests sometimes. Updating them to reference by relative path.

## 🛠 Changes

- updated all imports of `shared-types` within `lib/packages/shared-types` to use relative path instead