### PR TITLE
fix(daily-script-email-var): add email as secret for daily mismatch scripts

### DIFF
--- a/lib/lambda/runSeatoolStatusMismatchReport.test.ts
+++ b/lib/lambda/runSeatoolStatusMismatchReport.test.ts
@@ -214,6 +214,44 @@ describe("runSeatoolStatusMismatchReport", () => {
     });
   }
 
+  function setupSingleMismatchCsvReport() {
+    const seatoolCsvKey = "seatool-status-mismatch/main/input/mismatch.csv";
+    const objectStore: S3ObjectStore = new Map([
+      [
+        toStoreKey("report-bucket", seatoolCsvKey),
+        ["ID_Number,status,", "CA-25-0022,Pending-RAI,"].join("\n"),
+      ],
+    ]);
+    const putStore: S3ObjectStore = new Map();
+    mockS3({ objectStore, putStore });
+
+    const mget = vi.fn(async ({ body }: { body: { ids: string[] } }) => ({
+      body: {
+        docs: body.ids.map((id) => ({
+          _id: id,
+          found: true,
+          _source: {
+            id,
+            cmsStatus: "Submitted - Intake Needed",
+            stateStatus: "Submitted",
+            seatoolStatus: "Submitted",
+          },
+        })),
+      },
+    }));
+    vi.mocked(getClient).mockResolvedValue({ mget } as any);
+
+    return {
+      mget,
+      objectStore,
+      putStore,
+      event: {
+        seatoolCsvKey,
+        runTimestamp: "2026-03-19T16:45:07.000Z",
+      },
+    };
+  }
+
   it("normalizes status values like the manual comparison script", () => {
     expect(normalizeStatus("Pending - RAI")).toBe("Pending-RAI");
     expect(normalizeStatus("Pending – RAI")).toBe("Pending-RAI");
@@ -594,6 +632,73 @@ describe("runSeatoolStatusMismatchReport", () => {
           NEEDS_RAI_CHANGELOG_REVIEW: 1,
         },
         notificationStatus: "SENT",
+      }),
+    );
+  });
+
+  it("uses explicit status mismatch recipient override before the secret field", async () => {
+    process.env.SEATOOL_STATUS_MISMATCH_RECIPIENT_EMAILS =
+      '"Override Alerts" <override@example.com>';
+    const { event } = setupSingleMismatchCsvReport();
+
+    const result = await handler(event);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        mismatchCount: 1,
+        notificationStatus: "SENT",
+        notificationRecipients: ["override@example.com"],
+      }),
+    );
+
+    const sesCommand = sesSendSpy.mock.calls[0]?.[0] as any;
+    expect(sesCommand.input.Destinations).toEqual(["override@example.com"]);
+    expect(Buffer.from(sesCommand.input.RawMessage.Data).toString("utf8")).toContain(
+      'To: "Override Alerts" <override@example.com>',
+    );
+  });
+
+  it("disables status mismatch notification when the recipient secret field is empty", async () => {
+    vi.mocked(getSecret).mockResolvedValue(
+      JSON.stringify({
+        sourceEmail: ['"OneMAC Alerts" <source@example.com>'],
+      }),
+    );
+    const { event } = setupSingleMismatchCsvReport();
+
+    const result = await handler(event);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        mismatchCount: 1,
+        notificationStatus: "DISABLED",
+        notificationRecipients: [],
+      }),
+    );
+    expect(sesSendSpy).not.toHaveBeenCalled();
+  });
+
+  it("fails status mismatch notification when recipients exist but sourceEmail is missing", async () => {
+    vi.mocked(getSecret).mockResolvedValue(
+      JSON.stringify({
+        seatoolStatusMismatchAlerts: ['"Status Mismatch" <status-mismatch@example.com>'],
+      }),
+    );
+    const { event, putStore } = setupSingleMismatchCsvReport();
+
+    await expect(handler(event)).rejects.toThrow(
+      "SEATool status mismatch notification failed: SEATool status mismatch notification secret is missing sourceEmail",
+    );
+    expect(sesSendSpy).not.toHaveBeenCalled();
+
+    const summaryEntry = Array.from(putStore.entries()).find(([key]) =>
+      key.endsWith("/summary.json"),
+    );
+    expect(JSON.parse(summaryEntry?.[1] || "{}")).toEqual(
+      expect.objectContaining({
+        mismatchCount: 1,
+        notificationStatus: "FAILED",
+        notificationError: "SEATool status mismatch notification secret is missing sourceEmail",
       }),
     );
   });

