### PR TITLE
fix(ui): CHIP Submission Type field and word "Eligibility" are missin…

### DIFF
--- a/lib/packages/shared-utils/feature-flags.ts
+++ b/lib/packages/shared-utils/feature-flags.ts
@@ -86,4 +86,11 @@ export const featureFlags = {
     flag: "med-spa-footer",
     defaultValue: true,
   },
+  /*
+   *  Toggle visibility of details page of the chip spa eligibility submission
+   */
+  CHIP_SPA_DETAILS: {
+    flag: "chip-spa-details",
+    defaultValue: true,
+  },
 } as const;

--- a/react-app/src/features/package/index.tsx
+++ b/react-app/src/features/package/index.tsx
@@ -1,6 +1,7 @@
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, useMemo } from "react";
 import { LoaderFunctionArgs, redirect, useLoaderData } from "react-router";
-import { Authority } from "shared-types";
+import { Authority, opensearch } from "shared-types";
+import { ItemResult } from "shared-types/opensearch/changelog";
 
 import { getItem, useGetItem } from "@/api";
 import { CardWithTopBorder, ErrorAlert, LoadingSpinner } from "@/components";
@@ -32,29 +33,65 @@ type DetailsContentProps = {
   id: string;
 };
 
+const injectChipEligibilityAttachment = (
+  submission: opensearch.main.Document,
+  changelog: ItemResult[],
+): opensearch.main.Document => {
+  const alreadyHasChipEligibility = submission.attachments?.chipEligibility?.files?.length > 0;
+
+  if (alreadyHasChipEligibility) return submission;
+
+  const chipEligibilityAttachment = changelog.find((item) =>
+    item._source.attachments?.some((att) => att.title.toLowerCase().includes("chip eligibility")),
+  );
+
+  if (!chipEligibilityAttachment) return submission;
+
+  const chipAttachment = chipEligibilityAttachment._source.attachments.find((att) =>
+    att.title.toLowerCase().includes("chip eligibility"),
+  );
+
+  if (!chipAttachment) return submission;
+
+  return {
+    ...submission,
+    attachments: {
+      ...submission.attachments,
+      chipEligibility: {
+        files: [chipAttachment],
+        label: "CHIP Eligibility Template",
+      },
+    },
+  };
+};
+
 export const DetailsContent = ({ id }: DetailsContentProps) => {
   const { data: record, isLoading, error } = useGetItem(id);
 
+  const submission = record?._source;
+  const updatedSubmission = useMemo(() => {
+    return submission
+      ? injectChipEligibilityAttachment(submission, submission.changelog)
+      : undefined;
+  }, [submission]);
+
   if (isLoading) return <LoadingSpinner />;
-
-  if (error) return <ErrorAlert error={error} />;
-
-  const { _source: submission } = record;
+  if (error || !record || !updatedSubmission) return <ErrorAlert error={error} />;
 
   return (
     <div className="w-full py-1 px-4 lg:px-8 grid grid-cols-1 gap-y-6 sm:gap-y-6">
       <section id="package_overview" className="sm:mb-0 two-cols gap-y-3 sm:gap-y-3">
         <DetailCardWrapper title="Status">
-          <PackageStatusCard submission={submission} />
+          <PackageStatusCard submission={updatedSubmission} />
         </DetailCardWrapper>
         <DetailCardWrapper title="Package Actions">
-          <PackageActionsCard id={id} submission={submission} />
+          <PackageActionsCard id={id} submission={updatedSubmission} />
         </DetailCardWrapper>
       </section>
       <div className="grid grid-cols-1 gap-y-3">
-        <PackageDetails submission={submission} />
-        <PackageActivities id={id} changelog={submission.changelog} />
-        <AdminPackageActivities changelog={submission.changelog} />
+        <PackageDetails submission={updatedSubmission} />
+        <PackageActivities id={id} changelog={updatedSubmission.changelog} />
+        <AdminPackageActivities changelog={updatedSubmission.changelog} />
       </div>
     </div>
   );

--- a/react-app/src/features/package/package-details/details.tsx
+++ b/react-app/src/features/package/package-details/details.tsx
@@ -50,18 +50,26 @@ export type LabelAndValue = {
 type GetLabelAndValueFromSubmission = (
   submission: opensearch.main.Document,
   user: OneMacUser,
+  chipFlagEnabled: boolean,
 ) => LabelAndValue[];
 
-export const getSubmissionDetails: GetLabelAndValueFromSubmission = (submission, { user }) => {
-  const hasChipEligibilityAttachment =
-    Array.isArray(submission.attachments?.chipEligibility?.files) &&
-    submission.attachments.chipEligibility.files.length > 0;
+export const getSubmissionDetails: GetLabelAndValueFromSubmission = (
+  submission,
+  { user },
+  chipFlagEnabled,
+) => {
+  const hasChipEligibilityAttachment = Object.values(submission.attachments || {}).some(
+    (attachment) =>
+      attachment.label?.toLowerCase().includes("chip eligibility") &&
+      Array.isArray(attachment.files) &&
+      attachment.files.length > 0,
+  );
 
   const hasChipSubmissionType =
     Array.isArray(submission.chipSubmissionType) && submission.chipSubmissionType.length > 0;
 
   const chipSubmissionTypeField: LabelAndValue[] =
-    hasChipEligibilityAttachment || hasChipSubmissionType
+    chipFlagEnabled && (hasChipEligibilityAttachment || hasChipSubmissionType)
       ? [
           {
             label: "CHIP Submission Type",
@@ -73,6 +81,7 @@ export const getSubmissionDetails: GetLabelAndValueFromSubmission = (submission,
           },
         ]
       : [];
+
   return [
     {
       label: "Submission ID",

--- a/react-app/src/features/package/package-details/details.tsx
+++ b/react-app/src/features/package/package-details/details.tsx
@@ -68,7 +68,7 @@ export const getSubmissionDetails: GetLabelAndValueFromSubmission = (submission,
             value: hasChipSubmissionType ? (
               <span className="break-words">{submission.chipSubmissionType.join(", ")}</span>
             ) : (
-              BLANK_VALUE
+              <span className="italic text-gray-500">{BLANK_VALUE}</span>
             ),
           },
         ]

--- a/react-app/src/features/package/package-details/index.tsx
+++ b/react-app/src/features/package/package-details/index.tsx
@@ -40,8 +40,8 @@ export const PackageDetails = ({ submission }: PackageDetailsProps) => {
       Array.isArray(submission.chipSubmissionType) && submission.chipSubmissionType.length > 0;
 
     const hasChipEligibilityAttachment =
-      Array.isArray(submission.attachments) &&
-      submission.attachments.some((attachment) => attachment.type === "chipEligibility");
+      Array.isArray(submission.attachments?.chipEligibility?.files) &&
+      submission.attachments.chipEligibility.files.length > 0;
 
     if (hasChipSubmissionType || hasChipEligibilityAttachment) {
       return "CHIP Eligibility SPA Package Details";

--- a/react-app/src/features/package/package-details/index.tsx
+++ b/react-app/src/features/package/package-details/index.tsx
@@ -3,6 +3,7 @@ import { Authority, opensearch } from "shared-types";
 
 import { useGetUser } from "@/api/useGetUser";
 import { DetailsSection, LoadingSpinner } from "@/components";
+import { useFeatureFlag } from "@/hooks/useFeatureFlag";
 
 import {
   getApprovedAndEffectiveDetails,
@@ -35,6 +36,7 @@ type PackageDetailsProps = {
 
 export const PackageDetails = ({ submission }: PackageDetailsProps) => {
   const { data: user, isLoading: isUserLoading } = useGetUser();
+  const isCHIPDetailsEnabled = useFeatureFlag("CHIP_SPA_DETAILS");
   const title = useMemo(() => {
     const hasChipSubmissionType =
       Array.isArray(submission.chipSubmissionType) && submission.chipSubmissionType.length > 0;
@@ -43,7 +45,7 @@ export const PackageDetails = ({ submission }: PackageDetailsProps) => {
       Array.isArray(submission.attachments?.chipEligibility?.files) &&
       submission.attachments.chipEligibility.files.length > 0;
 
-    if (hasChipSubmissionType || hasChipEligibilityAttachment) {
+    if (isCHIPDetailsEnabled && (hasChipSubmissionType || hasChipEligibilityAttachment)) {
       return "CHIP Eligibility SPA Package Details";
     }
 
@@ -57,7 +59,7 @@ export const PackageDetails = ({ submission }: PackageDetailsProps) => {
     }
 
     return `${submission.authority} Package Details`;
-  }, [submission]);
+  }, [submission, isCHIPDetailsEnabled]);
 
   if (isUserLoading) return <LoadingSpinner />;
 
@@ -66,13 +68,15 @@ export const PackageDetails = ({ submission }: PackageDetailsProps) => {
       <div>
         <PackageDetailsGrid
           details={[
-            ...getSubmissionDetails(submission, user),
-            ...getApprovedAndEffectiveDetails(submission, user),
-            ...getDescriptionDetails(submission, user),
+            ...getSubmissionDetails(submission, user, isCHIPDetailsEnabled),
+            ...getApprovedAndEffectiveDetails(submission, user, isCHIPDetailsEnabled),
+            ...getDescriptionDetails(submission, user, isCHIPDetailsEnabled),
           ]}
         />
         <hr className="my-4" />
-        <PackageDetailsGrid details={getSubmittedByDetails(submission, user)} />
+        <PackageDetailsGrid
+          details={getSubmittedByDetails(submission, user, isCHIPDetailsEnabled)}
+        />
       </div>
     </DetailsSection>
   );


### PR DESCRIPTION
## 🎫 Linked Ticket

https://jiraent.cms.gov/browse/OY2-35209

[Ticket to close](link-to-ticket)

## 💬 Description / Notes

Env - VAL
Login as a state user and click on New Submission button.
Select the CHIP Eligibility SPA choice card to create/submit the form.
Enter all the mandatory fields and leave the CHIP Submission Type field empty by not selecting any value.
Submit the form.
Click on the Package ID on the Dashboard to navigate to Package Details page.
Issue #1 - Word "Eligibility" is missing on the header on the Details page.
Issue #2 - CHIP Submission Type field is missing instead of displaying as "-- --".
ID = MD-25-1178-P
