### PR TITLE
Script to export elastic search index to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ The upgraded OneMAC system streamlines the submission process for state users, e
 
 All documentation can be found on the [GitHub Wiki pages](https://github.com/Enterprise-CMCS/macpro-mako/wiki).
 
+## Operational Scripts
+
+### OpenSearch Data Export
+
+For exporting production OpenSearch data to S3, see the [export script documentation](scripts/export-index.md). This script is designed to run in AWS CloudShell with VPC connectivity to your OpenSearch domain.
+
 ## Contributing
 
 Work items for this project are tracked in Jira. Check out the [project kanban board](https://qmacbis.atlassian.net/jira/software/c/projects/OY2/boards/257) to view all work items affecting this repo.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:mocks": "(cd mocks && bun run build)",
     "build:ui": "(cd react-app && bun run build)",
     "repair:attachment-scan-status": "tsx scripts/repair-attachment-scan-status.ts",
+    "export:opensearch": "tsx scripts/export-opensearch-to-s3.ts",
     "watch": "tsc -w",
     "cdk": "cdk",
     "build:cli": "turbo build:cli",

--- a/scripts/export-index.md
+++ b/scripts/export-index.md
@@ -1,0 +1,146 @@
+# OpenSearch to S3 Export Script
+
+This script exports all production OpenSearch indexes to S3 as JSON files. It's designed to run in AWS CloudShell with VPC connectivity to your OpenSearch domain.
+
+## Prerequisites
+
+- AWS CloudShell with VPC connectivity to the OpenSearch domain
+- Appropriate IAM permissions for:
+  - Reading from OpenSearch domain
+  - Writing to S3 bucket
+  - Getting caller identity (STS)
+
+## Setup Instructions
+
+### 1. Login to AWS CloudShell
+
+- Open AWS CloudShell in your browser
+- Ensure you have VPC connectivity to your OpenSearch domain
+
+### 2. Clone the Repository
+
+```bash
+git clone https://github.com/Enterprise-CMCS/macpro-mako.git
+cd macpro-mako
+```
+
+### 3. Install Dependencies
+
+```bash
+# Install Node.js dependencies using npm (CloudShell default)
+npm install
+
+# If Bun is available and preferred
+# bun install
+```
+
+### 4. Run the Export Script
+
+```bash
+# Basic export to S3 bucket (uses default key prefix: opensearch-exports/yyyy-mm-dd)
+npx tsx scripts/export-index.ts --bucket your-s3-bucket-name --domain https://vpc-domain.us-east-1.es.amazonaws.com
+
+# With custom options
+npx tsx scripts/export-index.ts \
+  --bucket your-s3-bucket-name \
+  --domain https://vpc-domain.us-east-1.es.amazonaws.com \
+  --key-prefix "opensearch-exports/2024-04-28" \
+  --batch-size 2000
+```
+
+## Script Parameters
+
+| Parameter      | Required | Description                    | Default                    |
+| -------------- | -------- | ------------------------------ | -------------------------- |
+| `--bucket`     | Yes      | S3 bucket name for export      | None                       |
+| `--domain`     | Yes      | OpenSearch domain URL          | None                       |
+| `--batch-size` | No       | Batch size for scrolling       | 1000 (main), 5000 (others) |
+| `--key-prefix` | No       | S3 key prefix for files        | `opensearch-exports/yyyy-mm-dd` |
+| `--help`       | No       | Show usage information         | -                          |
+
+## Exported Indexes
+
+The script exports these production indexes:
+
+- `productionmain` - Package/submission records
+- `productionchangelog` - Package activity/history
+- `productiontypes` - SPA type reference data
+- `productionsubtypes` - Subtype reference data
+- `productioncpocs` - CPOC officer data
+- `productioninsights` - Insights sink data
+- `productionlegacyinsights` - Legacy insights sink data
+- `productionusers` - User profile/user records
+- `productionroles` - User role requests/status records
+
+## Output Format
+
+Each index is exported as a JSON file containing an array of document objects (just the `_source` data):
+
+```json
+[
+  { "id": "123", "field1": "value1", ... },
+  { "id": "456", "field2": "value2", ... },
+  ...
+]
+```
+
+S3 object metadata includes:
+
+- `sourceIndex`: Original OpenSearch index name
+- `exportedAt`: ISO timestamp of export
+- `documentCount`: Number of documents in the file
+
+## Example Usage
+
+```bash
+# Export with default key prefix (opensearch-exports/yyyy-mm-dd)
+npx tsx scripts/export-index.ts \
+  --bucket my-data-exports \
+  --domain https://vpc-domain.us-east-1.es.amazonaws.com
+
+# Export with custom organized S3 keys
+npx tsx scripts/export-index.ts \
+  --bucket my-data-exports \
+  --domain https://vpc-domain.us-east-1.es.amazonaws.com \
+  --key-prefix "custom-exports/2024/04/28"
+
+# Default creates files like:
+# s3://my-data-exports/opensearch-exports/2024-04-28/productionmain.json
+# s3://my-data-exports/opensearch-exports/2024-04-28/productionchangelog.json
+# etc.
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"OpenSearch domain URL is required"**
+   - Make sure you provide the `--domain` parameter with the full HTTPS URL
+   - Example: `--domain https://vpc-domain.us-east-1.es.amazonaws.com`
+
+2. **Network connectivity errors**
+   - Ensure CloudShell has VPC connectivity to your OpenSearch domain
+   - Verify the domain endpoint URL is correct and accessible
+
+3. **Permission errors**
+   - Verify your CloudShell role has permissions to read from OpenSearch
+   - Ensure S3 write permissions for the target bucket
+
+4. **Module not found errors**
+   - Run `npm install` to install dependencies
+   - Verify you're in the correct directory (`macpro-mako`)
+
+### Performance Notes
+
+- The `main` index uses smaller batches (1000) as it's typically the largest
+- Other indexes use larger batches (5000) for faster processing
+- Adjust `--batch-size` if you encounter memory issues or timeouts
+- Large exports may take significant time - the script shows progress updates
+
+## Security Considerations
+
+- The script uses CloudShell's automatic role-based authentication
+- OpenSearch domain URL is passed as a parameter (not stored)
+- No credentials are stored or logged
+- S3 object metadata preserves audit trail information
+- Consider bucket policies and access controls for exported data

--- a/scripts/export-index.ts
+++ b/scripts/export-index.ts
@@ -1,0 +1,309 @@
+#!/usr/bin/env tsx
+
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { GetCallerIdentityCommand, STSClient } from "@aws-sdk/client-sts";
+import type { Client } from "@opensearch-project/opensearch";
+
+import { getClient } from "../lib/libs/opensearch-lib";
+
+interface ExportOptions {
+  bucket: string;
+  domain: string;
+  batchSize?: number;
+  keyPrefix?: string;
+}
+
+interface ScrollResponse {
+  _scroll_id?: string;
+  hits: {
+    hits: Array<{ _source: unknown }>;
+    total: {
+      value: number;
+      relation: string;
+    };
+  };
+}
+
+const INDEXES_TO_EXPORT = [
+  "productionmain",
+  "productionchangelog",
+  "productiontypes",
+  "productionsubtypes",
+  "productioncpocs",
+  "productioninsights",
+  "productionlegacyinsights",
+  "productionusers",
+  "productionroles",
+] as const;
+
+class OpenSearchExporter {
+  private s3Client: S3Client;
+  private osClient: Client | null = null;
+  private domain: string;
+  private options: ExportOptions;
+
+  constructor(options: ExportOptions) {
+    this.options = options;
+    this.s3Client = new S3Client({});
+    this.domain = options.domain;
+  }
+
+  private async getOSClient(): Promise<Client> {
+    if (!this.osClient) {
+      this.osClient = await getClient(this.domain);
+    }
+    return this.osClient;
+  }
+
+  private async *scrollSearch(
+    indexName: string,
+    batchSize: number = 1000,
+  ): AsyncGenerator<unknown[], void, unknown> {
+    const client = await this.getOSClient();
+
+    console.log(`Starting scroll search for index: ${indexName}`);
+
+    // Initial search with scroll
+    const initialResponse = (await client.search({
+      index: indexName,
+      scroll: "2m", // Keep scroll context for 2 minutes
+      size: batchSize,
+      body: {
+        query: { match_all: {} },
+      },
+    })) as unknown as ScrollResponse;
+
+    let hits = initialResponse.hits.hits;
+    let scrollId = initialResponse._scroll_id;
+    let totalRetrieved = hits.length;
+
+    console.log(`Total documents in ${indexName}: ${initialResponse.hits.total.value}`);
+    console.log(`Retrieved batch 1: ${hits.length} documents`);
+
+    if (hits.length > 0) {
+      yield hits.map((hit) => hit._source);
+    }
+
+    // Continue scrolling while there are more results
+    while (hits.length > 0 && scrollId) {
+      const scrollResponse = (await client.scroll({
+        scroll_id: scrollId,
+        scroll: "2m",
+      })) as unknown as ScrollResponse;
+
+      hits = scrollResponse.hits.hits;
+      scrollId = scrollResponse._scroll_id;
+      totalRetrieved += hits.length;
+
+      if (hits.length > 0) {
+        console.log(`Retrieved batch: ${hits.length} documents (total: ${totalRetrieved})`);
+        yield hits.map((hit) => hit._source);
+      }
+    }
+
+    // Clear scroll context
+    if (scrollId) {
+      try {
+        await client.clearScroll({
+          scroll_id: scrollId,
+        });
+      } catch (error) {
+        console.warn(`Warning: Failed to clear scroll context: ${error}`);
+      }
+    }
+
+    console.log(`Completed scrolling ${indexName}. Total documents retrieved: ${totalRetrieved}`);
+  }
+
+  private async exportIndexToS3(indexName: string): Promise<void> {
+    console.log(`\n=== Exporting ${indexName} ===`);
+
+    const allDocuments: unknown[] = [];
+
+    try {
+      const batchSize = this.options.batchSize || (indexName === "productionmain" ? 1000 : 5000);
+
+      for await (const batch of this.scrollSearch(indexName, batchSize)) {
+        allDocuments.push(...batch);
+      }
+
+      console.log(`Total documents collected for ${indexName}: ${allDocuments.length}`);
+
+      // Upload to S3
+      const s3Key = this.options.keyPrefix
+        ? `${this.options.keyPrefix}/${indexName}.json`
+        : `${indexName}.json`;
+
+      console.log(`Uploading ${indexName}.json to S3...`);
+
+      const putCommand = new PutObjectCommand({
+        Bucket: this.options.bucket,
+        Key: s3Key,
+        Body: JSON.stringify(allDocuments, null, 2),
+        ContentType: "application/json",
+        Metadata: {
+          sourceIndex: indexName,
+          exportedAt: new Date().toISOString(),
+          documentCount: allDocuments.length.toString(),
+        },
+      });
+
+      await this.s3Client.send(putCommand);
+      console.log(`✅ Successfully exported ${indexName} to s3://${this.options.bucket}/${s3Key}`);
+      console.log(`   Documents: ${allDocuments.length}`);
+    } catch (error) {
+      console.error(`❌ Failed to export ${indexName}:`, error);
+      throw error;
+    }
+  }
+
+  async exportAll(): Promise<void> {
+    // Verify AWS credentials and S3 access
+    console.log("Verifying AWS credentials...");
+    const stsClient = new STSClient({});
+    const identity = await stsClient.send(new GetCallerIdentityCommand({}));
+    console.log(`✅ Authenticated as: ${identity.Arn}`);
+
+    console.log(`Starting OpenSearch export to S3 bucket: ${this.options.bucket}`);
+    console.log(`OpenSearch domain: ${this.domain}`);
+
+    const startTime = Date.now();
+    let successCount = 0;
+    let errorCount = 0;
+
+    for (const indexName of INDEXES_TO_EXPORT) {
+      try {
+        await this.exportIndexToS3(indexName);
+        successCount++;
+      } catch (error) {
+        console.error(`Failed to export ${indexName}:`, error);
+        errorCount++;
+      }
+    }
+
+    const duration = (Date.now() - startTime) / 1000;
+    console.log(`\n=== Export Summary ===`);
+    console.log(`Total time: ${duration.toFixed(2)} seconds`);
+    console.log(`Successful exports: ${successCount}`);
+    console.log(`Failed exports: ${errorCount}`);
+    console.log(`S3 bucket: ${this.options.bucket}`);
+
+    if (errorCount > 0) {
+      process.exit(1);
+    }
+  }
+}
+
+function parseArgs(argv: string[]): ExportOptions {
+  let bucket = "";
+  let domain = "";
+  let batchSize: number | undefined;
+  let keyPrefix: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    switch (arg) {
+      case "-b":
+      case "--bucket":
+        bucket = argv[index + 1] || "";
+        index += 1;
+        break;
+      case "-d":
+      case "--domain":
+        domain = argv[index + 1] || "";
+        index += 1;
+        break;
+      case "--batch-size": {
+        const parsed = Number.parseInt(argv[index + 1] || "", 10);
+        if (Number.isFinite(parsed) && parsed > 0) {
+          batchSize = parsed;
+        }
+        index += 1;
+        break;
+      }
+      case "--key-prefix":
+        keyPrefix = argv[index + 1];
+        index += 1;
+        break;
+      case "--help":
+      case "-h":
+        printUsage();
+        process.exit(0);
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (!bucket) {
+    console.error("Error: S3 bucket name is required");
+    printUsage();
+    process.exit(1);
+  }
+
+  if (!domain) {
+    console.error("Error: OpenSearch domain URL is required");
+    printUsage();
+    process.exit(1);
+  }
+
+  return {
+    bucket,
+    domain,
+    batchSize,
+    keyPrefix: keyPrefix || `opensearch-exports/${new Date().toISOString().split("T")[0]}`,
+  };
+}
+
+function printUsage() {
+  console.log(`
+Usage: tsx scripts/export-index.ts [OPTIONS]
+
+Export OpenSearch production indexes to S3 as JSON files
+
+OPTIONS:
+  -b, --bucket <bucket>           S3 bucket name for export (required)
+  -d, --domain <domain>           OpenSearch domain URL (required)
+  --batch-size <size>             Batch size for scrolling (default: 1000 for main, 5000 for others)
+  --key-prefix <prefix>           S3 key prefix for exported files
+  -h, --help                      Show this help message
+
+EXAMPLES:
+  tsx scripts/export-index.ts --bucket my-export-bucket --domain https://vpc-domain.us-east-1.es.amazonaws.com
+  tsx scripts/export-index.ts --bucket my-bucket --domain https://vpc-domain.us-east-1.es.amazonaws.com --key-prefix opensearch-exports/2024-04-28
+`);
+}
+
+async function main(): Promise<void> {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+
+    const exporter = new OpenSearchExporter(options);
+    await exporter.exportAll();
+  } catch (error) {
+    console.error("Export failed:", error);
+    process.exit(1);
+  }
+}
+
+// Handle graceful shutdown
+process.on("SIGINT", () => {
+  console.log("\n⚠️  Export interrupted by user");
+  process.exit(130);
+});
+
+process.on("uncaughtException", (error) => {
+  console.error("Uncaught exception:", error);
+  process.exit(1);
+});
+
+process.on("unhandledRejection", (reason, promise) => {
+  console.error("Unhandled rejection at:", promise, "reason:", reason);
+  process.exit(1);
+});
+
+main().catch((error) => {
+  console.error("Export failed:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
This is a script to export data in elastic search to S3 bucket. Due to lack of connectivity, we may have to execute this from cloudshell, which is fine as this script is intended for data migration efforts that Shamu is leading. 