### PR TITLE
fix(clamAV ): remove vulnerable runtime artifacts from ClamAV image

### DIFF
--- a/lib/local-constructs/clamav-scanning/Dockerfile
+++ b/lib/local-constructs/clamav-scanning/Dockerfile
@@ -28,7 +28,12 @@ RUN (dnf install -y clamav clamd || microdnf install -y clamav clamd || yum inst
     # npm is not required to execute the bundled Lambda handlers and keeping it
     # in the runtime image leaves known vulnerable transitive packages behind.
     && rm -rf /var/lang/lib/node_modules/npm \
-    && rm -f /var/lang/bin/npm /var/lang/bin/npx /usr/local/bin/npm /usr/local/bin/npx
+    && rm -f /var/lang/bin/npm /var/lang/bin/npx /usr/local/bin/npm /usr/local/bin/npx \
+    # The handlers are bundled with their own AWS SDK dependencies, so the
+    # runtime-provided SDK is unused and can leave stale vulnerable packages.
+    && rm -rf /var/runtime/node_modules/@aws-sdk \
+    # RIE is only needed for local container emulation, not in Lambda.
+    && rm -f /usr/local/bin/aws-lambda-rie
 
 COPY --from=builder ${LAMBDA_TASK_ROOT}/dist ./dist
 COPY src/conf/clamd.conf /etc/clamd.d/scan.conf

--- a/lib/local-constructs/clamav-scanning/index.ts
+++ b/lib/local-constructs/clamav-scanning/index.ts
@@ -153,7 +153,7 @@ export class ClamScanScanner extends Construct {
     const clamscanDefsLogGroup = new logs.LogGroup(this, `${id}ClamDefsLogGroup`, {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
-    const clamAvImageCacheBust = "2026-04-06-runtime-without-npm";
+    const clamAvImageCacheBust = "2026-04-16-remove-base-runtime-vuln-artifacts";
 
     const clamDefsLambda = new DockerImageFunction(this, "ServerlessClamDefs", {
       code: DockerImageCode.fromImageAsset(__dirname, {


### PR DESCRIPTION
## 💬 Description / Notes
This PR updates the ClamAV Lambda container image to remove unused vulnerable artifacts inherited from the AWS Lambda Node.js base image.

## 🛠 Changes
Updated Dockerfile to remove:

/var/runtime/node_modules/@aws-sdk
/usr/local/bin/aws-lambda-rie

Updated index.ts to bump the ClamAV image cache-bust value so CDK publishes a fresh image digest on deploy.

