### PR TITLE
chore(ui): added more gtag tracking info

### DIFF
--- a/react-app/globals.d.ts
+++ b/react-app/globals.d.ts
@@ -2,6 +2,7 @@ declare global {
   interface Window {
     dataLayer: any[];
     gtag: (...args: any[]) => void;
+    __gaUserRoleSet?: boolean;
   }
 }
 

--- a/react-app/src/components/ActionForm/index.tsx
+++ b/react-app/src/components/ActionForm/index.tsx
@@ -221,11 +221,16 @@ export const ActionForm = <Schema extends SchemaWithEnforcableProps>({
 
       const timeOnPageSec = (Date.now() - startTimePage) / 1000;
 
-      sendGAEvent("submission_submit_click", { package_type: formData.event });
+      sendGAEvent("submission_submit_click", { package_type: formData.event, package_id: id });
       sendGAEvent("submit_page_exit", {
         submission_type: formData.event,
         time_on_page_sec: timeOnPageSec,
       });
+      if (formData.event == "upload-subsequent-documents") {
+        sendGAEvent("upload-subsequent-documents", { package_id: id });
+      } else if (formData.event == "withdraw-package") {
+        sendGAEvent("withdraw-package", { package_id: id });
+      }
     } catch (error) {
       console.error(error);
       banner({

--- a/react-app/src/features/package/index.tsx
+++ b/react-app/src/features/package/index.tsx
@@ -6,7 +6,7 @@ import { ItemResult } from "shared-types/opensearch/changelog";
 import { getItem, useGetItem } from "@/api";
 import { CardWithTopBorder, ErrorAlert, LoadingSpinner } from "@/components";
 import { BreadCrumbs } from "@/components/BreadCrumb";
-import { detailsAndActionsCrumbs } from "@/utils";
+import { detailsAndActionsCrumbs, sendGAEvent } from "@/utils";
 
 import { AdminPackageActivities } from "./admin-changes";
 import { useDetailsSidebarLinks } from "./hooks";
@@ -148,11 +148,23 @@ type DetailsSidebarProps = {
 
 const DetailsSidebar = ({ id }: DetailsSidebarProps) => {
   const links = useDetailsSidebarLinks(id);
+  const handleSidebarClick = (linkId: string) => {
+    if (linkId === "package_activity" || linkId === "package_details") {
+      sendGAEvent("package_detail_sidebar_link_click", {
+        link: linkId,
+      });
+    }
+  };
 
   return (
     <aside className="min-w-56 flex-none font-semibold mt-6">
       {links.map(({ id, href, displayName }) => (
-        <a className="block mb-2 text-blue-900 hover:underline" key={id} href={href}>
+        <a
+          className="block mb-2 text-blue-900 hover:underline"
+          key={id}
+          href={href}
+          onClick={() => handleSidebarClick(id)}
+        >
           {displayName}
         </a>
       ))}

--- a/react-app/src/features/package/package-activity/index.tsx
+++ b/react-app/src/features/package/package-activity/index.tsx
@@ -18,16 +18,18 @@ import {
   TableRow,
 } from "@/components";
 import { BLANK_VALUE } from "@/consts";
+import { sendGAEvent } from "@/utils";
 
 import { Attachments, useAttachmentService } from "./hook";
 
 type AttachmentDetailsProps = {
   id: string;
+  packageId: string;
   attachments: opensearch.changelog.Document["attachments"];
   onClick: (attachment: Attachments[number]) => Promise<string>;
 };
 
-const AttachmentDetails = ({ id, attachments, onClick }: AttachmentDetailsProps) => (
+const AttachmentDetails = ({ id, packageId, attachments, onClick }: AttachmentDetailsProps) => (
   <TableBody>
     {attachments.map((attachment) => {
       return (
@@ -37,7 +39,13 @@ const AttachmentDetails = ({ id, attachments, onClick }: AttachmentDetailsProps)
             <Button
               className="ml-[-15px] align-left text-left min-h-fit"
               variant="link"
-              onClick={() => onClick(attachment).then(window.open)}
+              onClick={() => {
+                onClick(attachment).then(window.open);
+                sendGAEvent("attachment_download", {
+                  document_type: attachment.title,
+                  package_id: packageId,
+                });
+              }}
             >
               {attachment.filename}
             </Button>
@@ -70,7 +78,12 @@ const Submission = ({ packageActivity }: SubmissionProps) => {
               </TableRow>
             </TableHeader>
 
-            <AttachmentDetails attachments={attachments} id={id} onClick={onUrl} />
+            <AttachmentDetails
+              attachments={attachments}
+              id={id}
+              packageId={packageId}
+              onClick={onUrl}
+            />
           </Table>
         ) : (
           <p>No information submitted</p>
@@ -81,7 +94,13 @@ const Submission = ({ packageActivity }: SubmissionProps) => {
           variant="outline"
           className="w-max"
           loading={loading}
-          onClick={() => onZip(attachments)}
+          onClick={() => {
+            onZip(attachments);
+            sendGAEvent("section_attachments_download", {
+              number_attachments: attachments.length,
+              package_id: packageId,
+            });
+          }}
         >
           Download section attachments
         </Button>
@@ -177,6 +196,10 @@ const DownloadAllButton = ({ packageId, submissionChangelog }: DownloadAllButton
     }
 
     onZip(attachmentsAggregate);
+    sendGAEvent("all_attachments_download", {
+      number_attachments: attachmentsAggregate.length,
+      package_id: packageId,
+    });
   };
 
   return (


### PR DESCRIPTION
## 🎫 Linked Ticket

[OY2-35921](https://jiraent.cms.gov/browse/OY2-35921)

## 💬 Description / Notes

Adding additional data points for google analytics tracking

## 🛠 Changes

- added packageId to the `submission_submit_click` event
- if the submitted package is an "upload-subsequent-documents" type, send an `upload-subsequent-documents` event with the packageId
- if the submitted package is a "withdraw-package" type, send a `withdraw-package` event with the packageId
- if someone clicks a link in the sidebar of the package details page, send a `package_detail_sidebar_link_click` with the link name
- if someone downloads all of the attachments on the package details page, send an `all_attachments_download` event with the number of files downloaded and the packageId
- if someone downloads all of the attachments for a section on the package details page, send a `section_attachments_download` event with the number of files downloaded and the packageId
- if someone downloads a single attachment on the package details page, send an `attachment_download` with the document type and the packageId
