### PR TITLE
OY2-40837: Clarify .zip download unavailable-files warning message

### DIFF
--- a/lib/attachment-archive/failure-state.ts
+++ b/lib/attachment-archive/failure-state.ts
@@ -9,7 +9,7 @@ import {
 
 const DEFAULT_FAILURE_MESSAGE = "Unable to prepare the attachment archive.";
 const PARTIAL_ARCHIVE_WARNING_MESSAGE =
-  "Some attachments in this download are no longer available and were not included.";
+  "One or more files are unavailable and were not included as part of the .zip file download.";
 
 export const ATTACHMENT_ARCHIVE_TERMINAL_FAILURE_CODES = new Set<AttachmentArchiveFailureCode>(
   ATTACHMENT_ARCHIVE_FAILURE_CODES,

--- a/lib/lambda/attachmentArchive-lib.test.ts
+++ b/lib/lambda/attachmentArchive-lib.test.ts
@@ -438,7 +438,7 @@ describe("attachmentArchive-lib", () => {
         status: "READY",
         url: "https://example.com/archive.zip",
         warningMessage:
-          "Some attachments in this download are no longer available and were not included.",
+          "One or more files are unavailable and were not included as part of the .zip file download.",
       },
     });
   });
@@ -479,7 +479,7 @@ describe("attachmentArchive-lib", () => {
         artifactKey,
         filename: "MD-10-6772-section-1-initial-package-submitted-attachments.zip",
         warningMessage:
-          "Some attachments in this download are no longer available and were not included.",
+          "One or more files are unavailable and were not included as part of the .zip file download.",
       },
     });
   });

--- a/react-app/src/features/package/package-activity/hook.test.tsx
+++ b/react-app/src/features/package/package-activity/hook.test.tsx
@@ -176,7 +176,7 @@ describe("useAttachmentService", () => {
       filename: "testPackage - Mon Mar 23 2026.zip",
       url: "http://example.com/archive.zip",
       warningMessage:
-        "Some attachments in this download are no longer available and were not included.",
+        "One or more files are unavailable and were not included as part of the .zip file download.",
     });
 
     const { result } = renderHook(() => useAttachmentService({ packageId: "testPackage" }), {
@@ -189,7 +189,7 @@ describe("useAttachmentService", () => {
 
     await waitFor(() => {
       expect(result.current.archiveWarningMessage).toBe(
-        "Some attachments in this download are no longer available and were not included.",
+        "One or more files are unavailable and were not included as part of the .zip file download.",
       );
     });
     expect(result.current.archiveErrorMessage).toBeUndefined();

--- a/react-app/src/features/package/package-activity/index.test.tsx
+++ b/react-app/src/features/package/package-activity/index.test.tsx
@@ -803,7 +803,7 @@ describe("Package Activity", () => {
       attachmentErrorMessage: undefined,
       archiveErrorMessage: undefined,
       archiveWarningMessage:
-        "Some attachments in this download are no longer available and were not included.",
+        "One or more files are unavailable and were not included as part of the .zip file download.",
       loading: false,
       onArchive: vi.fn(),
       onUrl: vi.fn(),
@@ -820,7 +820,7 @@ describe("Package Activity", () => {
 
     expect(
       screen.getAllByText(
-        "Some attachments in this download are no longer available and were not included.",
+        "One or more files are unavailable and were not included as part of the .zip file download.",
       ).length,
     ).toBeGreaterThan(0);
   });


### PR DESCRIPTION
## Summary
- Fixes [OY2-40837](https://jiraent.cms.gov/browse/OY2-40837): when one or more files in a package/section download are unavailable, the partial `.zip` download warning used outdated wording that did not clearly describe the outcome.
- Replaces `PARTIAL_ARCHIVE_WARNING_MESSAGE` (and matching test expectations) with the agreed copy: "One or more files are unavailable and were not included as part of the .zip file download."
- No behavior change to when the warning is shown—only the user-facing text.

## Issue
During VAL validation of attachment archive downloads (related to OY2-40480), QA confirmed that when a corrupted/unavailable file exists under a section, remaining files still download in the `.zip`, but the warning message needed clearer product language.

## Resolution
Updated the shared warning constant in `lib/attachment-archive/failure-state.ts` and aligned unit/UI tests so the UI and API `warningMessage` surface the approved wording.

## Test plan
- [x] Targeted Vitest: `attachmentArchive-lib` and `package-activity`
- [ ] Confirm in UI that a partial archive READY response shows the new warning under Download section / Download all attachments