### PR TITLE
feat(archive): enable integrity exception registry for production

### DIFF
--- a/lib/stacks/api.integrity-schedule.test.ts
+++ b/lib/stacks/api.integrity-schedule.test.ts
@@ -130,7 +130,7 @@ describe("Api attachment archive integrity scheduling", () => {
     template.resourceCountIs("AWS::Scheduler::Schedule", 0);
   });
 
-  it("only enables the exception registry for the val integrity lambda", () => {
+  it("enables the integrity exception registry for val and production lambdas", () => {
     const valEnvironment = buildAttachmentArchiveIntegrityRunEnvironment({
       stage: "val",
       openSearchDomainEndpoint: "search-test-domain.us-east-1.es.amazonaws.com",
@@ -143,17 +143,27 @@ describe("Api attachment archive integrity scheduling", () => {
       "archive-integrity/val/exception-registry.json",
     );
 
-    for (const stage of ["main", "production"] as const) {
-      const environment = buildAttachmentArchiveIntegrityRunEnvironment({
-        stage,
-        openSearchDomainEndpoint: "search-test-domain.us-east-1.es.amazonaws.com",
-        indexNamespace: stage,
-        archiveWriteBucketName: `mako-${stage}-attachment-archives-123456789012`,
-        archiveBaseReadBucketName: `mako-${stage}-attachment-archives-123456789012`,
-        archiveOverlayPrefix: "",
-      });
-      expect(environment).not.toHaveProperty("ATTACHMENT_ARCHIVE_INTEGRITY_EXCEPTION_KEY");
-    }
+    const productionEnvironment = buildAttachmentArchiveIntegrityRunEnvironment({
+      stage: "production",
+      openSearchDomainEndpoint: "search-test-domain.us-east-1.es.amazonaws.com",
+      indexNamespace: "production",
+      archiveWriteBucketName: "mako-production-attachment-archives-123456789012",
+      archiveBaseReadBucketName: "mako-production-attachment-archives-123456789012",
+      archiveOverlayPrefix: "",
+    });
+    expect(productionEnvironment.ATTACHMENT_ARCHIVE_INTEGRITY_EXCEPTION_KEY).toBe(
+      "archive-integrity/production/exception-registry.json",
+    );
+
+    const mainEnvironment = buildAttachmentArchiveIntegrityRunEnvironment({
+      stage: "main",
+      openSearchDomainEndpoint: "search-test-domain.us-east-1.es.amazonaws.com",
+      indexNamespace: "main",
+      archiveWriteBucketName: "mako-main-attachment-archives-123456789012",
+      archiveBaseReadBucketName: "mako-main-attachment-archives-123456789012",
+      archiveOverlayPrefix: "",
+    });
+    expect(mainEnvironment).not.toHaveProperty("ATTACHMENT_ARCHIVE_INTEGRITY_EXCEPTION_KEY");
   });
 
   it("grants the archive worker list access to the stage attachment bucket", () => {

--- a/lib/stacks/attachment-archive-integrity.ts
+++ b/lib/stacks/attachment-archive-integrity.ts
@@ -6,9 +6,17 @@ import { isSharedArchiveStage } from "./archive-bucket-routing";
 export const ATTACHMENT_ARCHIVE_INTEGRITY_REPORT_PREFIX = "archive-integrity";
 export const ATTACHMENT_ARCHIVE_INTEGRITY_VAL_EXCEPTION_KEY =
   "archive-integrity/val/exception-registry.json";
+export const ATTACHMENT_ARCHIVE_INTEGRITY_PRODUCTION_EXCEPTION_KEY =
+  "archive-integrity/production/exception-registry.json";
 
 export function getAttachmentArchiveIntegrityExceptionKey(stage: string): string | undefined {
-  return stage === "val" ? ATTACHMENT_ARCHIVE_INTEGRITY_VAL_EXCEPTION_KEY : undefined;
+  if (stage === "val") {
+    return ATTACHMENT_ARCHIVE_INTEGRITY_VAL_EXCEPTION_KEY;
+  }
+  if (stage === "production") {
+    return ATTACHMENT_ARCHIVE_INTEGRITY_PRODUCTION_EXCEPTION_KEY;
+  }
+  return undefined;
 }
 
 export function shouldCreateAttachmentArchiveIntegritySchedule(


### PR DESCRIPTION
## Summary

Mirrors the val integrity exception-registry pattern to the production stage, so the daily attachment-archive integrity check (`mako-production-api-attachment-archive-integrity` Step Function) can suppress known-terminal scope failures (`ATTACHMENT_NOT_CLEAN` / `ALL_ATTACHMENTS_UNAVAILABLE`) and keep the alert email actionable.

- Adds `ATTACHMENT_ARCHIVE_INTEGRITY_PRODUCTION_EXCEPTION_KEY = "archive-integrity/production/exception-registry.json"` and threads it through `getAttachmentArchiveIntegrityExceptionKey` so the production integrity lambda gets `ATTACHMENT_ARCHIVE_INTEGRITY_EXCEPTION_KEY` in its env (val behaviour unchanged).
- Updates `lib/stacks/api.integrity-schedule.test.ts` so the previously-named "only enables ... for the val integrity lambda" assertion now covers both val and production positively, and still asserts other stages stay opted-out.

## Companion data (already in place)

The actual registry JSON has already been generated and uploaded to S3:

```
s3://mako-production-attachment-archives-591572556330/archive-integrity/production/exception-registry.json
```

Seeded from the 2026-04-29 manual integrity remediation run `1777458415240-1d151380`. 170 entries (106 section-scope + 64 package-scope, all `ATTACHMENT_NOT_CLEAN`) covering:
- 12 real terminally-failed packages: `CO-25-0016`, `CO-25-0023`, `DC-24-0025`, `IA-25-0011`, `NC-25-0019..NC-25-0024`, `VA-25-0016`, `WA-25-0010` (all blocked by virus-scan UKNOWNEXT/EXTMISMATCH on specific .docx/.xlsx/.DOC files)
- 52 ZZ-* test/sandbox packages with the same pattern

The production integrity lambda silently ignores the registry env until this PR ships, so the upload is harmless until then.

## Expected effect

Once this deploys, the next scheduled production integrity run should drop from today's baseline (`667 discrepancies / 0 exceptions`) to roughly:
- `~135 discrepancies` — residual hash-mismatch / package_section_hash_mismatch rows from withdrawn `-del` packages and ZZ-* test packages, which the existing registry mechanism does not cover (it only suppresses NOT_READY/ZIP_MISSING for terminal failures).
- `~170 exceptions` — the entries above.

A follow-up improvement to also silence HASH_MISMATCH for known-noisy packageIds is tracked separately and can be done after this lands.

## Test plan

- [x] `bun run test --run lib/stacks/api.integrity-schedule.test.ts` (7/7 pass)
- [x] `bun run test --run lib/lambda/runAttachmentArchiveIntegrityCheck.test.ts lib/lambda/notifyAttachmentArchiveIntegrity.test.ts` (15/15 pass)
- [x] `bun run lint`
- [ ] After merge to main -> val -> production, the next 02:00 ET scheduled integrity run should reflect the expected discrepancy/exception counts above.
