### PR TITLE
feat(ui): User Management" tab missing on the grey bottom footer

### DIFF
--- a/react-app/src/components/Footer/Footer.test.tsx
+++ b/react-app/src/components/Footer/Footer.test.tsx
@@ -12,9 +12,15 @@ vi.mock("@/api", () => ({
   useGetUser: () => ({
     data: {
       user: {
+        role: "statesubmitter",
         "custom:ismemberof": "ONEMAC_USER",
-        "custom:cms-roles": "", // Not a CMS role
+        "custom:cms-roles": "",
       },
+    },
+  }),
+  useGetUserDetails: () => ({
+    data: {
+      role: "statesubmitter",
     },
   }),
 }));

--- a/react-app/src/components/Footer/index.tsx
+++ b/react-app/src/components/Footer/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router";
+import { UserRoles } from "shared-types";
 import { isStateUser } from "shared-utils";
 
 import { useGetUser, useGetUserDetails } from "@/api";
@@ -31,6 +32,12 @@ export const Footer = ({ email, address, showNavLinks }: Props) => {
     const role = userDetailsData?.role;
     return ["systemadmin", "statesystemadmin", "cmsroleapprover", "helpdesk"].includes(role);
   }, [userDetailsData]);
+  const showDashboard = useMemo(() => {
+    const role = user?.user?.role as UserRoles | undefined;
+
+    return role && Object.values(UserRoles).includes(role) && role !== UserRoles.CMS_REVIEWER;
+  }, [user]);
+
   const isStateHomepage = useFeatureFlag("STATE_HOMEPAGE_FLAG");
 
   return (
@@ -42,9 +49,12 @@ export const Footer = ({ email, address, showNavLinks }: Props) => {
               <a href="/" className="underline font-bold">
                 <p>Home</p>
               </a>
-              <a href="/dashboard" className="underline font-bold">
-                <p>Dashboard</p>
-              </a>
+
+              {showDashboard && (
+                <a href="/dashboard" className="underline font-bold">
+                  <p>Dashboard</p>
+                </a>
+              )}
               {showUserManagement && (
                 <a href="/usermanagement" className="underline font-bold">
                   <p>User Management</p>

--- a/react-app/src/components/Footer/index.tsx
+++ b/react-app/src/components/Footer/index.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router";
-import { UserRoles } from "shared-types";
 import { isStateUser } from "shared-utils";
 
 import { useGetUser, useGetUserDetails } from "@/api";
@@ -32,12 +31,6 @@ export const Footer = ({ email, address, showNavLinks }: Props) => {
     const role = userDetailsData?.role;
     return ["systemadmin", "statesystemadmin", "cmsroleapprover", "helpdesk"].includes(role);
   }, [userDetailsData]);
-  const showDashboard = useMemo(() => {
-    const role = user?.user?.role as UserRoles | undefined;
-
-    return role && Object.values(UserRoles).includes(role) && role !== UserRoles.CMS_REVIEWER;
-  }, [user]);
-
   const isStateHomepage = useFeatureFlag("STATE_HOMEPAGE_FLAG");
 
   return (
@@ -50,11 +43,10 @@ export const Footer = ({ email, address, showNavLinks }: Props) => {
                 <p>Home</p>
               </a>
 
-              {showDashboard && (
-                <a href="/dashboard" className="underline font-bold">
-                  <p>Dashboard</p>
-                </a>
-              )}
+              <a href="/dashboard" className="underline font-bold">
+                <p>Dashboard</p>
+              </a>
+
               {showUserManagement && (
                 <a href="/usermanagement" className="underline font-bold">
                   <p>User Management</p>

--- a/react-app/src/components/Footer/index.tsx
+++ b/react-app/src/components/Footer/index.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router";
 import { isStateUser } from "shared-utils";
 
-import { useGetUser } from "@/api";
+import { useGetUser, useGetUserDetails } from "@/api";
 import { Alert, Button } from "@/components";
 import { useFeatureFlag } from "@/hooks/useFeatureFlag";
 
@@ -25,7 +25,12 @@ type MedSpaFooterProps = {
 
 export const Footer = ({ email, address, showNavLinks }: Props) => {
   const shouldShowNavLinks = showNavLinks ?? true;
-  const { data: user } = useGetUser();
+  const { isLoading: userLoading, data: user } = useGetUser();
+  const { data: userDetailsData, isLoading: userDetailsLoading } = useGetUserDetails();
+  const showUserManagement = useMemo(() => {
+    const role = userDetailsData?.role;
+    return ["systemadmin", "statesystemadmin", "cmsroleapprover", "helpdesk"].includes(role);
+  }, [userDetailsData]);
   const isStateHomepage = useFeatureFlag("STATE_HOMEPAGE_FLAG");
 
   return (
@@ -40,6 +45,11 @@ export const Footer = ({ email, address, showNavLinks }: Props) => {
               <a href="/dashboard" className="underline font-bold">
                 <p>Dashboard</p>
               </a>
+              {showUserManagement && (
+                <a href="/usermanagement" className="underline font-bold">
+                  <p>User Management</p>
+                </a>
+              )}
               {isStateHomepage && isStateUser(user.user) && (
                 <a href="/latestupdates" className="underline font-bold">
                   <p>Latest Updates</p>

--- a/react-app/src/components/Footer/index.tsx
+++ b/react-app/src/components/Footer/index.tsx
@@ -25,8 +25,8 @@ type MedSpaFooterProps = {
 
 export const Footer = ({ email, address, showNavLinks }: Props) => {
   const shouldShowNavLinks = showNavLinks ?? true;
-  const { isLoading: userLoading, data: user } = useGetUser();
-  const { data: userDetailsData, isLoading: userDetailsLoading } = useGetUserDetails();
+  const { data: user } = useGetUser();
+  const { data: userDetailsData } = useGetUserDetails();
   const showUserManagement = useMemo(() => {
     const role = userDetailsData?.role;
     return ["systemadmin", "statesystemadmin", "cmsroleapprover", "helpdesk"].includes(role);


### PR DESCRIPTION
## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

 https://jiraent.cms.gov/browse/OY2-34514

## 💬 Description / Notes

Login as a CMS Role approver.
Check for the grey bottom banner.
For the role approvers, additionally "User Management" tab should display.
Issue #1 : "User Management" tab missing on the grey bottom footer.
"statesystemadmin, cmsroleapprovers, helpdesk, CMSsystemadmin are the only ones that can see the user management page i believe"

## 🛠 Changes

Issue #2 - Make sure Dashboard tab does not appear on the grey bottom banner for the approver roles. (CMSroleapprovers, CMSsystemadmin)

