### PR TITLE
fix(404-lookup-number): prevent item lookup false negatives for 404 text

### DIFF
--- a/react-app/src/api/useGetItem.test.ts
+++ b/react-app/src/api/useGetItem.test.ts
@@ -105,6 +105,25 @@ describe("zod schema helpers", () => {
       await expect(unit.getItem("TEST_ID")).resolves.toBeUndefined();
     });
 
+    it("returns a found item when package content contains a 404 phone area code", async () => {
+      const packageResponse = {
+        found: true,
+        _id: "GA-25-0015",
+        _source: {
+          id: "GA-25-0015",
+          additionalInformation: "Please contact Perri Nena Smith at (404) 805-6716.",
+        },
+      };
+
+      mockedServer.use(
+        http.post("https://test-domain.execute-api.us-east-1.amazonaws.com/mocked-tests/item", () =>
+          HttpResponse.json(packageResponse),
+        ),
+      );
+
+      await expect(unit.getItem("GA-25-0015")).resolves.toEqual(packageResponse);
+    });
+
     it("should call sendGAEvent when the API throws an error", async () => {
       mockedServer.use(errorApiItemHandler);
 

--- a/react-app/src/api/useGetItem.ts
+++ b/react-app/src/api/useGetItem.ts
@@ -97,6 +97,10 @@ const isNotFoundItemPayload = (value: unknown): boolean => {
     statusCode?: number;
   };
 
+  if (candidate?.found === true && candidate?._source) {
+    return false;
+  }
+
   const responseStatus =
     candidate?.response?.status ??
     candidate?.response?.statusCode ??


### PR DESCRIPTION
## Context

This backports the production hotfix for the GA-25-0015 details-page issue into main.

GA-25-0015 was present in OpenSearch and visible on the dashboard, but opening the details page redirected back to the dashboard. The `/item` response included valid package data, but the package text contained a `(404)` phone area code. The frontend not-found detection treated that successful response as a missing record.

This commit was cherry-picked from production hotfix `5c55dc6555`.

## Solution

Short-circuit not-found detection when `/item` returns a successful package payload with `found: true` and `_source`.

This keeps actual 404/not-found handling intact while preventing valid package content from being scanned as an error payload.

## Testing

Ran:

`./run test --run react-app/src/api/useGetItem.test.ts`

Added regression coverage for a successful package response containing `(404) 805-6716`.