--- a/lib/lambda/runSeatoolStatusMismatchReport.test.ts
+++ b/lib/lambda/runSeatoolStatusMismatchReport.test.ts
@@ -61,8 +61,8 @@ describe("runSeatoolStatusMismatchReport", () => {
     SEATOOL_STATUS_MISMATCH_KAFKA_CONSUME_TIMEOUT_MS:
       process.env.SEATOOL_STATUS_MISMATCH_KAFKA_CONSUME_TIMEOUT_MS,
     SEATOOL_STATUS_MISMATCH_RECIPIENT_EMAILS: process.env.SEATOOL_STATUS_MISMATCH_RECIPIENT_EMAILS,
-    SEATOOL_STATUS_MISMATCH_RECIPIENT_SECRET_KEY:
-      process.env.SEATOOL_STATUS_MISMATCH_RECIPIENT_SECRET_KEY,
+    SEATOOL_STATUS_MISMATCH_RECIPIENT_CONFIG_FIELD:
+      process.env.SEATOOL_STATUS_MISMATCH_RECIPIENT_CONFIG_FIELD,
     emailAddressLookupSecretName: process.env.emailAddressLookupSecretName,
     brokerString: process.env.brokerString,
     osDomain: process.env.osDomain,
@@ -81,7 +81,7 @@ describe("runSeatoolStatusMismatchReport", () => {
       "aws.seatool.ksql.onemac.three.agg.State_Plan";
     process.env.SEATOOL_STATUS_MISMATCH_KAFKA_CONSUME_TIMEOUT_MS = "1000";
     delete process.env.SEATOOL_STATUS_MISMATCH_RECIPIENT_EMAILS;
-    process.env.SEATOOL_STATUS_MISMATCH_RECIPIENT_SECRET_KEY = "seatoolStatusMismatchAlerts";
+    process.env.SEATOOL_STATUS_MISMATCH_RECIPIENT_CONFIG_FIELD = "seatoolStatusMismatchAlerts";
     process.env.emailAddressLookupSecretName = "emailAddresses"; // pragma: allowlist secret
     process.env.brokerString = "broker1,broker2";
     process.env.osDomain = "https://test-opensearch.example.com";
@@ -152,8 +152,8 @@ describe("runSeatoolStatusMismatchReport", () => {
       originalEnv.SEATOOL_STATUS_MISMATCH_RECIPIENT_EMAILS,
     );
     restoreEnvValue(
-      "SEATOOL_STATUS_MISMATCH_RECIPIENT_SECRET_KEY",
-      originalEnv.SEATOOL_STATUS_MISMATCH_RECIPIENT_SECRET_KEY,
+      "SEATOOL_STATUS_MISMATCH_RECIPIENT_CONFIG_FIELD",
+      originalEnv.SEATOOL_STATUS_MISMATCH_RECIPIENT_CONFIG_FIELD,
     );
     restoreEnvValue("emailAddressLookupSecretName", originalEnv.emailAddressLookupSecretName);
     restoreEnvValue("brokerString", originalEnv.brokerString);

--- a/lib/lambda/runSeatoolStatusMismatchReport.test.ts
+++ b/lib/lambda/runSeatoolStatusMismatchReport.test.ts
@@ -61,6 +61,8 @@ describe("runSeatoolStatusMismatchReport", () => {
     SEATOOL_STATUS_MISMATCH_KAFKA_CONSUME_TIMEOUT_MS:
       process.env.SEATOOL_STATUS_MISMATCH_KAFKA_CONSUME_TIMEOUT_MS,
     SEATOOL_STATUS_MISMATCH_RECIPIENT_EMAILS: process.env.SEATOOL_STATUS_MISMATCH_RECIPIENT_EMAILS,
+    SEATOOL_STATUS_MISMATCH_RECIPIENT_SECRET_KEY:
+      process.env.SEATOOL_STATUS_MISMATCH_RECIPIENT_SECRET_KEY,
     emailAddressLookupSecretName: process.env.emailAddressLookupSecretName,
     brokerString: process.env.brokerString,
     osDomain: process.env.osDomain,
@@ -78,7 +80,8 @@ describe("runSeatoolStatusMismatchReport", () => {
     process.env.SEATOOL_STATUS_MISMATCH_SEATOOL_TOPIC =
       "aws.seatool.ksql.onemac.three.agg.State_Plan";
     process.env.SEATOOL_STATUS_MISMATCH_KAFKA_CONSUME_TIMEOUT_MS = "1000";
-    process.env.SEATOOL_STATUS_MISMATCH_RECIPIENT_EMAILS = "James.d@globalalliantinc.com";
+    delete process.env.SEATOOL_STATUS_MISMATCH_RECIPIENT_EMAILS;
+    process.env.SEATOOL_STATUS_MISMATCH_RECIPIENT_SECRET_KEY = "seatoolStatusMismatchAlerts";
     process.env.emailAddressLookupSecretName = "emailAddresses"; // pragma: allowlist secret
     process.env.brokerString = "broker1,broker2";
     process.env.osDomain = "https://test-opensearch.example.com";
@@ -91,6 +94,7 @@ describe("runSeatoolStatusMismatchReport", () => {
     vi.mocked(getSecret).mockResolvedValue(
       JSON.stringify({
         sourceEmail: ['"OneMAC Alerts" <source@example.com>'],
+        seatoolStatusMismatchAlerts: ["status-mismatch@example.com"],
       }),
     );
     mockedAdmin.connect.mockResolvedValue(undefined);
@@ -146,6 +150,10 @@ describe("runSeatoolStatusMismatchReport", () => {
     restoreEnvValue(
       "SEATOOL_STATUS_MISMATCH_RECIPIENT_EMAILS",
       originalEnv.SEATOOL_STATUS_MISMATCH_RECIPIENT_EMAILS,
+    );
+    restoreEnvValue(
+      "SEATOOL_STATUS_MISMATCH_RECIPIENT_SECRET_KEY",
+      originalEnv.SEATOOL_STATUS_MISMATCH_RECIPIENT_SECRET_KEY,
     );
     restoreEnvValue("emailAddressLookupSecretName", originalEnv.emailAddressLookupSecretName);
     restoreEnvValue("brokerString", originalEnv.brokerString);
@@ -553,14 +561,14 @@ describe("runSeatoolStatusMismatchReport", () => {
         skippedRows: 1,
         mismatchCount: 1,
         notificationStatus: "SENT",
-        notificationRecipients: ["James.d@globalalliantinc.com"],
+        notificationRecipients: ["status-mismatch@example.com"],
       }),
     );
     expect(mget).toHaveBeenCalledTimes(3);
     expect(sesSendSpy).toHaveBeenCalledTimes(1);
 
     const sesCommand = sesSendSpy.mock.calls[0]?.[0] as any;
-    expect(sesCommand.input.Destinations).toEqual(["James.d@globalalliantinc.com"]);
+    expect(sesCommand.input.Destinations).toEqual(["status-mismatch@example.com"]);
     const rawEmail = Buffer.from(sesCommand.input.RawMessage.Data).toString("utf8");
     expect(rawEmail).toContain("Subject: [main] OneMAC/SEATool status mismatches: 1");
     expect(rawEmail).toContain('filename="true_status_mismatches.csv"');

--- a/lib/lambda/runSeatoolStatusMismatchReport.ts
+++ b/lib/lambda/runSeatoolStatusMismatchReport.ts
@@ -19,7 +19,7 @@ const DEFAULT_BATCH_SIZE = 500;
 const DEFAULT_INPUT_SOURCE = "KAFKA";
 const DEFAULT_KAFKA_CONSUME_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_REPORT_PREFIX = "seatool-status-mismatch";
-const DEFAULT_RECIPIENT_SECRET_KEY = "seatoolStatusMismatchAlerts";
+const DEFAULT_RECIPIENT_CONFIG_FIELD = "seatoolStatusMismatchAlerts";
 const DEFAULT_SEATOOL_STATUS_TOPIC = "aws.seatool.ksql.onemac.three.agg.State_Plan";
 const RAW_SEATOOL_STATUS_DISPLAY_FALLBACKS: Record<string, string> = {
   "Pending-Finance": SEATOOL_STATUS.UNKNOWN,
@@ -111,7 +111,7 @@ type KafkaSourceConfig = {
 type ReportNotificationConfig = {
   emailAddressLookupSecretName: string;
   recipientEmailOverrides: ParsedEmailAddress[];
-  recipientSecretKey: string;
+  recipientConfigField: string;
 };
 
 type ParsedEmailAddress = {
@@ -235,14 +235,14 @@ function getNotificationConfig(): ReportNotificationConfig {
   const recipientEmailOverrides = parseEmailAddressList(
     parseAddressEntries(process.env.SEATOOL_STATUS_MISMATCH_RECIPIENT_EMAILS),
   );
-  const recipientSecretKey = (
-    process.env.SEATOOL_STATUS_MISMATCH_RECIPIENT_SECRET_KEY || DEFAULT_RECIPIENT_SECRET_KEY
+  const recipientConfigField = (
+    process.env.SEATOOL_STATUS_MISMATCH_RECIPIENT_CONFIG_FIELD || DEFAULT_RECIPIENT_CONFIG_FIELD
   ).trim();
 
   return {
     emailAddressLookupSecretName,
     recipientEmailOverrides,
-    recipientSecretKey,
+    recipientConfigField,
   };
 }
 
@@ -1073,7 +1073,7 @@ async function getNotificationEmailAddresses(notificationConfig: ReportNotificat
   const recipientEmails =
     notificationConfig.recipientEmailOverrides.length > 0
       ? notificationConfig.recipientEmailOverrides
-      : parseEmailAddressList(parseAddressEntries(secret[notificationConfig.recipientSecretKey]));
+      : parseEmailAddressList(parseAddressEntries(secret[notificationConfig.recipientConfigField]));
 
   if (recipientEmails.length === 0) {
     return {

--- a/lib/lambda/runSeatoolStatusMismatchReport.ts
+++ b/lib/lambda/runSeatoolStatusMismatchReport.ts
@@ -19,6 +19,7 @@ const DEFAULT_BATCH_SIZE = 500;
 const DEFAULT_INPUT_SOURCE = "KAFKA";
 const DEFAULT_KAFKA_CONSUME_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_REPORT_PREFIX = "seatool-status-mismatch";
+const DEFAULT_RECIPIENT_SECRET_KEY = "seatoolStatusMismatchAlerts";
 const DEFAULT_SEATOOL_STATUS_TOPIC = "aws.seatool.ksql.onemac.three.agg.State_Plan";
 const RAW_SEATOOL_STATUS_DISPLAY_FALLBACKS: Record<string, string> = {
   "Pending-Finance": SEATOOL_STATUS.UNKNOWN,
@@ -109,7 +110,8 @@ type KafkaSourceConfig = {
 
 type ReportNotificationConfig = {
   emailAddressLookupSecretName: string;
-  recipientEmails: string[];
+  recipientEmailOverrides: ParsedEmailAddress[];
+  recipientSecretKey: string;
 };
 
 type ParsedEmailAddress = {
@@ -230,13 +232,17 @@ function getNotificationConfig(): ReportNotificationConfig {
   const emailAddressLookupSecretName = (
     process.env.emailAddressLookupSecretName || "emailAddresses"
   ).trim();
-  const recipientEmails = parseEmailAddressList(
+  const recipientEmailOverrides = parseEmailAddressList(
     parseAddressEntries(process.env.SEATOOL_STATUS_MISMATCH_RECIPIENT_EMAILS),
-  ).map((address) => address.email);
+  );
+  const recipientSecretKey = (
+    process.env.SEATOOL_STATUS_MISMATCH_RECIPIENT_SECRET_KEY || DEFAULT_RECIPIENT_SECRET_KEY
+  ).trim();
 
   return {
     emailAddressLookupSecretName,
-    recipientEmails,
+    recipientEmailOverrides,
+    recipientSecretKey,
   };
 }
 
@@ -1058,17 +1064,31 @@ async function loadSeatoolInputData({
   });
 }
 
-async function getSourceEmailAddress(emailAddressLookupSecretName: string) {
-  const rawSecret = await getSecret(emailAddressLookupSecretName);
-  const secret = JSON.parse(rawSecret || "{}") as {
+async function getNotificationEmailAddresses(notificationConfig: ReportNotificationConfig) {
+  const rawSecret = await getSecret(notificationConfig.emailAddressLookupSecretName);
+  const secret = JSON.parse(rawSecret || "{}") as Record<string, unknown> & {
     sourceEmail?: unknown;
   };
   const sourceEmail = parseEmailAddressList(parseAddressEntries(secret.sourceEmail))[0];
+  const recipientEmails =
+    notificationConfig.recipientEmailOverrides.length > 0
+      ? notificationConfig.recipientEmailOverrides
+      : parseEmailAddressList(parseAddressEntries(secret[notificationConfig.recipientSecretKey]));
+
+  if (recipientEmails.length === 0) {
+    return {
+      recipientEmails,
+    };
+  }
+
   if (!sourceEmail) {
     throw new Error("SEATool status mismatch notification secret is missing sourceEmail");
   }
 
-  return sourceEmail;
+  return {
+    sourceEmail,
+    recipientEmails,
+  };
 }
 
 async function sendMismatchNotification({
@@ -1087,14 +1107,25 @@ async function sendMismatchNotification({
     };
   }
 
-  if (notificationConfig.recipientEmails.length === 0) {
+  const notificationEmails = await getNotificationEmailAddresses(notificationConfig);
+  if (notificationEmails.recipientEmails.length === 0) {
     return {
       notificationStatus: "DISABLED" as const,
       notificationRecipients: [] as string[],
     };
   }
 
-  const sourceEmail = await getSourceEmailAddress(notificationConfig.emailAddressLookupSecretName);
+  const sourceEmail = notificationEmails.sourceEmail;
+  if (!sourceEmail) {
+    throw new Error("SEATool status mismatch notification secret is missing sourceEmail");
+  }
+
+  const recipientEmailAddresses = notificationEmails.recipientEmails.map(
+    (address) => address.email,
+  );
+  const recipientEmailHeaders = notificationEmails.recipientEmails.map(
+    (address) => address.formatted,
+  );
   const subject = `[${result.stage}] OneMAC/SEATool status mismatches: ${result.mismatchCount}`;
   const sourceLine =
     result.inputSource === "KAFKA"
@@ -1112,7 +1143,7 @@ async function sendMismatchNotification({
   ].join("\n");
   const rawData = buildRawEmail({
     sourceEmailHeader: sourceEmail.formatted,
-    toEmailHeaders: notificationConfig.recipientEmails,
+    toEmailHeaders: recipientEmailHeaders,
     subject,
     bodyText,
     attachment: {
@@ -1128,13 +1159,13 @@ async function sendMismatchNotification({
         Data: Buffer.from(rawData, "utf8"),
       },
       Source: sourceEmail.email,
-      Destinations: notificationConfig.recipientEmails,
+      Destinations: recipientEmailAddresses,
     }),
   );
 
   return {
     notificationStatus: "SENT" as const,
-    notificationRecipients: notificationConfig.recipientEmails,
+    notificationRecipients: recipientEmailAddresses,
     notificationSentAt: new Date().toISOString(),
   };
 }
@@ -1268,7 +1299,9 @@ export const handler = async (
     );
   } catch (error) {
     result.notificationStatus = "FAILED";
-    result.notificationRecipients = notificationConfig.recipientEmails;
+    result.notificationRecipients = notificationConfig.recipientEmailOverrides.map(
+      (address) => address.email,
+    );
     result.notificationError = error instanceof Error ? error.message : String(error);
   }
 

--- a/lib/stacks/api.seatool-status-mismatch-report.test.ts
+++ b/lib/stacks/api.seatool-status-mismatch-report.test.ts
@@ -68,7 +68,7 @@ describe("SEATool status mismatch report scheduling", () => {
       SEATOOL_STATUS_MISMATCH_REPORT_BUCKET_NAME:
         "mako-production-attachment-archives-123456789012",
       SEATOOL_STATUS_MISMATCH_REPORT_PREFIX: "seatool-status-mismatch",
-      SEATOOL_STATUS_MISMATCH_RECIPIENT_SECRET_KEY: "seatoolStatusMismatchAlerts",
+      SEATOOL_STATUS_MISMATCH_RECIPIENT_CONFIG_FIELD: "seatoolStatusMismatchAlerts",
       SEATOOL_STATUS_MISMATCH_SEATOOL_TOPIC: "aws.seatool.ksql.onemac.three.agg.State_Plan",
       emailAddressLookupSecretName: "emailAddresses",
     });

--- a/lib/stacks/api.seatool-status-mismatch-report.test.ts
+++ b/lib/stacks/api.seatool-status-mismatch-report.test.ts
@@ -68,7 +68,7 @@ describe("SEATool status mismatch report scheduling", () => {
       SEATOOL_STATUS_MISMATCH_REPORT_BUCKET_NAME:
         "mako-production-attachment-archives-123456789012",
       SEATOOL_STATUS_MISMATCH_REPORT_PREFIX: "seatool-status-mismatch",
-      SEATOOL_STATUS_MISMATCH_RECIPIENT_EMAILS: "James.d@globalalliantinc.com",
+      SEATOOL_STATUS_MISMATCH_RECIPIENT_SECRET_KEY: "seatoolStatusMismatchAlerts",
       SEATOOL_STATUS_MISMATCH_SEATOOL_TOPIC: "aws.seatool.ksql.onemac.three.agg.State_Plan",
       emailAddressLookupSecretName: "emailAddresses",
     });

--- a/lib/stacks/seatool-status-mismatch-report.ts
+++ b/lib/stacks/seatool-status-mismatch-report.ts
@@ -4,7 +4,7 @@ import { Construct } from "constructs";
 import { isSharedArchiveStage } from "./archive-bucket-routing";
 
 export const SEATOOL_STATUS_MISMATCH_REPORT_PREFIX = "seatool-status-mismatch";
-export const SEATOOL_STATUS_MISMATCH_DEFAULT_RECIPIENT_EMAIL = "James.d@globalalliantinc.com";
+export const SEATOOL_STATUS_MISMATCH_DEFAULT_RECIPIENT_SECRET_KEY = "seatoolStatusMismatchAlerts";
 export const SEATOOL_STATUS_MISMATCH_DEFAULT_SCHEDULE_EXPRESSION = "cron(0 21 * * ? *)";
 export const SEATOOL_STATUS_MISMATCH_DEFAULT_SCHEDULE_TIMEZONE = "America/New_York";
 export const SEATOOL_STATUS_MISMATCH_SEATOOL_TOPIC = "aws.seatool.ksql.onemac.three.agg.State_Plan";
@@ -16,7 +16,7 @@ export function buildSeatoolStatusMismatchReportEnvironment({
   indexNamespace,
   reportBucketName,
   emailAddressLookupSecretName,
-  recipientEmails = SEATOOL_STATUS_MISMATCH_DEFAULT_RECIPIENT_EMAIL,
+  recipientSecretKey = SEATOOL_STATUS_MISMATCH_DEFAULT_RECIPIENT_SECRET_KEY,
 }: {
   stage: string;
   brokerString: string;
@@ -24,7 +24,7 @@ export function buildSeatoolStatusMismatchReportEnvironment({
   indexNamespace: string;
   reportBucketName: string;
   emailAddressLookupSecretName: string;
-  recipientEmails?: string;
+  recipientSecretKey?: string;
 }): Record<string, string> {
   return {
     brokerString,
@@ -36,7 +36,7 @@ export function buildSeatoolStatusMismatchReportEnvironment({
     SEATOOL_STATUS_MISMATCH_INPUT_KEY_PREFIX: `${SEATOOL_STATUS_MISMATCH_REPORT_PREFIX}/${stage}/input/`,
     SEATOOL_STATUS_MISMATCH_REPORT_BUCKET_NAME: reportBucketName,
     SEATOOL_STATUS_MISMATCH_REPORT_PREFIX: SEATOOL_STATUS_MISMATCH_REPORT_PREFIX,
-    SEATOOL_STATUS_MISMATCH_RECIPIENT_EMAILS: recipientEmails,
+    SEATOOL_STATUS_MISMATCH_RECIPIENT_SECRET_KEY: recipientSecretKey,
     SEATOOL_STATUS_MISMATCH_SEATOOL_TOPIC: SEATOOL_STATUS_MISMATCH_SEATOOL_TOPIC,
     emailAddressLookupSecretName,
   };

--- a/lib/stacks/seatool-status-mismatch-report.ts
+++ b/lib/stacks/seatool-status-mismatch-report.ts
@@ -4,7 +4,7 @@ import { Construct } from "constructs";
 import { isSharedArchiveStage } from "./archive-bucket-routing";
 
 export const SEATOOL_STATUS_MISMATCH_REPORT_PREFIX = "seatool-status-mismatch";
-export const SEATOOL_STATUS_MISMATCH_DEFAULT_RECIPIENT_SECRET_KEY = "seatoolStatusMismatchAlerts";
+export const SEATOOL_STATUS_MISMATCH_DEFAULT_RECIPIENT_CONFIG_FIELD = "seatoolStatusMismatchAlerts";
 export const SEATOOL_STATUS_MISMATCH_DEFAULT_SCHEDULE_EXPRESSION = "cron(0 21 * * ? *)";
 export const SEATOOL_STATUS_MISMATCH_DEFAULT_SCHEDULE_TIMEZONE = "America/New_York";
 export const SEATOOL_STATUS_MISMATCH_SEATOOL_TOPIC = "aws.seatool.ksql.onemac.three.agg.State_Plan";
@@ -16,7 +16,7 @@ export function buildSeatoolStatusMismatchReportEnvironment({
   indexNamespace,
   reportBucketName,
   emailAddressLookupSecretName,
-  recipientSecretKey = SEATOOL_STATUS_MISMATCH_DEFAULT_RECIPIENT_SECRET_KEY,
+  recipientConfigField = SEATOOL_STATUS_MISMATCH_DEFAULT_RECIPIENT_CONFIG_FIELD,
 }: {
   stage: string;
   brokerString: string;
@@ -24,7 +24,7 @@ export function buildSeatoolStatusMismatchReportEnvironment({
   indexNamespace: string;
   reportBucketName: string;
   emailAddressLookupSecretName: string;
-  recipientSecretKey?: string;
+  recipientConfigField?: string;
 }): Record<string, string> {
   return {
     brokerString,
@@ -36,7 +36,7 @@ export function buildSeatoolStatusMismatchReportEnvironment({
     SEATOOL_STATUS_MISMATCH_INPUT_KEY_PREFIX: `${SEATOOL_STATUS_MISMATCH_REPORT_PREFIX}/${stage}/input/`,
     SEATOOL_STATUS_MISMATCH_REPORT_BUCKET_NAME: reportBucketName,
     SEATOOL_STATUS_MISMATCH_REPORT_PREFIX: SEATOOL_STATUS_MISMATCH_REPORT_PREFIX,
-    SEATOOL_STATUS_MISMATCH_RECIPIENT_SECRET_KEY: recipientSecretKey,
+    SEATOOL_STATUS_MISMATCH_RECIPIENT_CONFIG_FIELD: recipientConfigField,
     SEATOOL_STATUS_MISMATCH_SEATOOL_TOPIC: SEATOOL_STATUS_MISMATCH_SEATOOL_TOPIC,
     emailAddressLookupSecretName,
   };


### PR DESCRIPTION
## 💬 Description / Notes
- Fast follow on to add email as a secret from secrets manager
