### PR TITLE
fix(empty-legacy-attachments): add attachment fallback for legacy attachments with 0 attachments

### DIFF
--- a/react-app/src/features/package/package-activity/index.test.tsx
+++ b/react-app/src/features/package/package-activity/index.test.tsx
@@ -390,6 +390,42 @@ describe("Package Activity", () => {
     expect(screen.getByText("Contract Amendment"));
   });
 
+  it("renders a legacy package activity when attachments are null", async () => {
+    const changelogWithNullAttachments = [
+      {
+        _id: "MA-24-0013-legacy-1728481070295",
+        _index: "productionchangelog",
+        found: true,
+        _source: {
+          id: "MA-24-0013-legacy-1728481070295",
+          packageId: "MA-24-0013",
+          timestamp: 1728481070295,
+          event: "legacy-withdraw-rai-request",
+          attachments: null,
+          additionalInformation:
+            "Massachusetts is withdrawing the 24-0013 RAI Response submitted on 8/12/24 in order to allow for more time to discuss with CMS.",
+          submitterEmail: "kaela.konefal@state.ma.us",
+          submitterName: "Kaela Konefal",
+          origin: "OneMACLegacy",
+        },
+      },
+    ] as unknown as opensearch.changelog.ItemResult[];
+
+    await renderFormWithPackageSectionAsync(
+      <PackageActivities id="MA-24-0013" changelog={changelogWithNullAttachments} />,
+      "MA-24-0013",
+    );
+
+    expect(screen.getByText("Package Activity (1)")).toBeInTheDocument();
+    expect(screen.getByText("No information submitted")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Massachusetts is withdrawing the 24-0013 RAI Response submitted on 8/12/24 in order to allow for more time to discuss with CMS.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Download all attachments")).not.toBeInTheDocument();
+  });
+
   it("requests the all-attachments archive and opens the returned url", async () => {
     const onArchive = vi.fn(() => Promise.resolve("http://example.com/all.zip"));
     const openSpy = vi.spyOn(window, "open").mockImplementation(vi.fn());

--- a/react-app/src/features/package/package-activity/index.tsx
+++ b/react-app/src/features/package/package-activity/index.tsx
@@ -28,7 +28,7 @@ type PackageActivityRecord = {
   label: string;
   submitterName?: string;
   timestamp?: string | number;
-  attachments: opensearch.changelog.Document["attachments"];
+  attachments: Attachments;
   additionalInformation?: string | null;
   detailMessage?: string;
   isAdminChange?: boolean;
@@ -97,7 +97,7 @@ const attachmentStatusMessageClassName = "text-sm font-normal text-red-700";
 type AttachmentDetailsProps = {
   id: string;
   packageId: string;
-  attachments: opensearch.changelog.Document["attachments"];
+  attachments: Attachments;
   onClick: (attachment: Attachments[number]) => Promise<string | undefined>;
 };
 
@@ -137,7 +137,7 @@ type SubmissionProps = {
 };
 
 const Submission = ({ packageActivity }: SubmissionProps) => {
-  const { attachments = [], id, packageId, additionalInformation, detailMessage } = packageActivity;
+  const { attachments, id, packageId, additionalInformation, detailMessage } = packageActivity;
   const {
     archiveErrorMessage,
     archiveWarningMessage,
@@ -323,7 +323,7 @@ const mapChangelogItemToPackageActivity = ({
     label,
     submitterName: packageActivity.submitterName,
     timestamp: packageActivity.timestamp,
-    attachments: packageActivity.attachments,
+    attachments: packageActivity.attachments ?? [],
     additionalInformation: packageActivity.additionalInformation,
     isAdminChange: packageActivity.isAdminChange,
   };


### PR DESCRIPTION
## 💬 Description / Notes
Add logic for legacy attachment fallback
