### PR TITLE
Revert "fix(remove-email-temp): Remove email change temporaily"

### DIFF
--- a/lib/libs/email/content/withdrawRai/index.tsx
+++ b/lib/libs/email/content/withdrawRai/index.tsx
@@ -31,11 +31,9 @@ export const withdrawRai: AuthoritiesWithUserTypesTemplate = {
       variables: Events["WithdrawRai"] & CommonEmailVariables & { emails: EmailAddresses },
     ) => {
       return {
-        to: [
-          ...variables.emails.cpocEmail,
-          ...variables.emails.srtEmails,
-          `${variables.submitterName} <${variables.submitterEmail}>`,
-        ],
+        to: variables.allStateUsersEmails?.length
+          ? variables.allStateUsersEmails
+          : [`${variables.submitterName} <${variables.submitterEmail}>`],
         subject: `Withdraw Formal RAI Response for SPA Package ${variables.id}`,
         body: await render(<MedSpaStateEmail variables={variables} />),
       };


### PR DESCRIPTION
## 🎫 Linked Ticket

https://jiraent.cms.gov/browse/OY2-35034

## 🛠 Changes

For medicaid SPA's removed CPOC SRT added all state users to the recipients, all other state recipients are correct

## 📸 Screenshots / Demo

Verified that CPOC & SRT are not on the state list
Medicaid:
![Screenshot 2025-06-09 at 4 41 00 PM](https://github.com/user-attachments/assets/149e4c3e-582c-4b60-9cc8-9536103ae5f3)


CHIP:
![Screenshot 2025-06-09 at 4 58 59 PM](https://github.com/user-attachments/assets/afbefd1a-d9a4-4dbb-8a2f-fdf964cc1d48)


Waiver:

![Screenshot 2025-06-09 at 5 04 17 PM](https://github.com/user-attachments/assets/b382fe04-b524-476a-9d2e-6273d34f2ff0)

