### PR TITLE
feat(add-ringo): Add Ringo

### DIFF
--- a/test/users/app-users.json
+++ b/test/users/app-users.json
@@ -116,7 +116,7 @@
     ]
   },
   {
-    "username": "george@example.com",
+    "username": "ringo@example.com",
     "attributes": [
       {
         "Name": "email",
@@ -136,7 +136,7 @@
       },
       {
         "Name": "custom:state",
-        "Value": "VA,OH,SC,CO,GA,MD,CA"
+        "Value": "NE"
       },
       {
         "Name": "custom:cms-roles",

--- a/test/users/app-users.json
+++ b/test/users/app-users.json
@@ -120,6 +120,35 @@
     "attributes": [
       {
         "Name": "email",
+        "Value": "ringo@example.com"
+      },
+      {
+        "Name": "given_name",
+        "Value": "Ringo"
+      },
+      {
+        "Name": "family_name",
+        "Value": "Starr"
+      },
+      {
+        "Name": "email_verified",
+        "Value": "true"
+      },
+      {
+        "Name": "custom:state",
+        "Value": "VA,OH,SC,CO,GA,MD,CA"
+      },
+      {
+        "Name": "custom:cms-roles",
+        "Value": "onemac-state-user"
+      }
+    ]
+  },
+  {
+    "username": "george@example.com",
+    "attributes": [
+      {
+        "Name": "email",
         "Value": "george@example.com"
       },
       {


### PR DESCRIPTION
# feat(users): add legendary drummer Ringo Starr as a test user 🥁✨  

## 🎫 Linked Ticket  
[Ticket to close](https://www.google.com/search?q=Ringo+Starr)  

## 💬 Description / Notes  
In a stunning twist for both software development and rock history, we’ve added Ringo Starr (yes, the one from The Beatles, not a cleverly disguised QA intern) as a test user in our system.  

This critical update ensures our app is **Beatle-tested, Beatle-approved**. Some may ask, *“Why Ringo?”* To which we reply: *“Because John, Paul, and George didn’t return our recruiter emails.”*  

This test user is perfect for scenarios where you need someone reliable to keep the tempo, show up on time, and occasionally shout “Peace and Love” into your logs.  

## 🛠 Changes  
- Added `ringo@example.com` as a test user.  
- Ensured his role is **drummer**, because obviously.  
- Gave him access to the “Octopus’s Garden” environment.  
- Denied access to “Yellow Submarine” (security concerns).  

## 📸 Screenshots / Demo  
Imagine a user list where Ringo is smiling politely while quietly wondering why he’s here.  