### PR TITLE
fix(legacy noso fix): support legacy NOSO subsequent documents and batch user lookups

### DIFF
--- a/lib/lambda/user-management/userManagementService.test.ts
+++ b/lib/lambda/user-management/userManagementService.test.ts
@@ -1,3 +1,4 @@
+import * as libs from "libs";
 import {
   getFilteredRoleDocsByEmail,
   getFilteredRoleDocsByState,
@@ -139,6 +140,22 @@ describe("User Management Service", () => {
         [OS_STATE_SUBMITTER_EMAIL]: OS_STATE_SUBMITTER_USER._source,
         [OS_STATE_SYSTEM_ADMIN_EMAIL]: OS_STATE_SYSTEM_ADMIN_USER._source,
       });
+    });
+    it("should chunk large email searches below the OpenSearch boolean clause limit", async () => {
+      const searchSpy = vi.spyOn(libs, "search").mockResolvedValue({
+        hits: {
+          hits: [],
+        },
+      } as any);
+
+      const emails = Array.from({ length: 501 }, (_, index) => `user-${index}@example.com`);
+
+      await expect(getUsersByEmails(emails)).resolves.toEqual({});
+      expect(searchSpy).toHaveBeenCalledTimes(3);
+      expect(searchSpy.mock.calls.map(([, , query]) => query.query.bool.should.length)).toEqual([
+        500, 500, 2,
+      ]);
+      searchSpy.mockRestore();
     });
   });
 

--- a/lib/lambda/user-management/userManagementService.ts
+++ b/lib/lambda/user-management/userManagementService.ts
@@ -4,6 +4,9 @@ import { Index, roles, users } from "shared-types/opensearch";
 import { getApprovingRole, normalizeEmail } from "shared-utils";
 
 const QUERY_LIMIT = 2000;
+// Each email adds a term and wildcard clause. Keep batches safely below OpenSearch's
+// default 1,024-clause boolean query limit.
+const EMAIL_QUERY_CHUNK_SIZE = 250;
 
 const getEmailShouldClauses = (email?: string | null) => {
   const normalizedEmail = normalizeEmail(email);
@@ -73,23 +76,34 @@ export const getUsersByEmails = async (
   }
 
   const { domain, index } = getDomainAndNamespace("users");
-  const results = await search(domain, index, {
-    size: QUERY_LIMIT,
-    query: {
-      bool: {
-        should: normalizedEmails.flatMap((email) => getEmailShouldClauses(email)),
-        minimum_should_match: 1,
-      },
-    },
-  });
-
-  return results.hits.hits.reduce(
-    (acc: any, hit: any) => {
-      acc[normalizeEmail(hit._source.email)] = hit._source;
-      return acc;
-    },
-    {} as Record<string, { fullName?: string }>,
+  const emailChunks = Array.from(
+    { length: Math.ceil(normalizedEmails.length / EMAIL_QUERY_CHUNK_SIZE) },
+    (_, index) =>
+      normalizedEmails.slice(index * EMAIL_QUERY_CHUNK_SIZE, (index + 1) * EMAIL_QUERY_CHUNK_SIZE),
   );
+  const results = await Promise.all(
+    emailChunks.map((emailChunk) =>
+      search(domain, index, {
+        size: QUERY_LIMIT,
+        query: {
+          bool: {
+            should: emailChunk.flatMap((email) => getEmailShouldClauses(email)),
+            minimum_should_match: 1,
+          },
+        },
+      }),
+    ),
+  );
+
+  return results
+    .flatMap((result) => result.hits.hits)
+    .reduce(
+      (acc: any, hit: any) => {
+        acc[normalizeEmail(hit._source.email)] = hit._source;
+        return acc;
+      },
+      {} as Record<string, { fullName?: string }>,
+    );
 };
 
 export const getAllUserRolesByEmail = async (email: string): Promise<roles.Document[]> => {

--- a/react-app/src/features/forms/post-submission/upload-subsequent-documents/effective-chip-event.test.tsx
+++ b/react-app/src/features/forms/post-submission/upload-subsequent-documents/effective-chip-event.test.tsx
@@ -60,3 +60,59 @@ describe("Upload Subsequent Documents for backend-converted CHIP Eligibility pac
     expect(screen.queryByText("Subsequent CHIP SPA Documents")).not.toBeInTheDocument();
   });
 });
+
+describe("Upload Subsequent Documents for legacy packages", () => {
+  beforeEach(() => {
+    cleanup();
+    delete process.env.SKIP_CLEANUP;
+  });
+
+  afterEach(() => {
+    delete process.env.SKIP_CLEANUP;
+  });
+
+  it("uses the package authority when the changelog has no initial submission event", async () => {
+    const id = "TX-21-0009";
+
+    mockedServer.use(
+      onceApiItemHandler({
+        _id: id,
+        found: true,
+        _source: {
+          id,
+          actionType: "New",
+          authority: "Medicaid SPA",
+          origin: "OneMACLegacy",
+          changelog: [
+            {
+              _id: `${id}-313433`,
+              _source: {
+                id: `${id}-313433`,
+                packageId: id,
+                event: "respond-to-rai",
+                timestamp: 1781214697656,
+              },
+            },
+            {
+              _id: `${id}-legacy-1741902359431`,
+              _source: {
+                id: `${id}-legacy-1741902359431`,
+                packageId: id,
+                event: "respond-to-rai",
+                timestamp: 1741902359431,
+              },
+            },
+          ],
+        },
+      } as opensearch.main.ItemResult),
+    );
+
+    await renderFormWithPackageSectionAsync(<UploadSubsequentDocuments />, id, "Medicaid SPA");
+
+    expect(screen.queryByRole("heading", { name: "dashboard test" })).not.toBeInTheDocument();
+    expect(screen.getByTestId("detail-section-title")).toHaveTextContent(
+      "Medicaid SPA Subsequent Documents Details",
+    );
+    expect(screen.getByTestId("cmsForm179-label")).toHaveTextContent("CMS-179 Form");
+  });
+});

