### PR TITLE
feat(ui): Swap out Enhanced Experience Banner in VAL for the MMDL banner

### DIFF
--- a/lib/packages/shared-utils/feature-flags.ts
+++ b/lib/packages/shared-utils/feature-flags.ts
@@ -93,4 +93,11 @@ export const featureFlags = {
     flag: "chip-spa-details",
     defaultValue: true,
   },
+  /*
+   *  Toggle visibility between the enhanced experience and mmdl banner
+   */
+  UPGRADE_MMDL_BANNER: {
+    flag: "upgrade-mmdl-banner",
+    defaultValue: true,
+  },
 } as const;

--- a/react-app/src/components/Banner/MMDLSpaBanner.tsx
+++ b/react-app/src/components/Banner/MMDLSpaBanner.tsx
@@ -4,88 +4,44 @@ import { Link } from "react-router";
 
 import { useGetSystemNotifs } from "@/api";
 import { FAQ_TAB } from "@/consts";
+import { useFeatureFlag } from "@/hooks/useFeatureFlag";
 
-// MMDL banner hidden for UAT until further notice, do not remove
-// const MMDLAlertBanner = () => {
-//   const { clearNotif, notifications } = useGetSystemNotifs();
-//   const isBannerHidden = useHideBanner();
-//   if (!notifications.length || isBannerHidden) return null;
-
-//   return (
-//     <section
-//       className="bg-[#E1F3F8] grid md:grid-cols-[min-content_auto_min-content] md:grid-rows-[auto_auto] grid-cols-[auto_auto] gap-4 md:gap-x-4 border-l-[8px] border-[#00A6D2] p-3"
-//       aria-label="mmdl-alert-banner"
-//     >
-//       <InfoCircledIcon className="w-10 h-10" aria-hidden="true" />
-//       <div className="flex gap-x-4 flex-grow">
-//         <div className="flex flex-col flex-grow">
-//           <h3 className="font-bold text-black text-lg break-words">{notifications[0].header}</h3>
-//           <p className="text-black leading-normal break-words">{notifications[0].body}</p>
-//         </div>
-//       </div>
-//       <div className="flex space-x-4 col-start-2 md:col-start-auto">
-//         {notifications[0].buttonText && (
-//           <Link
-//             to={notifications[0].buttonLink}
-//             onClick={(e) => notifications[0].disabled && e.preventDefault()}
-//             target={FAQ_TAB}
-//             rel="noopener noreferrer"
-//             className="border-2 border-black rounded h-[38px] px-4 text font-bold text-center whitespace-nowrap pt-1"
-//           >
-//             {notifications[0].buttonText}
-//           </Link>
-//         )}
-//         <button
-//           onClick={() => clearNotif(notifications[0].notifId)}
-//           aria-label="Dismiss"
-//           className="rounded-full w-6 h-6"
-//         >
-//           <Cross2Icon className="w-full h-full" aria-hidden="true" />
-//         </button>
-//       </div>
-//     </section>
-//   );
-// };
-
-// export default MMDLAlertBanner;
-
-//new upgrade banner for OneMAC Upgrade
+//MMDL banner hidden for UAT until further notice, do not remove
 const MMDLAlertBanner = () => {
   const { clearNotif, notifications } = useGetSystemNotifs();
-  if (!notifications.length) return null;
+  const isBannerHidden = useFeatureFlag("UPGRADE_MMDL_BANNER");
+  if (!notifications.length || isBannerHidden) return null;
 
   return (
     <section
-      className="bg-[#02BFE7] grid md:grid-cols-[min-content_auto_min-content] md:grid-rows-[auto_auto] grid-cols-[auto_auto] gap-4 md:gap-x-4 p-3"
+      className="bg-[#E1F3F8] grid md:grid-cols-[min-content_auto_min-content] md:grid-rows-[auto_auto] grid-cols-[auto_auto] gap-4 md:gap-x-4 border-l-[8px] border-[#00A6D2] p-3"
       aria-label="mmdl-alert-banner"
     >
-      <InfoCircledIcon className="w-10 h-10 text-black" aria-hidden="true" />
-      <div className="flex gap-x-4 flex-grow col-start-2 col-span-2 md:col-span-1">
+      <InfoCircledIcon className="w-10 h-10" aria-hidden="true" />
+      <div className="flex gap-x-4 flex-grow">
         <div className="flex flex-col flex-grow">
           <h3 className="font-bold text-black text-lg break-words">{notifications[0].header}</h3>
           <p className="text-black leading-normal break-words">{notifications[0].body}</p>
         </div>
       </div>
-      <div className="flex space-x-4 col-start-3 row-start-2 md:row-start-1">
+      <div className="flex space-x-4 col-start-2 md:col-start-auto">
         {notifications[0].buttonText && (
           <Link
             to={notifications[0].buttonLink}
             onClick={(e) => notifications[0].disabled && e.preventDefault()}
             target={FAQ_TAB}
             rel="noopener noreferrer"
-            className="border-2 border-black rounded h-[38px] px-4 text font-bold text-center whitespace-nowrap pt-1 text-black"
+            className="border-2 border-black rounded h-[38px] px-4 text font-bold text-center whitespace-nowrap pt-1"
           >
             {notifications[0].buttonText}
           </Link>
         )}
-      </div>
-      <div className="flex space-x-4 col-start-4 md:row-start-1">
         <button
           onClick={() => clearNotif(notifications[0].notifId)}
           aria-label="Dismiss"
           className="rounded-full w-6 h-6"
         >
-          <Cross2Icon className="w-full h-full text-black" aria-hidden="true" />
+          <Cross2Icon className="w-full h-full" aria-hidden="true" />
         </button>
       </div>
     </section>
@@ -93,3 +49,48 @@ const MMDLAlertBanner = () => {
 };
 
 export default MMDLAlertBanner;
+
+// //new upgrade banner for OneMAC Upgrade
+// const MMDLAlertBanner = () => {
+//   const { clearNotif, notifications } = useGetSystemNotifs();
+//   if (!notifications.length) return null;
+
+//   return (
+//     <section
+//       className="bg-[#02BFE7] grid md:grid-cols-[min-content_auto_min-content] md:grid-rows-[auto_auto] grid-cols-[auto_auto] gap-4 md:gap-x-4 p-3"
+//       aria-label="mmdl-alert-banner"
+//     >
+//       <InfoCircledIcon className="w-10 h-10 text-black" aria-hidden="true" />
+//       <div className="flex gap-x-4 flex-grow col-start-2 col-span-2 md:col-span-1">
+//         <div className="flex flex-col flex-grow">
+//           <h3 className="font-bold text-black text-lg break-words">{notifications[0].header}</h3>
+//           <p className="text-black leading-normal break-words">{notifications[0].body}</p>
+//         </div>
+//       </div>
+//       <div className="flex space-x-4 col-start-3 row-start-2 md:row-start-1">
+//         {notifications[0].buttonText && (
+//           <Link
+//             to={notifications[0].buttonLink}
+//             onClick={(e) => notifications[0].disabled && e.preventDefault()}
+//             target={FAQ_TAB}
+//             rel="noopener noreferrer"
+//             className="border-2 border-black rounded h-[38px] px-4 text font-bold text-center whitespace-nowrap pt-1 text-black"
+//           >
+//             {notifications[0].buttonText}
+//           </Link>
+//         )}
+//       </div>
+//       <div className="flex space-x-4 col-start-4 md:row-start-1">
+//         <button
+//           onClick={() => clearNotif(notifications[0].notifId)}
+//           aria-label="Dismiss"
+//           className="rounded-full w-6 h-6"
+//         >
+//           <Cross2Icon className="w-full h-full text-black" aria-hidden="true" />
+//         </button>
+//       </div>
+//     </section>
+//   );
+// };
+
+// export default MMDLAlertBanner;


### PR DESCRIPTION
## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

https://jiraent.cms.gov/browse/OY2-35235

## 💬 Description / Notes

This ticket is intended to turn on the on the feature flag for the enhanced experience banner and to display the MMDL banner in VAL. We have to make sure the MMDL banner does not display in PROD.

## 🛠 Changes

Ensure that the MMDL banner is displayed in VAL
Ensure the MMDL banner is not displayed in PROD
Ensure the Enhanced Experience banner is displayed in PROD