### PR TITLE
fix(ui): chip feature flag and details page

### DIFF
--- a/lib/packages/shared-utils/feature-flags.ts
+++ b/lib/packages/shared-utils/feature-flags.ts
@@ -86,4 +86,11 @@ export const featureFlags = {
     flag: "med-spa-footer",
     defaultValue: true,
   },
+  /*
+   *  Toggle visibility of details page of the chip spa eligibility submission
+   */
+  CHIP_SPA_DETAILS: {
+    flag: "chip-spa-details",
+    defaultValue: true,
+  },
 } as const;

--- a/react-app/src/features/package/package-details/details.tsx
+++ b/react-app/src/features/package/package-details/details.tsx
@@ -50,29 +50,38 @@ export type LabelAndValue = {
 type GetLabelAndValueFromSubmission = (
   submission: opensearch.main.Document,
   user: OneMacUser,
+  chipFlagEnabled: boolean,
 ) => LabelAndValue[];
 
-export const getSubmissionDetails: GetLabelAndValueFromSubmission = (submission, { user }) => {
-  const hasChipEligibilityAttachment =
-    Array.isArray(submission.attachments?.chipEligibility?.files) &&
-    submission.attachments.chipEligibility.files.length > 0;
+export const getSubmissionDetails: GetLabelAndValueFromSubmission = (
+  submission,
+  { user },
+  chipFlagEnabled,
+) => {
+  const hasChipEligibilityAttachment = Object.values(submission.attachments || {}).some(
+    (attachment) =>
+      attachment.label?.toLowerCase().includes("chip eligibility") &&
+      Array.isArray(attachment.files) &&
+      attachment.files.length > 0,
+  );
 
   const hasChipSubmissionType =
     Array.isArray(submission.chipSubmissionType) && submission.chipSubmissionType.length > 0;
 
   const chipSubmissionTypeField: LabelAndValue[] =
-    hasChipEligibilityAttachment || hasChipSubmissionType
+    chipFlagEnabled && (hasChipEligibilityAttachment || hasChipSubmissionType)
       ? [
           {
             label: "CHIP Submission Type",
             value: hasChipSubmissionType ? (
               <span className="break-words">{submission.chipSubmissionType.join(", ")}</span>
             ) : (
-              BLANK_VALUE
+              <span className="italic text-gray-500">Included in CHIP Eligibility Template</span>
             ),
           },
         ]
       : [];
+
   return [
     {
       label: "Submission ID",

--- a/react-app/src/features/package/package-details/index.tsx
+++ b/react-app/src/features/package/package-details/index.tsx
@@ -3,6 +3,7 @@ import { Authority, opensearch } from "shared-types";
 
 import { useGetUser } from "@/api/useGetUser";
 import { DetailsSection, LoadingSpinner } from "@/components";
+import { useFeatureFlag } from "@/hooks/useFeatureFlag";
 
 import {
   getApprovedAndEffectiveDetails,
@@ -35,6 +36,7 @@ type PackageDetailsProps = {
 
 export const PackageDetails = ({ submission }: PackageDetailsProps) => {
   const { data: user, isLoading: isUserLoading } = useGetUser();
+  const isCHIPDetailsEnabled = useFeatureFlag("CHIP_SPA_DETAILS");
   const title = useMemo(() => {
     const hasChipSubmissionType =
       Array.isArray(submission.chipSubmissionType) && submission.chipSubmissionType.length > 0;
@@ -43,7 +45,7 @@ export const PackageDetails = ({ submission }: PackageDetailsProps) => {
       Array.isArray(submission.attachments) &&
       submission.attachments.some((attachment) => attachment.type === "chipEligibility");
 
-    if (hasChipSubmissionType || hasChipEligibilityAttachment) {
+    if (isCHIPDetailsEnabled && (hasChipSubmissionType || hasChipEligibilityAttachment)) {
       return "CHIP Eligibility SPA Package Details";
     }
 
@@ -57,7 +59,7 @@ export const PackageDetails = ({ submission }: PackageDetailsProps) => {
     }
 
     return `${submission.authority} Package Details`;
-  }, [submission]);
+  }, [submission, isCHIPDetailsEnabled]);
 
   if (isUserLoading) return <LoadingSpinner />;
 
@@ -66,13 +68,15 @@ export const PackageDetails = ({ submission }: PackageDetailsProps) => {
       <div>
         <PackageDetailsGrid
           details={[
-            ...getSubmissionDetails(submission, user),
-            ...getApprovedAndEffectiveDetails(submission, user),
-            ...getDescriptionDetails(submission, user),
+            ...getSubmissionDetails(submission, user, isCHIPDetailsEnabled),
+            ...getApprovedAndEffectiveDetails(submission, user, isCHIPDetailsEnabled),
+            ...getDescriptionDetails(submission, user, isCHIPDetailsEnabled),
           ]}
         />
         <hr className="my-4" />
-        <PackageDetailsGrid details={getSubmittedByDetails(submission, user)} />
+        <PackageDetailsGrid
+          details={getSubmittedByDetails(submission, user, isCHIPDetailsEnabled)}
+        />
       </div>
     </DetailsSection>
   );


### PR DESCRIPTION
## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

https://jiraent.cms.gov/browse/OY2-35121

## 💬 Description / Notes

The header should be updated to say CHIP Eligibility SPA in each instance
If no type has been chosen, I think it would make sense to follow the existing pattern of showing "-- --"
The CHIP Submission Type selected values and the field itself should show on the Package Details page.
all hidden by an LD flag