--- a/react-app/src/features/forms/post-submission/upload-subsequent-documents/index.tsx
+++ b/react-app/src/features/forms/post-submission/upload-subsequent-documents/index.tsx
@@ -1,4 +1,5 @@
 import { Navigate, useParams } from "react-router";
+import { opensearch } from "shared-types";
 import { z } from "zod";
 
 import { useGetItem } from "@/api";
@@ -16,6 +17,72 @@ import { formSchemas } from "@/formSchemas";
 import { getEffectiveInitialSubmissionEvent } from "@/utils/chipEligibility";
 
 import { getFAQLinkForAttachments } from "../../faqLinks";
+
+const initialSubmissionEvents = [
+  "app-k",
+  "capitated-amendment",
+  "capitated-initial",
+  "capitated-renewal",
+  "contracting-amendment",
+  "contracting-initial",
+  "contracting-renewal",
+  "new-chip-details-submission",
+  "new-chip-submission",
+  "new-medicaid-submission",
+  "temporary-extension",
+] as const;
+
+type InitialSubmissionEvent = (typeof initialSubmissionEvents)[number];
+
+const isInitialSubmissionEvent = (event?: string | null): event is InitialSubmissionEvent =>
+  initialSubmissionEvents.some((submissionEvent) => submissionEvent === event);
+
+const inferInitialSubmissionEvent = (
+  submission: opensearch.main.Document,
+): InitialSubmissionEvent | null => {
+  const candidateEvents = [
+    submission.event,
+    submission.mockEvent,
+    ...(submission.changelog ?? []).map((item) => item._source?.event),
+  ];
+  const initialSubmissionEvent = candidateEvents.find(isInitialSubmissionEvent);
+
+  if (initialSubmissionEvent) {
+    return initialSubmissionEvent;
+  }
+
+  // Legacy packages may only have post-submission changelog events. In that case,
+  // reconstruct the initial form type from stable package metadata.
+  if (submission.actionType?.toLocaleLowerCase().includes("extend")) {
+    return "temporary-extension";
+  }
+
+  switch (submission.authority) {
+    case "Medicaid SPA":
+      return "new-medicaid-submission";
+    case "CHIP SPA":
+      return "new-chip-submission";
+    case "1915(c)":
+      return "app-k";
+    case "1915(b)": {
+      const waiverType =
+        "waiverAuthority" in submission && submission.waiverAuthority === "1915(b)(4)"
+          ? "contracting"
+          : "capitated";
+      const actionType = submission.actionType?.toLocaleLowerCase() ?? "";
+
+      if (actionType.includes("renew")) {
+        return `${waiverType}-renewal`;
+      }
+      if (actionType.includes("amend")) {
+        return `${waiverType}-amendment`;
+      }
+      return `${waiverType}-initial`;
+    }
+    default:
+      return null;
+  }
+};
 
 const pickAttachmentsAndAdditionalInfo = (
   schema: SchemaWithEnforcableProps,
@@ -107,24 +174,15 @@ export const UploadSubsequentDocuments = () => {
     return <Navigate to="/dashboard" />;
   }
 
-  let originalSubmissionEvent = (submission._source.changelog ?? []).reduce<string | null>(
-    (acc, { _source }) => (_source?.event ? _source?.event : acc),
-    null,
-  );
-  if (originalSubmissionEvent === "NOSO") {
-    originalSubmissionEvent = submission._source.mockEvent;
-  }
-
-  if (originalSubmissionEvent === "split-spa") {
-    originalSubmissionEvent = submission._source.mockEvent;
-  }
+  const originalSubmissionEvent = inferInitialSubmissionEvent(submission._source);
 
   const effectiveSubmissionEvent = getEffectiveInitialSubmissionEvent(
     submission._source,
     originalSubmissionEvent,
   );
 
-  const schema: SchemaWithEnforcableProps | undefined = formSchemas[effectiveSubmissionEvent];
+  const schema: SchemaWithEnforcableProps | undefined =
+    effectiveSubmissionEvent === null ? undefined : formSchemas[effectiveSubmissionEvent];
 
   if (schema === undefined) {
     return <Navigate to="/dashboard" />;


### PR DESCRIPTION
## Context
This PR addresses two production issues:
Legacy/NOSO packages such as TX-21-0009 redirect users to the dashboard when they select Upload Subsequent Document.
The User Management table appears empty for Help Desk and System Administrator users.

## Root causes
Some legacy NOSO packages do not contain an original-submission changelog event. The UI relied on that event to select a form schema and redirected to the dashboard when none was found.
Large user-management requests exceeded OpenSearch’s 1,024-clause limit after case-insensitive email matching was introduced. The UI presented the failed request as an empty table.

## Changes
Infer the original form type from stable package metadata when a legacy package has no initial-submission event.
Support Medicaid SPA, CHIP SPA, 1915(b), 1915(c), and temporary-extension legacy records.
Batch user email lookups to keep each OpenSearch query below the clause limit.
Add regression coverage for the production-shaped TX-21-0009 record and large user lists.