### PR TITLE
feat: Normalize email casing for user access

### DIFF
--- a/lib/lambda/middleware/hasPermissions.ts
+++ b/lib/lambda/middleware/hasPermissions.ts
@@ -1,7 +1,7 @@
 import { MiddlewareObj, Request } from "@middy/core";
 import { createError } from "@middy/util";
 import { SEATOOL_STATUS } from "shared-types";
-import { isCmsUser, isUserManagerUser } from "shared-utils";
+import { isCmsUser, isUserManagerUser, normalizeEmail } from "shared-utils";
 
 import { getAuthUserFromRequest, getPackageFromRequest } from "./utils";
 
@@ -61,7 +61,7 @@ export const canViewUser = (): MiddlewareObj => ({
     // authorization to view another user's details, throw an error
     if (
       userEmail &&
-      authenticatedUser.email !== userEmail &&
+      normalizeEmail(authenticatedUser.email) !== normalizeEmail(userEmail) &&
       !isUserManagerUser(authenticatedUser)
     ) {
       throw createError(403, JSON.stringify({ message: "Not authorized to view this resource" }));

--- a/lib/lambda/user-management/createUserProfile.ts
+++ b/lib/lambda/user-management/createUserProfile.ts
@@ -1,5 +1,6 @@
 import { produceMessage } from "libs/api/kafka";
 import { APIGatewayEvent } from "shared-types";
+import { normalizeEmail } from "shared-utils";
 
 import { authenticatedMiddy, ContextWithAuthenticatedUser } from "../middleware";
 import { getUserByEmail } from "./userManagementService";
@@ -15,9 +16,10 @@ export const handler = authenticatedMiddy({
     throw new Error("Email is undefined");
   }
 
-  const userInfo = await getUserByEmail(authenticatedUser.email);
+  const normalizedEmail = normalizeEmail(authenticatedUser.email);
+  const userInfo = await getUserByEmail(normalizedEmail);
 
-  const id = `${authenticatedUser.email}_user-information`;
+  const id = `${normalizedEmail}_user-information`;
 
   if (!userInfo) {
     await produceMessage(
@@ -25,7 +27,7 @@ export const handler = authenticatedMiddy({
       id,
       JSON.stringify({
         eventType: "user-info",
-        email: authenticatedUser.email,
+        email: normalizedEmail,
         fullName: `${authenticatedUser.given_name} ${authenticatedUser.family_name}`,
       }),
     );

--- a/lib/lambda/user-management/getUserDetails.ts
+++ b/lib/lambda/user-management/getUserDetails.ts
@@ -1,5 +1,6 @@
 import { createError } from "@middy/util";
 import { APIGatewayEvent } from "shared-types";
+import { normalizeEmail } from "shared-utils";
 import { z } from "zod";
 
 import { authenticatedMiddy, canViewUser, ContextWithAuthenticatedUser } from "../middleware";
@@ -26,7 +27,7 @@ export const handler = authenticatedMiddy({
 })
   .use(canViewUser())
   .handler(async (event: GetUserDetailsEvent, context: ContextWithAuthenticatedUser) => {
-    const email = event?.body?.userEmail || context?.authenticatedUser?.email;
+    const email = normalizeEmail(event?.body?.userEmail || context?.authenticatedUser?.email);
 
     if (!email) {
       throw new Error("Email is undefined");

--- a/lib/lambda/user-management/getUserProfile.ts
+++ b/lib/lambda/user-management/getUserProfile.ts
@@ -1,4 +1,5 @@
 import { APIGatewayEvent } from "shared-types";
+import { normalizeEmail } from "shared-utils";
 import { z } from "zod";
 
 import { authenticatedMiddy, canViewUser, ContextWithAuthenticatedUser } from "../middleware";
@@ -21,7 +22,7 @@ export const handler = authenticatedMiddy({
 })
   .use(canViewUser())
   .handler(async (event: GetUserProfileEvent, context: ContextWithAuthenticatedUser) => {
-    const email = event?.body?.userEmail || context?.authenticatedUser?.email;
+    const email = normalizeEmail(event?.body?.userEmail || context?.authenticatedUser?.email);
 
     if (!email) {
       throw new Error("Email is undefined");

--- a/lib/lambda/user-management/requestBaseCMSAccess.ts
+++ b/lib/lambda/user-management/requestBaseCMSAccess.ts
@@ -1,5 +1,6 @@
 import { APIGatewayEvent } from "aws-lambda";
 import { produceMessage } from "libs/api/kafka";
+import { normalizeEmail } from "shared-utils";
 
 import { authenticatedMiddy, ContextWithAuthenticatedUser } from "../middleware";
 import { getAllUserRolesByEmail, getUserByEmail } from "./userManagementService";
@@ -15,8 +16,9 @@ export const handler = authenticatedMiddy({
     throw new Error("Email is undefined");
   }
 
-  const userInfo = await getUserByEmail(authenticatedUser.email);
-  const userRoles = await getAllUserRolesByEmail(authenticatedUser.email);
+  const normalizedEmail = normalizeEmail(authenticatedUser.email);
+  const userInfo = await getUserByEmail(normalizedEmail);
+  const userRoles = await getAllUserRolesByEmail(normalizedEmail);
 
   if (userRoles.length) {
     return {
@@ -26,19 +28,19 @@ export const handler = authenticatedMiddy({
   }
 
   const date = Date.now();
-  const doneByEmail = userInfo?.email || authenticatedUser.email;
+  const doneByEmail = userInfo?.email || normalizedEmail;
   const doneByName =
     userInfo?.fullName || `${authenticatedUser.given_name} ${authenticatedUser.family_name}`; // full name of current user. Cognito (userAttributes) may have a different full name
 
   if (authenticatedUser["custom:ismemberof"]) {
-    const id = `${authenticatedUser.email}_N/A_defaultcmsuser`;
+    const id = `${normalizedEmail}_N/A_defaultcmsuser`;
 
     await produceMessage(
       process.env.topicName || "",
       id,
       JSON.stringify({
         eventType: "user-role",
-        email: authenticatedUser.email,
+        email: normalizedEmail,
         status: "active",
         territory: "N/A",
         role: "defaultcmsuser", // role for this state
@@ -55,14 +57,14 @@ export const handler = authenticatedMiddy({
   }
 
   if (authenticatedUser["custom:cms-roles"].includes("onemac-helpdesk")) {
-    const id = `${authenticatedUser.email}_N/A_helpdesk`;
+    const id = `${normalizedEmail}_N/A_helpdesk`;
 
     await produceMessage(
       process.env.topicName || "",
       id,
       JSON.stringify({
         eventType: "user-role",
-        email: authenticatedUser.email,
+        email: normalizedEmail,
         status: "active",
         territory: "N/A",
         role: "helpdesk", // role for this state

--- a/lib/lambda/user-management/submitRoleRequests.ts
+++ b/lib/lambda/user-management/submitRoleRequests.ts
@@ -2,7 +2,12 @@ import { createError } from "@middy/util";
 import { produceMessage } from "libs/api/kafka";
 import { APIGatewayEvent } from "shared-types";
 import { baseRoleInformationSchema } from "shared-types/events/legacy-user";
-import { canRequestAccess, canSelfRevokeAccess, canUpdateAccess } from "shared-utils";
+import {
+  canRequestAccess,
+  canSelfRevokeAccess,
+  canUpdateAccess,
+  normalizeEmail,
+} from "shared-utils";
 import { z } from "zod";
 
 import { authenticatedMiddy, ContextWithAuthenticatedUser } from "../middleware";
@@ -26,7 +31,7 @@ export const handler = authenticatedMiddy({
 }).handler(async (event: SubmitRoleRequestEvent, context: ContextWithAuthenticatedUser) => {
   const { authenticatedUser } = context;
   const {
-    email,
+    email: requestedEmail,
     state,
     role: roleToUpdate,
     eventType,
@@ -40,7 +45,9 @@ export const handler = authenticatedMiddy({
     throw new Error("Email is undefined");
   }
 
-  const userInfo = await getUserByEmail(authenticatedUser.email);
+  const email = normalizeEmail(requestedEmail);
+  const authenticatedEmail = normalizeEmail(authenticatedUser.email);
+  const userInfo = await getUserByEmail(authenticatedEmail);
 
   let status: RoleStatus;
   // Determine the status based on the user's role and action
@@ -69,7 +76,7 @@ export const handler = authenticatedMiddy({
 
   const id = `${email}_${state}_${roleToUpdate}`;
   const date = Date.now(); // correct time format?
-  const doneByEmail = userInfo?.email || authenticatedUser.email;
+  const doneByEmail = userInfo?.email || authenticatedEmail;
   const doneByName =
     userInfo?.fullName || `${authenticatedUser.given_name} ${authenticatedUser.family_name}`; // full name of current user. Cognito (userAttributes) may have a different full name
 

--- a/lib/lambda/user-management/userManagementService.test.ts
+++ b/lib/lambda/user-management/userManagementService.test.ts
@@ -51,6 +51,10 @@ describe("User Management Service", () => {
       const result = await getUserByEmail(OS_STATE_SYSTEM_ADMIN_EMAIL);
       expect(result).toEqual(OS_STATE_SYSTEM_ADMIN_USER._source);
     });
+    it("should return the same user for mixed-case email input", async () => {
+      const result = await getUserByEmail("StateSubmitter@Nightwatch.Test");
+      expect(result).toEqual(OS_STATE_SUBMITTER_USER._source);
+    });
   });
 
   describe("getUsersByEmail", () => {
@@ -165,6 +169,10 @@ describe("User Management Service", () => {
       const result = await getAllUserRolesByEmail(OS_STATE_SYSTEM_ADMIN_EMAIL);
       expect(result).toEqual(getFilteredRoleDocsByEmail(OS_STATE_SYSTEM_ADMIN_EMAIL));
     });
+    it("should return the correct roles for mixed-case email input", async () => {
+      const result = await getAllUserRolesByEmail("StateSubmitter@Nightwatch.Test");
+      expect(result).toEqual(getFilteredRoleDocsByEmail(OS_STATE_SUBMITTER_EMAIL));
+    });
   });
 
   describe("userHasThisRole", () => {
@@ -192,6 +200,14 @@ describe("User Management Service", () => {
     });
     it("should return true if the email, state, and role record exist", async () => {
       const result = await userHasThisRole(OS_STATE_SYSTEM_ADMIN_EMAIL, "MD", "statesystemadmin");
+      expect(result).toBeTruthy();
+    });
+    it("should match roles with mixed-case email input", async () => {
+      const result = await userHasThisRole(
+        "StateSystemAdmin@Nightwatch.Test",
+        "MD",
+        "statesystemadmin",
+      );
       expect(result).toBeTruthy();
     });
   });
@@ -259,6 +275,11 @@ describe("User Management Service", () => {
     it("should return the latest role for the state sysadmin", async () => {
       const [role] = getLatestRoleByEmail(OS_STATE_SYSTEM_ADMIN_EMAIL);
       const result = await getLatestActiveRoleByEmail(OS_STATE_SYSTEM_ADMIN_EMAIL);
+      expect(result).toEqual(role._source);
+    });
+    it("should return the latest role for mixed-case email input", async () => {
+      const [role] = getLatestRoleByEmail(OS_STATE_SUBMITTER_EMAIL);
+      const result = await getLatestActiveRoleByEmail("StateSubmitter@Nightwatch.Test");
       expect(result).toEqual(role._source);
     });
   });

--- a/lib/lambda/user-management/userManagementService.ts
+++ b/lib/lambda/user-management/userManagementService.ts
@@ -1,52 +1,91 @@
 import { search } from "libs";
 import { getDomainAndNamespace } from "libs/utils";
 import { Index, roles, users } from "shared-types/opensearch";
-import { getApprovingRole } from "shared-utils";
+import { getApprovingRole, normalizeEmail } from "shared-utils";
 
 const QUERY_LIMIT = 2000;
+
+const getEmailShouldClauses = (email?: string | null) => {
+  const normalizedEmail = normalizeEmail(email);
+  if (!normalizedEmail) {
+    return [];
+  }
+
+  return [
+    { term: { "email.keyword": normalizedEmail } },
+    {
+      wildcard: {
+        "email.keyword": {
+          value: normalizedEmail,
+          case_insensitive: true,
+        },
+      },
+    },
+  ];
+};
+
+const getCaseInsensitiveEmailQuery = (email?: string | null) => {
+  const should = getEmailShouldClauses(email);
+  if (!should.length) {
+    return null;
+  }
+
+  return {
+    bool: {
+      should,
+      minimum_should_match: 1,
+    },
+  };
+};
 
 export const getUserByEmail = async (
   email: string,
   domainNamespace?: { domain: string; index: Index },
 ): Promise<users.Document | null> => {
-  console.log("Looking up user by email:", email);
+  const normalizedEmail = normalizeEmail(email);
+  console.log("Looking up user by email:", normalizedEmail);
+  if (!normalizedEmail) {
+    return null;
+  }
   if (!domainNamespace) domainNamespace = getDomainAndNamespace("users");
   const { domain, index } = domainNamespace;
 
   const result = await search(domain, index, {
-    size: 1,
-    query: {
-      term: {
-        "email.keyword": email,
-      },
-    },
+    size: 10,
+    query: getCaseInsensitiveEmailQuery(normalizedEmail),
   });
 
-  return result.hits.hits[0]?._source ?? null;
+  const canonicalHit =
+    result.hits.hits.find((hit: any) => normalizeEmail(hit?._source?.email) === normalizedEmail) ??
+    result.hits.hits[0];
+
+  return canonicalHit?._source ?? null;
 };
 
 export const getUsersByEmails = async (
   emails: string[],
 ): Promise<Record<string, { fullName?: string }>> => {
+  const normalizedEmails = Array.from(
+    new Set((emails || []).map((email) => normalizeEmail(email)).filter(Boolean)),
+  );
+  if (!normalizedEmails.length) {
+    return {};
+  }
+
   const { domain, index } = getDomainAndNamespace("users");
   const results = await search(domain, index, {
     size: QUERY_LIMIT,
     query: {
       bool: {
-        should: emails
-          ?.filter((email) => email)
-          .map((email) => ({
-            term: {
-              "email.keyword": email,
-            },
-          })),
+        should: normalizedEmails.flatMap((email) => getEmailShouldClauses(email)),
+        minimum_should_match: 1,
       },
     },
   });
 
   return results.hits.hits.reduce(
     (acc: any, hit: any) => {
-      acc[hit._source.email] = hit._source;
+      acc[normalizeEmail(hit._source.email)] = hit._source;
       return acc;
     },
     {} as Record<string, { fullName?: string }>,
@@ -54,15 +93,15 @@ export const getUsersByEmails = async (
 };
 
 export const getAllUserRolesByEmail = async (email: string): Promise<roles.Document[]> => {
+  const normalizedEmail = normalizeEmail(email);
+  if (!normalizedEmail) {
+    return [];
+  }
   const { domain, index } = getDomainAndNamespace("roles");
 
   const result = await search(domain, index, {
     size: QUERY_LIMIT,
-    query: {
-      term: {
-        "email.keyword": email,
-      },
-    },
+    query: getCaseInsensitiveEmailQuery(normalizedEmail),
   });
 
   return result.hits.hits.map((hit: any) => ({ ...hit._source }));
@@ -73,6 +112,10 @@ export const userHasThisRole = async (
   state: string,
   role: string,
 ): Promise<boolean> => {
+  const normalizedEmail = normalizeEmail(email);
+  if (!normalizedEmail || !state || !role) {
+    return false;
+  }
   const { domain, index } = getDomainAndNamespace("roles");
 
   const result = await search(domain, index, {
@@ -80,7 +123,7 @@ export const userHasThisRole = async (
     query: {
       bool: {
         must: [
-          { term: { "email.keyword": email } },
+          { bool: { should: getEmailShouldClauses(normalizedEmail), minimum_should_match: 1 } },
           { term: { status: "active" } },
           { term: { role: role } },
           { term: { "territory.keyword": state } },
@@ -129,7 +172,7 @@ export const getUserRolesWithNames = async (roleRequests: any[]) => {
 
   const rolesWithName = roleRequests.map((roleObj) => {
     const email = roleObj.email;
-    const fullName = users[email]?.fullName || "Unknown";
+    const fullName = users[normalizeEmail(email)]?.fullName || "Unknown";
 
     return {
       ...roleObj,
@@ -142,13 +185,20 @@ export const getUserRolesWithNames = async (roleRequests: any[]) => {
 };
 
 export const getLatestActiveRoleByEmail = async (email: string): Promise<roles.Document | null> => {
+  const normalizedEmail = normalizeEmail(email);
+  if (!normalizedEmail) {
+    return null;
+  }
   const { domain, index } = getDomainAndNamespace("roles");
 
   const result = await search(domain, index, {
     size: 1,
     query: {
       bool: {
-        must: [{ term: { "email.keyword": email } }, { term: { status: "active" } }],
+        must: [
+          { bool: { should: getEmailShouldClauses(normalizedEmail), minimum_should_match: 1 } },
+          { term: { status: "active" } },
+        ],
       },
     },
     sort: [
@@ -279,6 +329,10 @@ export const getActiveStatesForUserByEmail = async (
   email: string,
   latestActiveRole?: string,
 ): Promise<string[]> => {
+  const normalizedEmail = normalizeEmail(email);
+  if (!normalizedEmail) {
+    return [];
+  }
   const { domain, index } = getDomainAndNamespace("roles");
 
   const result = await search(domain, index, {
@@ -286,7 +340,7 @@ export const getActiveStatesForUserByEmail = async (
     query: {
       bool: {
         must: [
-          { term: { "email.keyword": email } },
+          { bool: { should: getEmailShouldClauses(normalizedEmail), minimum_should_match: 1 } },
           { term: { status: "active" } },
           ...(latestActiveRole ? [{ term: { role: latestActiveRole } }] : []),
         ],
@@ -330,7 +384,7 @@ export const getStateUsersByState = async (
 
   const seen = new Set<string>();
   const emails = rolesResult.hits.hits
-    .map((hit: any) => hit._source.email)
+    .map((hit: any) => normalizeEmail(hit._source.email))
     .filter((email: string): email is string => {
       if (seen.has(email)) return false;
       seen.add(email);
@@ -343,9 +397,8 @@ export const getStateUsersByState = async (
     size: QUERY_LIMIT,
     query: {
       bool: {
-        should: emails.map((email: string) => ({
-          term: { "email.keyword": email },
-        })),
+        should: emails.flatMap((email: string) => getEmailShouldClauses(email)),
+        minimum_should_match: 1,
       },
     },
     _source: ["email", "fullName"],

--- a/lib/libs/api/auth/user.test.ts
+++ b/lib/libs/api/auth/user.test.ts
@@ -67,6 +67,29 @@ describe("Auth functions", () => {
         lookupUserAttributes("12345678-1234-1234-1234-123456789012", USER_POOL_ID),
       ).rejects.toThrow("No user found with this sub");
     });
+
+    it("lowercases email values from Cognito attributes", async () => {
+      const emailAttribute = testStateSubmitter.UserAttributes?.find(
+        (attr) => attr.Name === "email",
+      );
+      const originalEmail = emailAttribute?.Value;
+
+      if (!emailAttribute) {
+        throw new Error("Test user is missing email attribute");
+      }
+
+      emailAttribute.Value = "StateSubmitter@Nightwatch.Test";
+
+      try {
+        const userAttributes = await lookupUserAttributes(
+          testStateSubmitter.Username || "",
+          USER_POOL_ID,
+        );
+        expect(userAttributes.email).toBe("statesubmitter@nightwatch.test");
+      } finally {
+        emailAttribute.Value = originalEmail;
+      }
+    });
   });
 
   describe("isAuthorized", () => {

--- a/lib/libs/api/auth/user.ts
+++ b/lib/libs/api/auth/user.ts
@@ -5,7 +5,7 @@ import {
 } from "@aws-sdk/client-cognito-identity-provider";
 import { APIGatewayEvent } from "aws-lambda";
 import { CognitoUserAttributes } from "shared-types";
-import { isCmsUser, isCmsWriteUser, isHelpDeskUser } from "shared-utils";
+import { isCmsUser, isCmsWriteUser, isHelpDeskUser, normalizeEmail } from "shared-utils";
 
 import {
   getActiveStatesForUserByEmail,
@@ -38,6 +38,7 @@ function userAttrDict(cognitoUser: CognitoUserType): CognitoUserAttributes {
     });
   }
   attributes["username"] = cognitoUser.Username;
+  attributes["email"] = normalizeEmail(attributes["email"]);
 
   return attributes as CognitoUserAttributes;
 }

--- a/lib/packages/shared-utils/user-helper.test.ts
+++ b/lib/packages/shared-utils/user-helper.test.ts
@@ -10,6 +10,7 @@ import {
   isCmsWriteUser,
   isIDM,
   isStateUser,
+  normalizeEmail,
 } from ".";
 import {
   testCMSCognitoUser,
@@ -102,5 +103,16 @@ describe("canRequestAccess", () => {
   });
   it("should return true if the role is allowed to request access", () => {
     expect(canRequestAccess("statesubmitter")).toBeTruthy();
+  });
+});
+
+describe("normalizeEmail", () => {
+  it("returns a trimmed lowercase email", () => {
+    expect(normalizeEmail("  Mixed.Case@Example.com ")).toBe("mixed.case@example.com");
+  });
+
+  it("returns an empty string for missing values", () => {
+    expect(normalizeEmail()).toBe("");
+    expect(normalizeEmail(null)).toBe("");
   });
 });

--- a/lib/packages/shared-utils/user-helper.ts
+++ b/lib/packages/shared-utils/user-helper.ts
@@ -22,6 +22,8 @@ const userHasAuthorizedRole = (user: FullUser | UserDetails | null, authorized: 
   return authorized.includes(user.role);
 };
 
+export const normalizeEmail = (email?: string | null): string => email?.trim().toLowerCase() || "";
+
 /** Confirms user is any kind of CMS user */
 export const isCmsUser = (user: FullUser | UserDetails | null) =>
   userHasAuthorizedRole(user, CMS_ROLES);
@@ -69,7 +71,10 @@ export const canSelfRevokeAccess = (
   currentEmail: string,
   emailToUpdate: string,
 ) => {
-  return currentRole === "statesubmitter" && currentEmail === emailToUpdate;
+  return (
+    currentRole === "statesubmitter" &&
+    normalizeEmail(currentEmail) === normalizeEmail(emailToUpdate)
+  );
 };
 
 // gets the role that approves current user

--- a/mocks/data/osusers.ts
+++ b/mocks/data/osusers.ts
@@ -235,12 +235,18 @@ export const NO_STATE_SUBMITTER_USER = osUsers[NO_STATE_SUBMITTER_EMAIL];
 
 export const userResultList = Object.values(osUsers);
 
+const normalizeEmail = (email?: string | null) => email?.trim().toLowerCase() || "";
+
 export const getFilteredUserResultList = (emails: string[]) =>
-  userResultList.filter((user) => emails.includes(user?._source?.email || ""));
+  userResultList.filter((user) =>
+    emails.map(normalizeEmail).includes(normalizeEmail(user?._source?.email || "")),
+  );
 
 export const userDocList: TestUserDocument[] = userResultList
   .filter((user) => user?._source)
   .map((user) => user?._source as TestUserDocument);
 
 export const getFilteredUserDocList = (emails: string[]) =>
-  userDocList.filter((user) => emails.includes(user?.email || ""));
+  userDocList.filter((user) =>
+    emails.map(normalizeEmail).includes(normalizeEmail(user?.email || "")),
+  );

--- a/mocks/data/roles.ts
+++ b/mocks/data/roles.ts
@@ -740,8 +740,10 @@ export const roleResults: TestRoleResult[] = [
 
 export const roleDocs = roleResults.map((role) => role?._source as TestRoleDocument);
 
+const normalizeEmail = (email?: string | null) => email?.trim().toLowerCase() || "";
+
 export const getFilteredRolesByEmail = (email: string) =>
-  roleResults.filter((role) => role?._source?.email === email);
+  roleResults.filter((role) => normalizeEmail(role?._source?.email) === normalizeEmail(email));
 
 export const getFilteredRoleDocsByEmail = (email: string) =>
   getFilteredRolesByEmail(email).map((role) => role?._source as TestRoleDocument);
@@ -770,7 +772,11 @@ export const getFilteredRoleDocsByRole = (role: string) =>
 
 export const getLatestRoleByEmail = (email: string) =>
   roleResults
-    .filter((role) => role?._source?.email === email && role?._source?.status === "active")
+    .filter(
+      (role) =>
+        normalizeEmail(role?._source?.email) === normalizeEmail(email) &&
+        role?._source?.status === "active",
+    )
     .sort((a, b) => {
       const lastModifiedDateA = a?._source?.lastModifiedDate || 0;
       const lastModifiedDateB = b?._source?.lastModifiedDate || 0;
@@ -791,7 +797,7 @@ export const getActiveStatesForUserByEmail = (email: string, role?: string) =>
         .filter(
           (roleItem) =>
             roleItem &&
-            roleItem._source?.email === email &&
+            normalizeEmail(roleItem._source?.email) === normalizeEmail(email) &&
             (!role || roleItem._source?.role === role) &&
             roleItem._source?.status === "active",
         )
@@ -803,7 +809,7 @@ export const getActiveStatesForUserByEmail = (email: string, role?: string) =>
 export const getApprovedRoleByEmailAndState = (email: string, state: string, role: string) =>
   roleResults.find(
     (roleItem) =>
-      roleItem?._source?.email === email &&
+      normalizeEmail(roleItem?._source?.email) === normalizeEmail(email) &&
       roleItem?._source?.territory === state &&
       roleItem?._source?.role === role &&
       roleItem?._source?.status === "active",

--- a/mocks/handlers/opensearch/roles.ts
+++ b/mocks/handlers/opensearch/roles.ts
@@ -12,6 +12,44 @@ import {
 import { SearchQueryBody, TestRoleResult } from "../../index.d";
 import { getFilterValueAsString } from "../search.utils";
 
+type QueryRules = Parameters<typeof getFilterValueAsString>[0];
+
+const normalizeEmail = (email?: string | null) => email?.trim().toLowerCase() || "";
+
+const toQueryArray = (query: QueryRules) => (Array.isArray(query) ? query : query ? [query] : []);
+
+const getEmailFromShouldQuery = (should: QueryRules) => {
+  const termEmail = getFilterValueAsString(should, "term", "email.keyword");
+  if (termEmail) {
+    return normalizeEmail(termEmail);
+  }
+
+  const wildcardRule = toQueryArray(should).find(
+    (rule: any) => rule?.wildcard?.["email.keyword"],
+  ) as any;
+  const wildcardEmail = wildcardRule?.wildcard?.["email.keyword"];
+
+  if (typeof wildcardEmail === "string") {
+    return normalizeEmail(wildcardEmail);
+  }
+
+  if (wildcardEmail && typeof wildcardEmail === "object" && "value" in wildcardEmail) {
+    return normalizeEmail(String(wildcardEmail.value));
+  }
+
+  return "";
+};
+
+const getEmailFromMustQuery = (must: QueryRules) => {
+  const email = getEmailFromShouldQuery(must);
+  if (email) {
+    return email;
+  }
+
+  const boolRule = toQueryArray(must).find((rule: any) => rule?.bool?.should) as any;
+  return getEmailFromShouldQuery(boolRule?.bool?.should);
+};
+
 const defaultRoleSearchHandler = http.post<PathParams, SearchQueryBody>(
   "https://vpc-opensearchdomain-mock-domain.us-east-1.es.amazonaws.com/test-namespace-roles/_search",
   async ({ request }) => {
@@ -21,19 +59,22 @@ const defaultRoleSearchHandler = http.post<PathParams, SearchQueryBody>(
     if (query?.term?.["email.keyword"]) {
       const email = getFilterValueAsString(query, "term", "email.keyword") || "";
       hits = getFilteredRolesByEmail(email);
+    } else if (query?.bool?.should) {
+      const email = getEmailFromShouldQuery(query.bool.should);
+      hits = getFilteredRolesByEmail(email);
     } else if (query?.term?.["territory.keyword"]) {
       const state = getFilterValueAsString(query, "term", "territory.keyword") || "";
       hits = getFilteredRolesByState(state);
     } else if (query?.bool?.must && query?.bool?.must_not && _source) {
-      const email = getFilterValueAsString(query.bool.must, "term", "email.keyword") || "";
+      const email = getEmailFromMustQuery(query.bool.must);
       hits = getFilteredRolesByEmail(email).filter(
         (roleObj) => roleObj._source?.status === "active",
       );
     } else if (query?.bool?.must && size === 1) {
-      const email = getFilterValueAsString(query.bool.must, "term", "email.keyword") || "";
+      const email = getEmailFromMustQuery(query.bool.must);
       hits = getLatestRoleByEmail(email);
     } else if (query?.bool?.must) {
-      const email = getFilterValueAsString(query.bool.must, "term", "email.keyword") || "";
+      const email = getEmailFromMustQuery(query.bool.must);
       const role = getFilterValueAsString(query.bool.must, "term", "role") || "";
       const state = getFilterValueAsString(query.bool.must, "term", "territory.keyword") || "";
       if (email) {
@@ -91,6 +132,12 @@ export const errorOnSearchTypeRoleSearchHandler = (failOn: string) =>
         }
         const email = getFilterValueAsString(query, "term", "email.keyword") || "";
         hits = getFilteredRolesByEmail(email);
+      } else if (query?.bool?.should) {
+        if (failOn === "getAllUserRolesByEmail") {
+          return new HttpResponse("Internal server error", { status: 500 });
+        }
+        const email = getEmailFromShouldQuery(query.bool.should);
+        hits = getFilteredRolesByEmail(email);
       } else if (query?.term?.["territory.keyword"]) {
         if (failOn === "getAllUserRolesByState") {
           return new HttpResponse("Internal server error", { status: 500 });
@@ -101,7 +148,7 @@ export const errorOnSearchTypeRoleSearchHandler = (failOn: string) =>
         if (failOn === "getActiveStatesForUserByEmail") {
           return new HttpResponse("Internal server error", { status: 500 });
         }
-        const email = getFilterValueAsString(query.bool.must, "term", "email.keyword") || "";
+        const email = getEmailFromMustQuery(query.bool.must);
         hits = getFilteredRolesByEmail(email).filter(
           (roleObj) => roleObj._source?.status === "active",
         );
@@ -109,10 +156,10 @@ export const errorOnSearchTypeRoleSearchHandler = (failOn: string) =>
         if (failOn === "getLatestActiveRoleByEmail") {
           return new HttpResponse("Internal server error", { status: 500 });
         }
-        const email = getFilterValueAsString(query.bool.must, "term", "email.keyword") || "";
+        const email = getEmailFromMustQuery(query.bool.must);
         hits = getLatestRoleByEmail(email);
       } else if (query?.bool?.must) {
-        const email = getFilterValueAsString(query.bool.must, "term", "email.keyword") || "";
+        const email = getEmailFromMustQuery(query.bool.must);
         const role = getFilterValueAsString(query.bool.must, "term", "role") || "";
         const state = getFilterValueAsString(query.bool.must, "term", "territory.keyword") || "";
         if (email) {

--- a/mocks/handlers/opensearch/users.ts
+++ b/mocks/handlers/opensearch/users.ts
@@ -4,6 +4,12 @@ import { getFilteredUserResultList } from "../../data/osusers";
 import { SearchQueryBody } from "../../index.d";
 import { getFilterValueAsStringArray } from "../search.utils";
 
+type QueryRules = Parameters<typeof getFilterValueAsStringArray>[0];
+
+const normalizeEmail = (email?: string | null) => email?.trim().toLowerCase() || "";
+
+const toQueryArray = (query: QueryRules) => (Array.isArray(query) ? query : query ? [query] : []);
+
 const defaultUserSearchHandler = http.post<PathParams, SearchQueryBody>(
   "https://vpc-opensearchdomain-mock-domain.us-east-1.es.amazonaws.com/test-namespace-users/_search",
   async ({ request }) => {
@@ -16,7 +22,17 @@ const defaultUserSearchHandler = http.post<PathParams, SearchQueryBody>(
     }
     if (query?.bool?.should) {
       const should = query?.bool?.should;
-      emails = getFilterValueAsStringArray(should, "term", "email.keyword");
+      const termEmails = getFilterValueAsStringArray(should, "term", "email.keyword");
+      const wildcardEmails = toQueryArray(should)
+        .map((rule: any) => rule?.wildcard?.["email.keyword"])
+        .flatMap((value: any) =>
+          typeof value === "string"
+            ? [value]
+            : value && typeof value === "object" && "value" in value
+              ? [String(value.value)]
+              : [],
+        );
+      emails = [...new Set([...termEmails, ...wildcardEmails].map(normalizeEmail).filter(Boolean))];
     }
 
     const hits = getFilteredUserResultList(emails);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:archive": "test -d lib/attachment-archive/node_modules || (echo 'Missing lib/attachment-archive dependencies. Run ./run install.' >&2; exit 1); (cd lib/attachment-archive && bun run typecheck)",
     "build:mocks": "(cd mocks && bun run build)",
     "build:ui": "(cd react-app && bun run build)",
+    "audit:case-email-duplicates": "tsx scripts/audit-case-insensitive-user-duplicates.ts",
     "repair:attachment-scan-status": "tsx scripts/repair-attachment-scan-status.ts",
     "export:opensearch": "tsx scripts/export-opensearch-to-s3.ts",
     "watch": "tsc -w",

--- a/scripts/audit-case-insensitive-user-duplicates.ts
+++ b/scripts/audit-case-insensitive-user-duplicates.ts
@@ -1,0 +1,215 @@
+import process from "node:process";
+
+import {
+  AdminDisableUserCommand,
+  CognitoIdentityProviderClient,
+  ListUsersCommand,
+  type UserType,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { fromIni } from "@aws-sdk/credential-providers";
+
+type Options = {
+  userPoolId: string;
+  region: string;
+  profile?: string;
+  apply: boolean;
+  disableDuplicates: boolean;
+};
+
+type UserSummary = {
+  username: string;
+  email: string;
+  normalizedEmail: string;
+  enabled: boolean;
+  status?: string;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+const parseArgs = (argv: string[]): Options => {
+  const options: Partial<Options> = {
+    region: process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || "us-east-1",
+    apply: false,
+    disableDuplicates: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === "--user-pool-id" && next) {
+      options.userPoolId = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--region" && next) {
+      options.region = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--profile" && next) {
+      options.profile = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--apply") {
+      options.apply = true;
+      continue;
+    }
+
+    if (arg === "--disable-duplicates") {
+      options.disableDuplicates = true;
+      continue;
+    }
+  }
+
+  if (!options.userPoolId) {
+    throw new Error(
+      "Missing required argument --user-pool-id. Example: bunx tsx scripts/audit-case-insensitive-user-duplicates.ts --user-pool-id us-east-1_example",
+    );
+  }
+
+  return options as Options;
+};
+
+const normalizeEmail = (email?: string | null) => email?.trim().toLowerCase() || "";
+
+const getEmail = (user: UserType): string => {
+  const attribute = user.Attributes?.find((item) => item.Name === "email");
+  return attribute?.Value || "";
+};
+
+const summarizeUser = (user: UserType): UserSummary | null => {
+  const email = getEmail(user);
+  const normalizedEmail = normalizeEmail(email);
+
+  if (!normalizedEmail || !user.Username) {
+    return null;
+  }
+
+  return {
+    username: user.Username,
+    email,
+    normalizedEmail,
+    enabled: user.Enabled ?? false,
+    status: user.UserStatus,
+    createdAt: user.UserCreateDate?.toISOString(),
+    updatedAt: user.UserLastModifiedDate?.toISOString(),
+  };
+};
+
+const chooseCanonicalUser = (users: UserSummary[]) =>
+  [...users].sort((left, right) => {
+    if (normalizeEmail(left.email) === left.email && normalizeEmail(right.email) !== right.email) {
+      return -1;
+    }
+    if (normalizeEmail(left.email) !== left.email && normalizeEmail(right.email) === right.email) {
+      return 1;
+    }
+    if ((left.enabled ? 1 : 0) !== (right.enabled ? 1 : 0)) {
+      return right.enabled ? 1 : -1;
+    }
+    return (left.createdAt || "").localeCompare(right.createdAt || "");
+  })[0];
+
+const listAllUsers = async (client: CognitoIdentityProviderClient, userPoolId: string) => {
+  const users: UserType[] = [];
+  let paginationToken: string | undefined;
+
+  do {
+    const response = await client.send(
+      new ListUsersCommand({
+        UserPoolId: userPoolId,
+        Limit: 60,
+        PaginationToken: paginationToken,
+      }),
+    );
+
+    users.push(...(response.Users || []));
+    paginationToken = response.PaginationToken;
+  } while (paginationToken);
+
+  return users;
+};
+
+const main = async () => {
+  const options = parseArgs(process.argv.slice(2));
+
+  const client = new CognitoIdentityProviderClient({
+    region: options.region,
+    credentials: options.profile ? fromIni({ profile: options.profile }) : undefined,
+  });
+
+  const users = await listAllUsers(client, options.userPoolId);
+  const grouped = new Map<string, UserSummary[]>();
+
+  for (const user of users) {
+    const summary = summarizeUser(user);
+    if (!summary) {
+      continue;
+    }
+
+    const existing = grouped.get(summary.normalizedEmail) || [];
+    existing.push(summary);
+    grouped.set(summary.normalizedEmail, existing);
+  }
+
+  const duplicates = [...grouped.entries()]
+    .filter(([, groupedUsers]) => groupedUsers.length > 1)
+    .map(([normalizedEmail, groupedUsers]) => {
+      const canonical = chooseCanonicalUser(groupedUsers);
+      const duplicatesToDisable = groupedUsers.filter(
+        (user) => user.username !== canonical.username,
+      );
+
+      return {
+        normalizedEmail,
+        canonical,
+        duplicates: duplicatesToDisable,
+      };
+    })
+    .sort((left, right) => left.normalizedEmail.localeCompare(right.normalizedEmail));
+
+  const report = {
+    userPoolId: options.userPoolId,
+    region: options.region,
+    totalUsers: users.length,
+    duplicateEmailGroups: duplicates.length,
+    dryRun: !options.apply,
+    disableDuplicatesRequested: options.disableDuplicates,
+    duplicates,
+  };
+
+  console.log(JSON.stringify(report, null, 2));
+
+  if (!options.apply || !options.disableDuplicates) {
+    return;
+  }
+
+  for (const duplicateGroup of duplicates) {
+    for (const duplicate of duplicateGroup.duplicates) {
+      if (!duplicate.enabled) {
+        continue;
+      }
+
+      await client.send(
+        new AdminDisableUserCommand({
+          UserPoolId: options.userPoolId,
+          Username: duplicate.username,
+        }),
+      );
+
+      console.log(
+        `Disabled duplicate user ${duplicate.username} for ${duplicateGroup.normalizedEmail}`,
+      );
+    }
+  }
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What Changed

- Normalizes authenticated user email values to lowercase before user-management processing.
- Makes user-management user and role lookups case-insensitive against OpenSearch so legacy mixed-case records still resolve.
- Writes new user-profile and role-request events with lowercase email values and lowercase email-derived IDs in the touched user-management flows.
- Compares self-view and self-revoke email checks case-insensitively.
- Adds a dry-run duplicate-account audit script for finding case-insensitive duplicate Cognito users.
- Updates focused mocks and tests for mixed-case email lookup behavior.

## Jira

- Implementation ticket: OY2-37506
- Follow-up manual remediation/business review ticket: OY2-40615

## What This Does Not Do

- Does not automatically merge, delete, disable, or backfill existing duplicate accounts during normal application flows.
- Does not bulk rewrite existing OpenSearch user or role records.
- Does not define final business rules for choosing a canonical survivor across duplicate accounts.
- Does not make IdP-side configuration changes.

## Read-Only Audit Summary

Read-only checks were run across dev, val, and production on July 8, 2026. The detailed findings are captured in OY2-40615.

- Dev: Cognito auth has 2 duplicate groups; OpenSearch users has 2 case-variant groups; OpenSearch roles has 2 case-variant groups.
- Val: Cognito auth has 3 duplicate groups; OpenSearch users has 4 case-variant groups; OpenSearch roles has 2 case-variant groups.
- Production: Cognito auth has 3 duplicate groups; OpenSearch users has 22 case-variant groups; OpenSearch roles has 21 case-variant groups.
- Cognito search pools had 0 duplicate email groups in all three environments.

## Validation

- `./run test --run lib/lambda/user-management/userManagementService.test.ts lib/libs/api/auth/user.test.ts lib/packages/shared-utils/user-helper.test.ts`
- Pre-push hook on `git push origin email-os-sens` passed ESLint, large-file check, and secret detection.

## Notes

The branch was already up to date with `origin/main`; `git merge origin/main --no-edit` returned `Already up to date.`
