### PR TITLE
fix(clamav): prevent ENOSPC from permanently blocking attachment downloads

### DIFF
--- a/lib/local-constructs/clamav-scanning/Dockerfile
+++ b/lib/local-constructs/clamav-scanning/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 oven/bun:1.1.20-alpine AS builder
 
 # Increment CACHE_BUST to force Docker to pull a fresh base image (e.g., for security patches)
-ARG CACHE_BUST=2026-07-23-clamav-al2023-latest-security-refresh
+ARG CACHE_BUST=2026-07-27-enospc-tmp-cleanup
 LABEL cache.bust="${CACHE_BUST}"
 
 WORKDIR /app
@@ -15,7 +15,7 @@ RUN bun run build
 
 FROM --platform=linux/amd64 public.ecr.aws/lambda/nodejs:24
 
-ARG CACHE_BUST=2026-07-23-clamav-al2023-latest-security-refresh
+ARG CACHE_BUST=2026-07-27-enospc-tmp-cleanup
 LABEL cache.bust="${CACHE_BUST}"
 
 WORKDIR ${LAMBDA_TASK_ROOT}

--- a/lib/local-constructs/clamav-scanning/index.ts
+++ b/lib/local-constructs/clamav-scanning/index.ts
@@ -163,7 +163,7 @@ export class ClamScanScanner extends Construct {
     const clamscanDefsLogGroup = new logs.LogGroup(this, `${id}ClamDefsLogGroup`, {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
-    const clamAvImageCacheBust = "2026-07-23-clamav-al2023-latest-security-refresh";
+    const clamAvImageCacheBust = "2026-07-27-enospc-tmp-cleanup";
 
     const clamDefsLambda = new DockerImageFunction(this, "ServerlessClamDefs", {
       code: DockerImageCode.fromImageAsset(__dirname, {
@@ -174,6 +174,7 @@ export class ClamScanScanner extends Construct {
       }),
       timeout: cdk.Duration.minutes(1),
       memorySize: 10240,
+      ephemeralStorageSize: cdk.Size.mebibytes(2048),
       role: this.lambdaRole,
       logGroup: clamscanDefsLogGroup,
       onSuccess: new destinations.SqsDestination(successQueue),
@@ -196,6 +197,7 @@ export class ClamScanScanner extends Construct {
       }),
       timeout,
       memorySize: 10240,
+      ephemeralStorageSize: cdk.Size.mebibytes(2048),
       role: this.lambdaRole,
       logGroup: clamscanLambdaLogGroup,
       onSuccess: new destinations.SqsDestination(successQueue),

--- a/lib/local-constructs/clamav-scanning/src/handlers/scan.test.ts
+++ b/lib/local-constructs/clamav-scanning/src/handlers/scan.test.ts
@@ -13,7 +13,18 @@ import {
   STATUS_ERROR_PROCESSING_FILE,
   tagWithScanStatus,
 } from "./../lib";
-import { handler } from "./scan";
+import { handler, isTransientScanError } from "./scan";
+
+const { unlinkMock } = vi.hoisted(() => ({
+  unlinkMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("fs/promises", () => ({
+  default: {
+    unlink: unlinkMock,
+  },
+  unlink: unlinkMock,
+}));
 
 vi.mock("pino", () => {
   return {
@@ -75,6 +86,7 @@ test("should handle event and return scan results", async () => {
   (checkFileExt as any).mockResolvedValueOnce(STATUS_CLEAN_FILE);
   (scanLocalFile as any).mockResolvedValueOnce(STATUS_CLEAN_FILE);
   (tagWithScanStatus as any).mockResolvedValueOnce(undefined);
+  unlinkMock.mockClear();
 
   const result = await handler(mockEvent);
 
@@ -86,8 +98,10 @@ test("should handle event and return scan results", async () => {
   expect(downloadFileFromS3).toHaveBeenCalledWith("test-key", "test-bucket");
   expect(checkFileExt).toHaveBeenCalledWith("file-location");
   expect(scanLocalFile).toHaveBeenCalledWith("file-location");
+  expect(tagWithScanStatus).toHaveBeenCalledTimes(1);
   expect(tagWithScanStatus).toHaveBeenCalledWith("test-bucket", "test-key", STATUS_CLEAN_FILE);
-  expect(result).toEqual([STATUS_CLEAN_FILE, STATUS_CLEAN_FILE]);
+  expect(unlinkMock).toHaveBeenCalledWith("file-location");
+  expect(result).toEqual([STATUS_CLEAN_FILE]);
 });
 
 test("should handle errors during event processing", async () => {
@@ -103,4 +117,32 @@ test("should handle errors during event processing", async () => {
   expect(startClamd).toHaveBeenCalled();
   expect(extractKeyFromS3Event).toHaveBeenCalled();
   expect(result).toEqual([STATUS_ERROR_PROCESSING_FILE]);
+});
+
+test("should cleanup local download and avoid ERROR tag on ENOSPC", async () => {
+  const enospc = Object.assign(new Error("ENOSPC: no space left on device, write"), {
+    code: "ENOSPC",
+  });
+
+  (downloadAVDefinitions as any).mockResolvedValueOnce(undefined);
+  (startClamd as any).mockResolvedValueOnce(undefined);
+  (extractKeyFromS3Event as any).mockReturnValueOnce("test-key");
+  (extractBucketFromS3Event as any).mockReturnValueOnce("test-bucket");
+  (checkFileSize as any).mockResolvedValueOnce(STATUS_CLEAN_FILE);
+  (downloadFileFromS3 as any).mockResolvedValueOnce("file-location");
+  (checkFileExt as any).mockResolvedValueOnce(STATUS_CLEAN_FILE);
+  (scanLocalFile as any).mockRejectedValueOnce(enospc);
+  unlinkMock.mockClear();
+
+  await expect(handler(mockEvent)).rejects.toThrow(/ENOSPC/);
+  expect(tagWithScanStatus).not.toHaveBeenCalled();
+  expect(unlinkMock).toHaveBeenCalledWith("file-location");
+});
+
+test("isTransientScanError detects disk-full failures", () => {
+  expect(isTransientScanError(Object.assign(new Error("write failed"), { code: "ENOSPC" }))).toBe(
+    true,
+  );
+  expect(isTransientScanError(new Error("ENOSPC: no space left on device, write"))).toBe(true);
+  expect(isTransientScanError(new Error("AccessDenied"))).toBe(false);
 });

--- a/lib/local-constructs/clamav-scanning/src/handlers/scan.ts
+++ b/lib/local-constructs/clamav-scanning/src/handlers/scan.ts
@@ -16,12 +16,16 @@ import {
 } from "./../lib";
 const logger = pino();
 
+function getErrorCode(error: unknown): string | undefined {
+  if (error && typeof error === "object" && "code" in error) {
+    return String((error as { code?: unknown }).code);
+  }
+  return undefined;
+}
+
 export function isTransientScanError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : `${error}`;
-  const code =
-    error && typeof error === "object" && "code" in error
-      ? String((error as { code?: unknown }).code)
-      : undefined;
+  const code = getErrorCode(error);
 
   return (
     code === "ENOSPC" || message.includes("ENOSPC") || message.includes("no space left on device")
@@ -36,11 +40,7 @@ async function cleanupLocalDownload(fileLoc: string | undefined): Promise<void> 
   try {
     await fs.unlink(fileLoc);
   } catch (error) {
-    const code =
-      error && typeof error === "object" && "code" in error
-        ? String((error as { code?: unknown }).code)
-        : undefined;
-    if (code !== "ENOENT") {
+    if (getErrorCode(error) !== "ENOENT") {
       logger.error({ err: error, fileLoc }, "Failed to cleanup local download");
     }
   }
@@ -95,8 +95,6 @@ export async function handler(event: any): Promise<string[]> {
       await tagWithScanStatus(s3ObjectBucket, s3ObjectKey, virusScanStatus);
       results.push(virusScanStatus);
     } catch (error) {
-      // Transient disk pressure should fail the invocation so SQS can retry on a
-      // healthy environment instead of permanently tagging the object ERROR.
       if (isTransientScanError(error)) {
         logger.error({ err: error, s3ObjectBucket, s3ObjectKey }, "Transient scan failure");
         throw error;

--- a/lib/local-constructs/clamav-scanning/src/handlers/scan.ts
+++ b/lib/local-constructs/clamav-scanning/src/handlers/scan.ts
@@ -24,9 +24,7 @@ export function isTransientScanError(error: unknown): boolean {
       : undefined;
 
   return (
-    code === "ENOSPC" ||
-    message.includes("ENOSPC") ||
-    message.includes("no space left on device")
+    code === "ENOSPC" || message.includes("ENOSPC") || message.includes("no space left on device")
   );
 }
 

--- a/lib/local-constructs/clamav-scanning/src/handlers/scan.ts
+++ b/lib/local-constructs/clamav-scanning/src/handlers/scan.ts
@@ -1,3 +1,4 @@
+import fs from "fs/promises";
 import pino from "pino";
 
 import {
@@ -14,6 +15,38 @@ import {
   tagWithScanStatus,
 } from "./../lib";
 const logger = pino();
+
+export function isTransientScanError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : `${error}`;
+  const code =
+    error && typeof error === "object" && "code" in error
+      ? String((error as { code?: unknown }).code)
+      : undefined;
+
+  return (
+    code === "ENOSPC" ||
+    message.includes("ENOSPC") ||
+    message.includes("no space left on device")
+  );
+}
+
+async function cleanupLocalDownload(fileLoc: string | undefined): Promise<void> {
+  if (!fileLoc) {
+    return;
+  }
+
+  try {
+    await fs.unlink(fileLoc);
+  } catch (error) {
+    const code =
+      error && typeof error === "object" && "code" in error
+        ? String((error as { code?: unknown }).code)
+        : undefined;
+    if (code !== "ENOENT") {
+      logger.error({ err: error, fileLoc }, "Failed to cleanup local download");
+    }
+  }
+}
 
 export async function handler(event: any): Promise<string[]> {
   logger.info("Download AV Definitions");
@@ -44,6 +77,7 @@ export async function handler(event: any): Promise<string[]> {
     }
 
     let virusScanStatus: string;
+    let fileLoc: string | undefined;
 
     try {
       virusScanStatus = await checkFileSize(s3ObjectKey, s3ObjectBucket);
@@ -52,7 +86,7 @@ export async function handler(event: any): Promise<string[]> {
         results.push(virusScanStatus);
         continue;
       }
-      const fileLoc: string = await downloadFileFromS3(s3ObjectKey, s3ObjectBucket);
+      fileLoc = await downloadFileFromS3(s3ObjectKey, s3ObjectBucket);
       virusScanStatus = await checkFileExt(fileLoc);
       if (virusScanStatus !== STATUS_CLEAN_FILE) {
         await tagWithScanStatus(s3ObjectBucket, s3ObjectKey, virusScanStatus);
@@ -62,14 +96,20 @@ export async function handler(event: any): Promise<string[]> {
       virusScanStatus = (await scanLocalFile(fileLoc))!;
       await tagWithScanStatus(s3ObjectBucket, s3ObjectKey, virusScanStatus);
       results.push(virusScanStatus);
-    } catch {
+    } catch (error) {
+      // Transient disk pressure should fail the invocation so SQS can retry on a
+      // healthy environment instead of permanently tagging the object ERROR.
+      if (isTransientScanError(error)) {
+        logger.error({ err: error, s3ObjectBucket, s3ObjectKey }, "Transient scan failure");
+        throw error;
+      }
+
       virusScanStatus = STATUS_ERROR_PROCESSING_FILE;
       await tagWithScanStatus(s3ObjectBucket, s3ObjectKey, virusScanStatus);
       results.push(virusScanStatus);
+    } finally {
+      await cleanupLocalDownload(fileLoc);
     }
-
-    await tagWithScanStatus(s3ObjectBucket, s3ObjectKey, virusScanStatus);
-    results.push(virusScanStatus);
   }
 
   return results;

--- a/lib/local-constructs/clamav-scanning/src/lib/s3.ts
+++ b/lib/local-constructs/clamav-scanning/src/lib/s3.ts
@@ -47,8 +47,9 @@ export async function downloadFileFromS3(
     fs.mkdirSync(constants.TMP_DOWNLOAD_PATH);
   }
 
-  const localPath: string = `${constants.TMP_DOWNLOAD_PATH}${randomUUID()}--${s3ObjectKey}`;
-  fs.createWriteStream(localPath);
+  // Keep filenames unique and filesystem-safe; object keys may include path separators.
+  const safeKey = s3ObjectKey.replace(/[\\/]/g, "_");
+  const localPath: string = `${constants.TMP_DOWNLOAD_PATH}${randomUUID()}--${safeKey}`;
 
   logger.info(`Downloading file s3://${s3ObjectBucket}/${s3ObjectKey}`);
 
@@ -67,6 +68,11 @@ export async function downloadFileFromS3(
     return localPath;
   } catch (err) {
     logger.error(err);
+    try {
+      await asyncfs.unlink(localPath);
+    } catch {
+      // Ignore cleanup failures for partial downloads.
+    }
     throw err;
   }
 }

--- a/lib/local-constructs/clamav-scanning/src/lib/s3.ts
+++ b/lib/local-constructs/clamav-scanning/src/lib/s3.ts
@@ -47,7 +47,6 @@ export async function downloadFileFromS3(
     fs.mkdirSync(constants.TMP_DOWNLOAD_PATH);
   }
 
-  // Keep filenames unique and filesystem-safe; object keys may include path separators.
   const safeKey = s3ObjectKey.replace(/[\\/]/g, "_");
   const localPath: string = `${constants.TMP_DOWNLOAD_PATH}${randomUUID()}--${safeKey}`;
 
@@ -71,7 +70,7 @@ export async function downloadFileFromS3(
     try {
       await asyncfs.unlink(localPath);
     } catch {
-      // Ignore cleanup failures for partial downloads.
+      // ignore
     }
     throw err;
   }


### PR DESCRIPTION
## Problem

On VAL, users could not download attachments (single file or Download all) for recently uploaded packages. The UI showed messages like “file scanning did not complete successfully” / “unable to prepare the attachment archive.”

Root cause: the ClamAV scanner Lambda was writing uploads into `/tmp` and never deleting them. On a warm environment, `/tmp` filled up (`ENOSPC`). Failures were caught and the object was permanently tagged `virusScanStatus=ERROR`, which blocks downloads via the attachments bucket policy. Default ephemeral storage (512 MB) left little headroom once AV definitions were loaded.

## Quick fix (already applied on VAL)

- Recycled the ClamAV Lambda execution environment to clear `/tmp`
- Redrove scans for affected packages so tags returned to `CLEAN`
- Cleared stuck archive `FAILED` state and rebuilt archives where needed

## Long-term fix (this PR)

- Delete local `/tmp` downloads after each scan (success or failure)
- Increase Lambda ephemeral storage to 2048 MiB for defs and scan functions
- Treat `ENOSPC` as transient: fail the invocation so SQS can retry instead of permanently tagging `ERROR`
- Sanitize temp filenames for keys with path separators and clean up partial downloads
- Cache-bust the Docker image so the rebuilt scanner ships with the handler changes
- Add unit coverage for cleanup and transient disk-full behavior

## Test plan

- [ ] `./run test --run lib/local-constructs/clamav-scanning`
- [ ] Confirm CDK synth includes `ephemeralStorageSize` on ClamAV Lambdas
- [ ] After deploy: upload a test attachment, verify `virusScanStatus=CLEAN` and single/archive download succeed
- [ ] Confirm scanner logs show local download cleanup and no recurring `ENOSPC` under normal load