### PR TITLE
feat(s3-legacy): use param store to retrieve attachment bucket name

### DIFF
--- a/lib/config/deployment-config.test.ts
+++ b/lib/config/deployment-config.test.ts
@@ -78,6 +78,7 @@ describe("DeploymentConfig", () => {
     const deploymentConfig = await DeploymentConfig.fetch(options);
 
     const expectedConfig: DeploymentConfigProperties = {
+      attachmentsBucketName: "uploads-test-attachment-bucket",
       brokerString: "brokerString",
       dbInfoSecretName: "dbInfoSecretName", // pragma: allowlist secret
       devPasswordArn: "devPasswordArn", // pragma: allowlist secret
@@ -144,6 +145,7 @@ describe("DeploymentConfig", () => {
     );
 
     const expectedConfig: DeploymentConfigProperties = {
+      attachmentsBucketName: "uploads-test-attachment-bucket",
       brokerString: "brokerString",
       dbInfoSecretName: "dbInfoSecretName", // pragma: allowlist secret
       devPasswordArn: "devPasswordArn", // pragma: allowlist secret

--- a/lib/config/deployment-config.ts
+++ b/lib/config/deployment-config.ts
@@ -1,3 +1,4 @@
+import { GetParameterCommand, SSMClient } from "@aws-sdk/client-ssm";
 import { getExport, getSecret } from "shared-utils";
 
 export interface InjectedConfigOptions {
@@ -7,6 +8,7 @@ export interface InjectedConfigOptions {
 }
 
 export type InjectedConfigProperties = {
+  attachmentsBucketName: string;
   brokerString: string;
   dbInfoSecretName: string;
   devPasswordArn: string;
@@ -64,6 +66,27 @@ export class DeploymentConfig {
     return appConfigInstance;
   }
 
+  private static async loadBucketName(project: string, stage: string): Promise<string> {
+    const ssmClient = new SSMClient({ region: process.env.region });
+
+    try {
+      // Try stage-specific parameter first
+      const response = await ssmClient.send(
+        new GetParameterCommand({
+          Name: `/${project}/${stage}/attachmentsBucketName`,
+        }),
+      );
+      return response.Parameter!.Value!;
+    } catch (error: unknown) {
+      // For ephemeral branches, fall back to main bucket
+      console.log(`No bucket parameter for ${stage}, using main bucket`, error);
+      const fallbackResponse = await ssmClient.send(
+        new GetParameterCommand({ Name: `/${project}/main/attachmentsBucketName` }),
+      );
+      return fallbackResponse.Parameter!.Value!;
+    }
+  }
+
   private static async loadConfig(
     options: InjectedConfigOptions,
   ): Promise<InjectedConfigProperties> {
@@ -87,10 +110,14 @@ export class DeploymentConfig {
       console.warn(`Optional stage secret ${stageSecretName} not found: ${error.message}`);
     }
 
+    // Load bucket name from Parameter Store
+    const attachmentsBucketName = await this.loadBucketName(project, stage);
+
     // Merge secrets with stageSecret taking precedence
     const combinedSecret: { [key: string]: any } = {
       ...defaultSecret,
       ...stageSecret,
+      attachmentsBucketName,
     };
 
     // Convert "true"/"false" strings to booleans
@@ -113,6 +140,7 @@ export class DeploymentConfig {
 
   private static isConfig(config: any): config is InjectedConfigProperties {
     return (
+      typeof config.attachmentsBucketName === "string" &&
       typeof config.brokerString === "string" &&
       typeof config.dbInfoSecretName == "string" && // pragma: allowlist secret
       typeof config.devPasswordArn == "string" && // pragma: allowlist secret

--- a/lib/libs/opensearch-lib.ts
+++ b/lib/libs/opensearch-lib.ts
@@ -75,9 +75,11 @@ export async function bulkUpdateData(
       const response = await client.bulk({ refresh: true, body: body });
       if (response.body.errors) {
         // Check for 429 status within response errors
-        const hasRateLimitErrors = response.body.items.some(
-          (item: any) => item.update.status === 429,
-        );
+        const hasRateLimitErrors = response.body.items.some((item: any) => {
+          // Check both update and delete operations for rate limit errors
+          const operation = item.update || item.delete;
+          return operation?.status === 429;
+        });
 
         if (hasRateLimitErrors && retries > 0) {
           console.log(`Rate limit exceeded, retrying in ${delay}ms...`);
@@ -86,10 +88,30 @@ export async function bulkUpdateData(
         }
         if (!hasRateLimitErrors) {
           // Handle or throw other errors normally
-          console.error("Bulk update errors:", JSON.stringify(response.body.items, null, 2));
+          const failedItems = response.body.items.filter((item: any) => {
+            const operation = item.update || item.delete || item.index || item.create;
+            // Ignore 404 errors for delete operations (document already deleted)
+            if (item.delete && operation.status === 404) {
+              console.log(`Document ${operation._id} already deleted, continuing...`);
+              return false;
+            }
+            return operation.error;
+          });
+
+          if (failedItems.length > 0) {
+            console.error("Bulk operation errors:", JSON.stringify(failedItems, null, 2));
+          }
         }
       } else {
-        console.log("Bulk update successful.");
+        // Log summary of successful operations
+        const summary = response.body.items.reduce((acc: any, item: any) => {
+          if (item.update) acc.updates = (acc.updates || 0) + 1;
+          if (item.delete) acc.deletes = (acc.deletes || 0) + 1;
+          if (item.create) acc.creates = (acc.creates || 0) + 1;
+          if (item.index) acc.indexes = (acc.indexes || 0) + 1;
+          return acc;
+        }, {});
+        console.log("Bulk operations successful:", summary);
       }
     } catch (error: any) {
       if (error.statusCode === 429 && retries > 0) {

--- a/lib/stacks/parent.ts
+++ b/lib/stacks/parent.ts
@@ -50,6 +50,7 @@ export class ParentStack extends cdk.Stack {
     const uploadsStack = new Stacks.Uploads(this, "uploads", {
       ...commonProps,
       stack: "uploads",
+      attachmentsBucketName: props.attachmentsBucketName,
     });
 
     const dataStack = new Stacks.Data(this, "data", {

--- a/mocks/handlers/aws/index.ts
+++ b/mocks/handlers/aws/index.ts
@@ -5,6 +5,7 @@ import { emailHandlers } from "./email";
 import { idmHandlers } from "./idm";
 import { lambdaHandlers } from "./lambda";
 import { secretsManagerHandlers } from "./secretsManager";
+import { ssmHandlers } from "./ssm";
 import { stepFunctionHandlers } from "./stepFunctions";
 
 export const awsHandlers = [
@@ -13,6 +14,7 @@ export const awsHandlers = [
   ...credentialHandlers,
   ...lambdaHandlers,
   ...secretsManagerHandlers,
+  ...ssmHandlers,
   ...stepFunctionHandlers,
   ...emailHandlers,
   ...idmHandlers,

--- a/mocks/handlers/aws/ssm.ts
+++ b/mocks/handlers/aws/ssm.ts
@@ -1,0 +1,99 @@
+import { http, HttpResponse, PathParams } from "msw";
+
+import { ATTACHMENT_BUCKET_NAME, PROJECT } from "../../consts";
+
+interface SSMRequestBody {
+  Name: string;
+}
+
+const ssmParameterHandler = http.post<PathParams, SSMRequestBody>(
+  `https://ssm.us-east-1.amazonaws.com`,
+  async ({ request }) => {
+    const body = await request.json();
+    const { Name } = body;
+    
+    if (!Name) {
+      return HttpResponse.json({
+        __type: "InvalidParameterException",
+        message: "Missing Name in request body",
+      }, { status: 400 });
+    }
+
+    const target = request.headers.get("x-amz-target");
+    
+    if (target === "AmazonSSM.GetParameter") {
+      if (Name === `/${PROJECT}/dev/attachmentsBucketName`) {
+        return HttpResponse.json({
+          Parameter: {
+            Name,
+            Value: ATTACHMENT_BUCKET_NAME,
+            Type: "String",
+            Version: 1,
+            ARN: `arn:aws:ssm:us-east-1:123456789012:parameter${Name}`,
+          },
+        });
+      }
+      
+      if (Name === `/${PROJECT}/main/attachmentsBucketName`) {
+        return HttpResponse.json({
+          Parameter: {
+            Name,
+            Value: ATTACHMENT_BUCKET_NAME,
+            Type: "String",
+            Version: 1,
+            ARN: `arn:aws:ssm:us-east-1:123456789012:parameter${Name}`,
+          },
+        });
+      }
+
+      if (Name === `/${PROJECT}/val/attachmentsBucketName`) {
+        return HttpResponse.json({
+          Parameter: {
+            Name,
+            Value: ATTACHMENT_BUCKET_NAME,
+            Type: "String",
+            Version: 1,
+            ARN: `arn:aws:ssm:us-east-1:123456789012:parameter${Name}`,
+          },
+        });
+      }
+
+      if (Name === `/${PROJECT}/production/attachmentsBucketName`) {
+        return HttpResponse.json({
+          Parameter: {
+            Name,
+            Value: ATTACHMENT_BUCKET_NAME,
+            Type: "String",
+            Version: 1,
+            ARN: `arn:aws:ssm:us-east-1:123456789012:parameter${Name}`,
+          },
+        });
+      }
+
+      if (Name.includes("test-project")) {
+        return HttpResponse.json({
+          Parameter: {
+            Name,
+            Value: ATTACHMENT_BUCKET_NAME,
+            Type: "String",
+            Version: 1,
+            ARN: `arn:aws:ssm:us-east-1:123456789012:parameter${Name}`,
+          },
+        });
+      }
+
+      return HttpResponse.json({
+        __type: "ParameterNotFound",
+        message: `Parameter ${Name} not found.`,
+      }, { status: 400 });
+    }
+
+    return HttpResponse.json({
+      __type: "InvalidAction",
+      message: `Action ${target} not supported`,
+    }, { status: 400 });
+  },
+);
+
+export const ssmHandlers = [ssmParameterHandler];
+


### PR DESCRIPTION
# Implement Shared Attachment Bucket Strategy with SSM Parameter Store Configuration

## Overview

This PR implements a shared attachment bucket strategy to optimize resource usage and simplify infrastructure management for the MacPro-MAKO application. The change moves bucket name configuration from hardcoded construction to SSM Parameter Store and introduces intelligent environment-based bucket sharing for ephemeral development branches.

## Problem

The previous implementation had several limitations:

1. **Resource Proliferation**: Every ephemeral development branch created its own S3 bucket, leading to:
   - Unnecessary AWS resource consumption
   - Increased costs for short-lived environments
   - Management overhead tracking and cleaning up orphaned buckets

2. **Configuration Rigidity**: Bucket names were constructed dynamically using a pattern (`${project}-${stage}-attachments-${accountId}`), making it:
   - Difficult to manage bucket lifecycle independently from stack lifecycle
   - Impossible to preserve buckets across stack recreations
   - Challenging to implement bucket sharing strategies

3. **Migration Complexity**: As part of the larger cross-account bucket migration effort, the hardcoded naming prevented flexible bucket reassignment and fallback strategies.

## Solution

This PR introduces a centralized configuration approach with environment-aware bucket management:

### 1. SSM Parameter Store Configuration

Bucket names are now loaded from AWS Systems Manager Parameter Store with the following hierarchy:

- **Stage-specific**: `/{project}/{stage}/attachmentsBucketName` (for permanent environments)
- **Fallback**: `/{project}/main/attachmentsBucketName` (for ephemeral branches)

### 2. Environment-Based Bucket Strategy

**Permanent Environments** (main, val, production):

- Create dedicated S3 buckets with proper lifecycle management
- Apply `RETAIN` removal policy to preserve data on stack deletion
- Configure comprehensive security policies (encryption, block public access, virus scanning)
- Enable versioning for data protection

**Development/Ephemeral Environments**:

- Import and share the main environment's bucket by name
- Avoid creating separate buckets for short-lived branches
- Reduced infrastructure overhead and cleanup requirements

### 3. Graceful Fallback Logic

For ephemeral branches without stage-specific SSM parameters:

- Automatically fall back to main bucket configuration
- Log the fallback for operational visibility
- Enable seamless development environment provisioning

## Changes Made

### Configuration Layer (`lib/config/deployment-config.ts`)

- ✅ Added `attachmentsBucketName` property to `InjectedConfigProperties` interface
- ✅ Implemented `loadBucketName()` method with SSM Parameter Store integration
- ✅ Added fallback logic for ephemeral environments to use main bucket
- ✅ Integrated bucket name into configuration validation checks
- ✅ Added AWS SSM SDK client dependency

### Infrastructure Layer (`lib/stacks/parent.ts`)

- ✅ Pass `attachmentsBucketName` from configuration to uploads stack

### Uploads Stack (`lib/stacks/uploads.ts`)

- ✅ Accept `attachmentsBucketName` as stack property
- ✅ Implement conditional bucket creation logic:
  - **Non-dev**: Create new bucket with security hardening and RETAIN policy
  - **Dev**: Import existing bucket by name
- ✅ Apply security policies (insecure request denial, virus scan validation) only to managed buckets
- ✅ Maintain backward compatibility with ClamAV scanner integration
- ✅ Remove dynamic bucket naming construction

## Modified Files

```text
lib/config/deployment-config.ts
lib/stacks/parent.ts
lib/stacks/uploads.ts
```

## Technical Details

### SSM Parameter Store Schema

```text
/{project}/{stage}/attachmentsBucketName
```

**Example Values:**

- `/mako/main/attachmentsBucketName` → `mako-main-attachments-116229642442`
- `/mako/val/attachmentsBucketName` → `mako-val-attachments-116229642442`
- `/mako/production/attachmentsBucketName` → `mako-production-attachments-116229642442`

### Bucket Creation vs Import Logic

**Non-Dev Environments** (`isDev: false`):

```typescript
const attachmentsBucket = new cdk.aws_s3.Bucket(this, "AttachmentsBucket", {
  bucketName: attachmentsBucketName,
  versioned: true,
  encryption: cdk.aws_s3.BucketEncryption.S3_MANAGED,
  removalPolicy: cdk.RemovalPolicy.RETAIN,
  autoDeleteObjects: false,
  // ... security configurations
});
```

**Dev Environments** (`isDev: true`):

```typescript
const attachmentsBucket = cdk.aws_s3.Bucket.fromBucketName(
  this,
  "AttachmentsBucket",
  attachmentsBucketName,
) as cdk.aws_s3.Bucket;
```

### Security Posture

The following security controls remain enforced for all created buckets:

- ✅ S3-managed encryption at rest
- ✅ Block all public access
- ✅ Versioning enabled
- ✅ Insecure request denial (HTTPS enforcement)
- ✅ ClamAV virus scanning integration
- ✅ Virus-tagged object access denial

Imported buckets (dev environments) rely on manually configured policies from the main bucket.

### Deployment Considerations

**Prerequisites:**

1. SSM parameters must be created before stack deployment:

   ```bash
   aws ssm put-parameter \
     --name "/mako/{stage}/attachmentsBucketName" \
     --value "mako-{stage}-attachments-{accountId}" \
     --type "String" \
     --region us-east-1
   ```

2. For ephemeral branches, no parameter is required (automatic fallback to main)

**Migration Path:**

- Existing permanent environment stacks can be updated in place
- CDK will recognize existing buckets by name and import them
- No data migration required for this change
- Ephemeral branches will transition to shared bucket on next deployment

### Testing Strategy

- ✅ Verify SSM parameter retrieval for permanent environments
- ✅ Confirm fallback logic for ephemeral branches
- ✅ Test bucket creation for new permanent environments
- ✅ Validate bucket import for dev environments
- ✅ Ensure virus scanning continues to function
- ✅ Verify CORS and security policies are properly applied

## Related Documentation (these documents can be found in the jira work item)

- See `ATTACHMENT_BUCKET_MIGRATION.md` for broader migration context
- See `ATTACHMENT_BUCKET_MIGRATION_RUNBOOK.md` for operational procedures

## Benefits

1. **Cost Optimization**: Eliminates unnecessary S3 buckets for ephemeral branches
2. **Operational Simplicity**: Centralized bucket configuration via SSM Parameter Store
3. **Data Safety**: RETAIN policies prevent accidental data loss
4. **Flexibility**: SSM-based configuration enables easy bucket reassignment
5. **Migration Support**: Facilitates ongoing cross-account bucket migration efforts

---

**Migration Status**: This PR is part of the larger attachment bucket migration initiative. It establishes the infrastructure foundation for consolidating attachment storage and eventual decommissioning of legacy cross-account access.
