### PR TITLE
fix(ui): CHIP Submission Type field and word "Eligibility" are missin…

### DIFF
--- a/react-app/src/features/package/package-details/details.tsx
+++ b/react-app/src/features/package/package-details/details.tsx
@@ -53,9 +53,7 @@ type GetLabelAndValueFromSubmission = (
 ) => LabelAndValue[];
 
 export const getSubmissionDetails: GetLabelAndValueFromSubmission = (submission, { user }) => {
-  const hasChipEligibilityAttachment =
-    Array.isArray(submission.attachments?.chipEligibility?.files) &&
-    submission.attachments.chipEligibility.files.length > 0;
+  const hasChipEligibilityAttachment = !!submission.attachments?.chipEligibility?.files?.length;
 
   const hasChipSubmissionType =
     Array.isArray(submission.chipSubmissionType) && submission.chipSubmissionType.length > 0;
@@ -68,7 +66,7 @@ export const getSubmissionDetails: GetLabelAndValueFromSubmission = (submission,
             value: hasChipSubmissionType ? (
               <span className="break-words">{submission.chipSubmissionType.join(", ")}</span>
             ) : (
-              BLANK_VALUE
+              <span className="italic text-gray-500">Included in CHIP Eligibility Template</span>
             ),
           },
         ]


### PR DESCRIPTION
## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

https://jiraent.cms.gov/browse/OY2-35209

## 💬 Description / Notes

Env - VAL
Login as a state user and click on New Submission button.
Select the CHIP Eligibility SPA choice card to create/submit the form.
Enter all the mandatory fields and leave the CHIP Submission Type field empty by not selecting any value.
Submit the form.
Click on the Package ID on the Dashboard to navigate to Package Details page.
Issue #1 - Word "Eligibility" is missing on the header on the Details page.
Issue #2 - CHIP Submission Type field is missing instead of displaying as "-- --".
ID = MD-25-1178-P
 