### PR TITLE
fix(sechub update): move attachment-archive worker to alpine bun image

### DIFF
--- a/lib/attachment-archive/Dockerfile
+++ b/lib/attachment-archive/Dockerfile
@@ -1,9 +1,9 @@
-FROM oven/bun:1.3.11
+FROM oven/bun:1.3.11-alpine
 
 # Refresh base OS packages so rebuilt images pick up available security fixes.
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk update \
+    && apk upgrade \
+    && rm -rf /var/cache/apk/*
 
 WORKDIR /app
 


### PR DESCRIPTION
## 💬 Description / Notes
This PR updates the attachment-archive worker image to use the Alpine Bun base image instead of the Debian Bun base image.


## 🛠 Changes
- Switch the base image from oven/bun:1.3.11 to oven/bun:1.3.11-alpine
- Replace the Debian package refresh step with the Alpine equivalent using apk
