### PR TITLE
Feat(ui): CMS Profile - withdraw pending request ui 

### DIFF
--- a/react-app/src/components/Profile/RoleStatusCard/RoleStatusCardNew.tsx
+++ b/react-app/src/components/Profile/RoleStatusCard/RoleStatusCardNew.tsx
@@ -1,4 +1,5 @@
-import { Clock, XCircle, XIcon } from "lucide-react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { Clock, EllipsisVertical, XCircle, XIcon } from "lucide-react";
 import { UserRole } from "shared-types/events/legacy-user";
 import { isStateRole, newUserRoleMap } from "shared-utils";
 
@@ -40,6 +41,37 @@ export const RoleStatusCardNew = ({
               ? `${newUserRoleMap[access.role]} - ${access.territory}`
               : newUserRoleMap[access.role]}
           </h3>
+
+          {/* in OY2-35201 we can remove !isState*/}
+          {!isState && access.status === "pending" && (
+            <DropdownMenu.Root>
+              <DropdownMenu.DropdownMenuTrigger
+                aria-label="Role Status Options"
+                data-testid="role-status-actions"
+                asChild
+              >
+                <button
+                  className="disabled:text-gray-200"
+                  data-testid="self-revoke"
+                  title="Self Revoke Access"
+                >
+                  <EllipsisVertical size={30} />
+                </button>
+              </DropdownMenu.DropdownMenuTrigger>
+
+              <DropdownMenu.Content
+                className="flex flex-col bg-white rounded-md shadow-lg p-4 border"
+                align="start"
+              >
+                <DropdownMenu.Item asChild>
+                  <button className="text-primary" onClick={onClick}>
+                    Cancel Request
+                  </button>
+                </DropdownMenu.Item>
+              </DropdownMenu.Content>
+            </DropdownMenu.Root>
+          )}
+
           {role === "statesubmitter" && (
             <button
               className="text-blue-700 disabled:text-gray-200"

--- a/react-app/src/features/profile/me/index.tsx
+++ b/react-app/src/features/profile/me/index.tsx
@@ -20,9 +20,14 @@ import { Option } from "@/components/Opensearch/main/Filtering/Drawer/Filterable
 import { FilterableSelect } from "@/components/Opensearch/main/Filtering/Drawer/Filterable";
 import { useAvailableStates } from "@/hooks/useAvailableStates";
 import { useFeatureFlag } from "@/hooks/useFeatureFlag";
-import { convertStateAbbrToFullName } from "@/utils";
 
-import { filterRoleStatus, hasPendingRequests, orderRoleStatus, stateAccessRoles } from "../utils";
+import {
+  filterRoleStatus,
+  getConfirmationModalText,
+  hasPendingRequests,
+  orderRoleStatus,
+  stateAccessRoles,
+} from "../utils";
 
 export const MyProfile = () => {
   const { data: userDetails, isLoading: isDetailLoading } = useGetUserDetails();
@@ -36,6 +41,7 @@ export const MyProfile = () => {
 
   const { mutateAsync: submitRequest, isLoading: areRolesLoading } = useSubmitRoleRequests();
   const [selfRevokeState, setSelfRevokeState] = useState<StateCode | null>(null);
+  const [selfWithdrawPending, setSelfWithdrawPending] = useState<boolean>(false);
   const [showAddState, setShowAddState] = useState<boolean>(true);
   const [requestedStates, setRequestedStates] = useState<StateCode[]>([]);
   const [pendingRequests, setPendingRequests] = useState<boolean>(false);
@@ -186,6 +192,31 @@ export const MyProfile = () => {
       window.scrollTo(0, 0);
     }
   };
+
+  const handleRoleStatusClick = (status: string, territory: StateCode) => {
+    if (status === "pending" && isNewUserRoleDisplay) return setSelfWithdrawPending(true);
+    return setSelfRevokeState(territory);
+  };
+
+  const { dialogTitle, dialogBody, ariaLabelledBy } = getConfirmationModalText(
+    selfRevokeState,
+    selfWithdrawPending,
+  );
+
+  const handleDialogOnAccept = async () => {
+    if (selfRevokeState) await handleSelfRevokeAccess();
+    else {
+      // TODO: add in the logic to remove pending request move state change into that function
+      console.log("Withdraw pending request");
+      setSelfWithdrawPending(false);
+    }
+  };
+
+  const handleDialogOnCancel = () => {
+    setSelfRevokeState(null);
+    setSelfWithdrawPending(false);
+  };
+
   const showAllStateAccess = isNewUserRoleDisplay
     ? true
     : stateAccessRoles.includes(userDetails?.role);
@@ -225,20 +256,22 @@ export const MyProfile = () => {
                 )}
                 {/* TODO: Get state system admin for that state */}
                 <ConfirmationDialog
-                  open={selfRevokeState !== null}
-                  title="Withdraw State Access?"
-                  body={`This action cannot be undone. ${convertStateAbbrToFullName(selfRevokeState)} State System Admin will be notified.`}
+                  open={selfRevokeState !== null || selfWithdrawPending}
+                  title={dialogTitle}
+                  body={dialogBody}
                   acceptButtonText="Confirm"
-                  aria-labelledby="Self Revoke Access Modal"
-                  onAccept={handleSelfRevokeAccess}
-                  onCancel={() => setSelfRevokeState(null)}
+                  aria-labelledby={ariaLabelledBy}
+                  onAccept={handleDialogOnAccept}
+                  onCancel={handleDialogOnCancel}
                 />
                 {orderedRoleStatus?.map((access) => (
                   <RoleStatusCard
                     key={`${access.territory}-${access.role}`}
                     access={access}
                     role={userDetails.role}
-                    onClick={() => setSelfRevokeState(access.territory as StateCode)}
+                    onClick={() =>
+                      handleRoleStatusClick(access.status, access.territory as StateCode)
+                    }
                   />
                 ))}
                 {isNewUserRoleDisplay && !hideAddRoleButton ? (

--- a/react-app/src/features/profile/utils.ts
+++ b/react-app/src/features/profile/utils.ts
@@ -1,3 +1,4 @@
+import { StateCode } from "shared-types";
 import { UserRole } from "shared-types/events/legacy-user";
 
 import { StateAccess } from "@/api";
@@ -49,4 +50,33 @@ export const filterRoleStatus = (userDetails, userProfile) => {
 export const hasPendingRequests = (stateAccess) => {
   if (!stateAccess || stateAccess.length < 1) return false;
   return stateAccess.some((role) => role.status === "pending");
+};
+
+// get which confirmation text to use
+export const getConfirmationModalText = (
+  selfRevokeState: StateCode | null,
+  selfWithdrawPending: boolean,
+) => {
+  if (selfRevokeState) {
+    return {
+      dialogTitle: "Withdraw State Access?",
+      dialogBody: `This action cannot be undone. ${convertStateAbbrToFullName(
+        selfRevokeState,
+      )} State System Admin will be notified.`,
+      ariaLabelledBy: "Self Revoke Access Modal",
+    };
+  }
+  if (selfWithdrawPending) {
+    return {
+      dialogTitle: "Withdraw Role Request?",
+      dialogBody: "This role is still pending approval. Withdrawing it will cancel your request.",
+      ariaLabelledBy: "Self Withdraw Pending Access Modal",
+    };
+  }
+
+  return {
+    dialogTitle: "",
+    dialogBody: "",
+    ariaLabelledBy: "",
+  };
 };


### PR DESCRIPTION
## 🎫 Linked Ticket
https://jiraent.cms.gov/browse/OY2-35122

## 💬 Description / Notes
- added conditional rendering of 3 dots when on cms profile & pending 
- conditional rendering of the modal 
- also tried to make it easy to update when we do the same for state profile

## 📸 Screenshots / Demo
<img width="658" height="639" alt="Screenshot 2025-07-11 at 11 06 07 AM" src="https://github.com/user-attachments/assets/5bf268ab-29be-48ab-a142-0545371c525f" />
<img width="502" height="319" alt="Screenshot 2025-07-11 at 11 06 13 AM" src="https://github.com/user-attachments/assets/010d6aa1-837f-49d1-9268-769b26b13185" />

