### PR TITLE
fix(ui-infra): remediate Netsparker UI findings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,11 +27,13 @@ jobs:
         env:
           REF_NAME: ${{ github.ref_name }}
         run: |
-          STAGE_NAME="$REF_NAME"
+          STAGE_NAME=$(printf '%s' "$REF_NAME" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//')
 
-          if [[ "$REF_NAME" == snyk-* && ${#REF_NAME} -gt 26 ]]; then
-              REF_HASH=$(printf '%s' "$REF_NAME" | sha1sum | cut -c1-8)
-              REF_PREFIX="${REF_NAME#snyk-}"
+          if [[ "$STAGE_NAME" == snyk-* && ${#STAGE_NAME} -gt 26 ]]; then
+              REF_HASH=$(printf '%s' "$STAGE_NAME" | sha1sum | cut -c1-8)
+              REF_PREFIX="${STAGE_NAME#snyk-}"
               STAGE_NAME="snyk-${REF_PREFIX:0:2}-${REF_HASH}"
           fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,13 +27,11 @@ jobs:
         env:
           REF_NAME: ${{ github.ref_name }}
         run: |
-          STAGE_NAME=$(printf '%s' "$REF_NAME" \
-            | tr '[:upper:]' '[:lower:]' \
-            | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//')
+          STAGE_NAME="$REF_NAME"
 
-          if [[ "$STAGE_NAME" == snyk-* && ${#STAGE_NAME} -gt 26 ]]; then
-              REF_HASH=$(printf '%s' "$STAGE_NAME" | sha1sum | cut -c1-8)
-              REF_PREFIX="${STAGE_NAME#snyk-}"
+          if [[ "$REF_NAME" == snyk-* && ${#REF_NAME} -gt 26 ]]; then
+              REF_HASH=$(printf '%s' "$REF_NAME" | sha1sum | cut -c1-8)
+              REF_PREFIX="${REF_NAME#snyk-}"
               STAGE_NAME="snyk-${REF_PREFIX:0:2}-${REF_HASH}"
           fi
 

--- a/lib/stacks/ui-infra.test.ts
+++ b/lib/stacks/ui-infra.test.ts
@@ -1,0 +1,83 @@
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+
+import { UiInfra } from "./ui-infra";
+
+function buildUiInfraTemplate() {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, "UiInfraTest", {
+    env: {
+      account: "123456789012",
+      region: "us-east-1",
+    },
+  });
+
+  const uiInfra = new UiInfra(stack, "ui-infra", {
+    project: "mako",
+    stage: "val",
+    stack: "ui-infra",
+    isDev: false,
+    domainName: "onemacval.cms.gov",
+    domainCertificateArn:
+      "arn:aws:acm:us-east-1:123456789012:certificate/00000000-0000-0000-0000-000000000000",
+  });
+
+  return Template.fromStack(uiInfra);
+}
+
+function getCloudFrontFunctionCode(template: Template) {
+  const functions = template.findResources("AWS::CloudFront::Function");
+
+  return Object.values(functions).map((resource) => {
+    const properties = resource.Properties as { FunctionCode?: string };
+    return properties.FunctionCode || "";
+  });
+}
+
+function getDistributionConfig(template: Template) {
+  const distributions = template.findResources("AWS::CloudFront::Distribution");
+  const distribution = Object.values(distributions)[0] as {
+    Properties?: {
+      DistributionConfig?: unknown;
+    };
+  };
+
+  return JSON.stringify(distribution.Properties?.DistributionConfig || {});
+}
+
+describe("UiInfra security remediations", () => {
+  it("adds response headers that prevent MIME sniffing while preserving HSTS", () => {
+    const functionCode = getCloudFrontFunctionCode(buildUiInfraTemplate()).join("\n");
+
+    expect(functionCode).toContain("strict-transport-security");
+    expect(functionCode).toContain("x-content-type-options");
+    expect(functionCode).toContain("nosniff");
+  });
+
+  it("blocks backup-file probes before the SPA fallback can return index.html", () => {
+    const functionCode = getCloudFrontFunctionCode(buildUiInfraTemplate()).join("\n");
+
+    expect(functionCode).toContain(".bak");
+    expect(functionCode).toContain("statusCode: 404");
+    expect(functionCode).toContain("Backup file paths are not served");
+  });
+
+  it("attaches the backup block at viewer-request and headers at viewer-response", () => {
+    const distributionConfig = getDistributionConfig(buildUiInfraTemplate());
+
+    expect(distributionConfig).toContain("viewer-request");
+    expect(distributionConfig).toContain("viewer-response");
+  });
+
+  it("does not ship jszip in the UI dependency graph", () => {
+    const repoRoot = join(__dirname, "../..");
+    const packageManifest = readFileSync(join(repoRoot, "react-app/package.json"), "utf8");
+    const lockfile = readFileSync(join(repoRoot, "bun.lockb")).toString("utf8");
+
+    expect(packageManifest.toLowerCase()).not.toContain("jszip");
+    expect(lockfile.toLowerCase()).not.toContain("jszip");
+  });
+});

--- a/lib/stacks/ui-infra.ts
+++ b/lib/stacks/ui-infra.ts
@@ -111,14 +111,41 @@ export class UiInfra extends cdk.NestedStack {
       comment: "OAI to prevent direct public access to the bucket",
     });
 
-    // HSTS Function
-    const hstsFunction = new cdk.aws_cloudfront.Function(this, "HstsFunction", {
-      comment: "This function adds headers to implement HSTS",
+    const backupFileBlockFunction = new cdk.aws_cloudfront.Function(
+      this,
+      "BackupFileBlockFunction",
+      {
+        comment: "This function blocks backup-file probes before SPA fallback",
+        code: cdk.aws_cloudfront.FunctionCode.fromInline(`
+        function handler(event) {
+          var request = event.request;
+          var uri = request.uri.toLowerCase();
+
+          if (uri.endsWith('.bak')) {
+            return {
+              statusCode: 404,
+              statusDescription: 'Not Found',
+              headers: {
+                'content-type': { value: 'text/plain; charset=utf-8' }
+              },
+              body: 'Backup file paths are not served'
+            };
+          }
+
+          return request;
+        }
+      `),
+      },
+    );
+
+    const securityHeadersFunction = new cdk.aws_cloudfront.Function(this, "HstsFunction", {
+      comment: "This function adds security headers",
       code: cdk.aws_cloudfront.FunctionCode.fromInline(`
         function handler(event) {
           var response = event.response;
           var headers = response.headers;
           headers['strict-transport-security'] = { value: 'max-age=63072000; includeSubdomains; preload'};
+          headers['x-content-type-options'] = { value: 'nosniff' };
           return response;
         }
       `),
@@ -154,7 +181,11 @@ export class UiInfra extends cdk.NestedStack {
                 viewerProtocolPolicy: cdk.aws_cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
                 functionAssociations: [
                   {
-                    function: hstsFunction,
+                    function: backupFileBlockFunction,
+                    eventType: cdk.aws_cloudfront.FunctionEventType.VIEWER_REQUEST,
+                  },
+                  {
+                    function: securityHeadersFunction,
                     eventType: cdk.aws_cloudfront.FunctionEventType.VIEWER_RESPONSE,
                   },
                 ],


### PR DESCRIPTION
## 🎫 Linked Ticket

[OY2-36129](https://jiraent.cms.gov/browse/OY2-36129)
[OY2-39908](https://jiraent.cms.gov/browse/OY2-39908)

## 💬 Description / Notes

Addresses the OneMAC VAL Netsparker findings tracked in OY2-36129:

- Possible Backup File Disclosure for `.bak` probe paths
- Version Disclosure (jszip)
- Missing `X-Content-Type-Options` Header

The UI CloudFront stack now blocks `.bak` requests before the SPA fallback can serve `index.html`, and response headers now include `X-Content-Type-Options: nosniff` while preserving HSTS. The current UI dependency graph and built bundle do not include `jszip`, and a regression test covers that expectation.

## 🛠 Changes

- Added a CloudFront viewer-request function to return `404` for `.bak` paths.
- Updated the existing CloudFront viewer-response function to add `X-Content-Type-Options: nosniff`.
- Added CDK regression tests for the CloudFront functions, function associations, security headers, backup-file block, and absence of `jszip`.

## 📸 Screenshots / Demo

N/A - infrastructure/header behavior only.

## Validation

- `bun vitest run --project=lib stacks/ui-infra.test.ts`
- `bun vitest run --project=lib stacks/ui-infra.test.ts stacks/api.integrity-schedule.test.ts stacks/attachment-archive-state-machine.test.ts`
- `bun run build:lib`
- `bun run build:ui`
- `bun eslint lib/stacks/ui-infra.ts lib/stacks/ui-infra.test.ts`
- `bun prettier --check lib/stacks/ui-infra.ts lib/stacks/ui-infra.test.ts`
- `git diff --check`
- `rg -n -i "jszip|JSZip" react-app/dist react-app/package.json package.json bun.lockb || true`