### PR TITLE
feat(archive): enable integrity exception registry for production

### DIFF
--- a/lib/stacks/api.integrity-schedule.test.ts
+++ b/lib/stacks/api.integrity-schedule.test.ts
@@ -130,7 +130,7 @@ describe("Api attachment archive integrity scheduling", () => {
     template.resourceCountIs("AWS::Scheduler::Schedule", 0);
   });
 
-  it("only enables the exception registry for the val integrity lambda", () => {
+  it("enables the integrity exception registry for val and production lambdas", () => {
     const valEnvironment = buildAttachmentArchiveIntegrityRunEnvironment({
       stage: "val",
       openSearchDomainEndpoint: "search-test-domain.us-east-1.es.amazonaws.com",
@@ -143,17 +143,27 @@ describe("Api attachment archive integrity scheduling", () => {
       "archive-integrity/val/exception-registry.json",
     );
 
-    for (const stage of ["main", "production"] as const) {
-      const environment = buildAttachmentArchiveIntegrityRunEnvironment({
-        stage,
-        openSearchDomainEndpoint: "search-test-domain.us-east-1.es.amazonaws.com",
-        indexNamespace: stage,
-        archiveWriteBucketName: `mako-${stage}-attachment-archives-123456789012`,
-        archiveBaseReadBucketName: `mako-${stage}-attachment-archives-123456789012`,
-        archiveOverlayPrefix: "",
-      });
-      expect(environment).not.toHaveProperty("ATTACHMENT_ARCHIVE_INTEGRITY_EXCEPTION_KEY");
-    }
+    const productionEnvironment = buildAttachmentArchiveIntegrityRunEnvironment({
+      stage: "production",
+      openSearchDomainEndpoint: "search-test-domain.us-east-1.es.amazonaws.com",
+      indexNamespace: "production",
+      archiveWriteBucketName: "mako-production-attachment-archives-123456789012", // pragma: allowlist secret
+      archiveBaseReadBucketName: "mako-production-attachment-archives-123456789012", // pragma: allowlist secret
+      archiveOverlayPrefix: "",
+    });
+    expect(productionEnvironment.ATTACHMENT_ARCHIVE_INTEGRITY_EXCEPTION_KEY).toBe(
+      "archive-integrity/production/exception-registry.json",
+    );
+
+    const mainEnvironment = buildAttachmentArchiveIntegrityRunEnvironment({
+      stage: "main",
+      openSearchDomainEndpoint: "search-test-domain.us-east-1.es.amazonaws.com",
+      indexNamespace: "main",
+      archiveWriteBucketName: "mako-main-attachment-archives-123456789012",
+      archiveBaseReadBucketName: "mako-main-attachment-archives-123456789012",
+      archiveOverlayPrefix: "",
+    });
+    expect(mainEnvironment).not.toHaveProperty("ATTACHMENT_ARCHIVE_INTEGRITY_EXCEPTION_KEY");
   });
 
   it("grants the archive worker list access to the stage attachment bucket", () => {

--- a/lib/stacks/attachment-archive-integrity.ts
+++ b/lib/stacks/attachment-archive-integrity.ts
@@ -6,9 +6,17 @@ import { isSharedArchiveStage } from "./archive-bucket-routing";
 export const ATTACHMENT_ARCHIVE_INTEGRITY_REPORT_PREFIX = "archive-integrity";
 export const ATTACHMENT_ARCHIVE_INTEGRITY_VAL_EXCEPTION_KEY =
   "archive-integrity/val/exception-registry.json";
+export const ATTACHMENT_ARCHIVE_INTEGRITY_PRODUCTION_EXCEPTION_KEY =
+  "archive-integrity/production/exception-registry.json";
 
 export function getAttachmentArchiveIntegrityExceptionKey(stage: string): string | undefined {
-  return stage === "val" ? ATTACHMENT_ARCHIVE_INTEGRITY_VAL_EXCEPTION_KEY : undefined;
+  if (stage === "val") {
+    return ATTACHMENT_ARCHIVE_INTEGRITY_VAL_EXCEPTION_KEY;
+  }
+  if (stage === "production") {
+    return ATTACHMENT_ARCHIVE_INTEGRITY_PRODUCTION_EXCEPTION_KEY;
+  }
+  return undefined;
 }
 
 export function shouldCreateAttachmentArchiveIntegritySchedule(


### PR DESCRIPTION
Mirrors the val integrity exception registry pattern to the production stage so the daily integrity check can suppress known-terminal scope failures (ATTACHMENT_NOT_CLEAN / ALL_ATTACHMENTS_UNAVAILABLE) and keep the alert email actionable.

The companion production registry seeded from the 2026-04-29 integrity remediation run (170 entries: 106 section + 64 package, all ATTACHMENT_NOT_CLEAN) lives at
s3://mako-production-attachment-archives-591572556330/archive-integrity/production/exception-registry.json.

Once this PR deploys to production the next scheduled integrity run should drop from ~667 discrepancies / 0 exceptions to ~135 discrepancies (the residual hash-mismatch noise from withdrawn -del / ZZ-* test packages, which the existing registry mechanism does not cover) / ~170 exceptions.

Made-with: Cursor

<!--
TODO for PR Author:
- Would your work benefit from unit tests?
- Have you formatted your files using Prettier/ESLint?
- Delete any irrelevant sections below before opening the pull request
- title your PR using the angular commit convention -> https://www.conventionalcommits.org/en/v1.0.0/
  type-of-changes(scope-in-codebase): distilled description of changes
  e.g. feat/fix/test(ui/api/lib): refactor Hello World console log
-->

## 🎫 Linked Ticket

<!-- Link to the JIRA ticket to track this work -->

[Ticket to close](link-to-ticket)

## 💬 Description / Notes

<!-- Briefly describe the background of the issue -->
<!-- If you feel the original ticket lacks important details, this would be the place to share them -->

## 🛠 Changes

<!-- List your code changes made to implement the solution -->

## 📸 Screenshots / Demo

<!-- ### Before -->

<!-- ### After -->
