### PR TITLE
fix(attachment-archive): recover downloads waiting on file scans

### DIFF
--- a/.github/skills/splunk/references/source-mapping.md
+++ b/.github/skills/splunk/references/source-mapping.md
@@ -15,6 +15,7 @@ This file maps AWS Lambda CloudWatch log sources to the Splunk `source` names us
 | -------------------------------------------------- | -------- | -------------------------------------------------------------- |
 | mako-val-api-attachmentArchiveBackfillStatus       | impl     | /aws/lambda/mako-val-api-attachmentArchiveBackfillStatus       |
 | mako-val-api-backfillAttachmentArchives            | impl     | /aws/lambda/mako-val-api-backfillAttachmentArchives            |
+| mako-val-api-forwardAttachmentArchiveRetries       | impl     | /aws/lambda/mako-val-api-forwardAttachmentArchiveRetries       |
 | mako-val-api-getAttachmentArchive                  | impl     | /aws/lambda/mako-val-api-getAttachmentArchive                  |
 | mako-val-api-markAttachmentArchiveFailed           | impl     | /aws/lambda/mako-val-api-markAttachmentArchiveFailed           |
 | mako-val-api-notifyAttachmentArchiveIntegrity      | impl     | /aws/lambda/mako-val-api-notifyAttachmentArchiveIntegrity      |

--- a/lib/attachment-archive/rebuild-queue.test.ts
+++ b/lib/attachment-archive/rebuild-queue.test.ts
@@ -1,8 +1,41 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { buildAttachmentArchiveMessageGroupId } from "./rebuild-queue";
+const { send } = vi.hoisted(() => ({
+  send: vi.fn(),
+}));
+
+vi.mock("@aws-sdk/client-sqs", () => ({
+  SendMessageCommand: class SendMessageCommand {
+    input: Record<string, unknown>;
+
+    constructor(input: Record<string, unknown>) {
+      this.input = input;
+    }
+  },
+  SQSClient: class SQSClient {
+    send = send;
+  },
+}));
+
+import {
+  buildAttachmentArchiveMessageGroupId,
+  sendAttachmentArchiveRebuildRequest,
+} from "./rebuild-queue";
 
 describe("attachment archive rebuild queue", () => {
+  const originalQueueUrl = process.env.ATTACHMENT_ARCHIVE_REBUILD_QUEUE_URL;
+
+  beforeEach(() => {
+    process.env.ATTACHMENT_ARCHIVE_REBUILD_QUEUE_URL =
+      "https://sqs.us-east-1.amazonaws.com/123456789012/archive-rebuild.fifo";
+    send.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    process.env.ATTACHMENT_ARCHIVE_REBUILD_QUEUE_URL = originalQueueUrl;
+    send.mockReset();
+  });
+
   it("builds a stable fifo-compatible message group id", () => {
     const packageId = "CA-22-2020-hjfg TEST";
     const groupId = buildAttachmentArchiveMessageGroupId(packageId);
@@ -28,5 +61,24 @@ describe("attachment archive rebuild queue", () => {
     expect(buildAttachmentArchiveMessageGroupId("MD-1", { preferDraft: false })).toBe(
       buildAttachmentArchiveMessageGroupId("MD-1"),
     );
+  });
+
+  it("does not set an unsupported per-message delay for the FIFO queue", async () => {
+    await sendAttachmentArchiveRebuildRequest({
+      packageId: "MD-1",
+      source: "request",
+      sourceScanRetryCount: 2,
+    });
+
+    const command = send.mock.calls[0]?.[0] as { input: Record<string, unknown> };
+    expect(command.input).not.toHaveProperty("DelaySeconds");
+    expect(command.input).toMatchObject({
+      QueueUrl: process.env.ATTACHMENT_ARCHIVE_REBUILD_QUEUE_URL,
+      MessageBody: JSON.stringify({
+        packageId: "MD-1",
+        source: "request",
+        sourceScanRetryCount: 2,
+      }),
+    });
   });
 });

--- a/lib/attachment-archive/rebuild-queue.test.ts
+++ b/lib/attachment-archive/rebuild-queue.test.ts
@@ -20,19 +20,24 @@ vi.mock("@aws-sdk/client-sqs", () => ({
 import {
   buildAttachmentArchiveMessageGroupId,
   sendAttachmentArchiveRebuildRequest,
+  sendAttachmentArchiveRetryRequest,
 } from "./rebuild-queue";
 
 describe("attachment archive rebuild queue", () => {
   const originalQueueUrl = process.env.ATTACHMENT_ARCHIVE_REBUILD_QUEUE_URL;
+  const originalRetryQueueUrl = process.env.ATTACHMENT_ARCHIVE_RETRY_QUEUE_URL;
 
   beforeEach(() => {
     process.env.ATTACHMENT_ARCHIVE_REBUILD_QUEUE_URL =
       "https://sqs.us-east-1.amazonaws.com/123456789012/archive-rebuild.fifo";
+    process.env.ATTACHMENT_ARCHIVE_RETRY_QUEUE_URL =
+      "https://sqs.us-east-1.amazonaws.com/123456789012/archive-retry.fifo";
     send.mockResolvedValue({});
   });
 
   afterEach(() => {
     process.env.ATTACHMENT_ARCHIVE_REBUILD_QUEUE_URL = originalQueueUrl;
+    process.env.ATTACHMENT_ARCHIVE_RETRY_QUEUE_URL = originalRetryQueueUrl;
     send.mockReset();
   });
 
@@ -79,6 +84,23 @@ describe("attachment archive rebuild queue", () => {
         source: "request",
         sourceScanRetryCount: 2,
       }),
+    });
+  });
+
+  it("sends source-scan retries to the dedicated delayed queue", async () => {
+    const message = {
+      packageId: "MD-1",
+      source: "request" as const,
+      sourceScanRetryCount: 2,
+    };
+
+    await sendAttachmentArchiveRetryRequest(message);
+
+    const command = send.mock.calls[0]?.[0] as { input: Record<string, unknown> };
+    expect(command.input).not.toHaveProperty("DelaySeconds");
+    expect(command.input).toMatchObject({
+      QueueUrl: process.env.ATTACHMENT_ARCHIVE_RETRY_QUEUE_URL,
+      MessageBody: JSON.stringify(message),
     });
   });
 });

--- a/lib/attachment-archive/rebuild-queue.ts
+++ b/lib/attachment-archive/rebuild-queue.ts
@@ -28,7 +28,6 @@ export function getAttachmentArchiveRebuildQueueUrl(): string {
 
 export async function sendAttachmentArchiveRebuildRequest(
   message: AttachmentArchiveRebuildMessage,
-  options: { delaySeconds?: number } = {},
 ) {
   await sqsClient.send(
     new SendMessageCommand({
@@ -37,7 +36,6 @@ export async function sendAttachmentArchiveRebuildRequest(
       MessageGroupId: buildAttachmentArchiveMessageGroupId(message.packageId, {
         preferDraft: message.preferDraft,
       }),
-      ...(typeof options.delaySeconds === "number" ? { DelaySeconds: options.delaySeconds } : {}),
     }),
   );
 }

--- a/lib/attachment-archive/rebuild-queue.ts
+++ b/lib/attachment-archive/rebuild-queue.ts
@@ -26,16 +26,36 @@ export function getAttachmentArchiveRebuildQueueUrl(): string {
   return queueUrl;
 }
 
-export async function sendAttachmentArchiveRebuildRequest(
+export function getAttachmentArchiveRetryQueueUrl(): string {
+  const queueUrl = process.env.ATTACHMENT_ARCHIVE_RETRY_QUEUE_URL;
+  if (!queueUrl) {
+    throw new Error("ATTACHMENT_ARCHIVE_RETRY_QUEUE_URL must be defined");
+  }
+
+  return queueUrl;
+}
+
+async function sendAttachmentArchiveQueueRequest(
+  queueUrl: string,
   message: AttachmentArchiveRebuildMessage,
 ) {
   await sqsClient.send(
     new SendMessageCommand({
-      QueueUrl: getAttachmentArchiveRebuildQueueUrl(),
+      QueueUrl: queueUrl,
       MessageBody: JSON.stringify(message),
       MessageGroupId: buildAttachmentArchiveMessageGroupId(message.packageId, {
         preferDraft: message.preferDraft,
       }),
     }),
   );
+}
+
+export async function sendAttachmentArchiveRebuildRequest(
+  message: AttachmentArchiveRebuildMessage,
+) {
+  await sendAttachmentArchiveQueueRequest(getAttachmentArchiveRebuildQueueUrl(), message);
+}
+
+export async function sendAttachmentArchiveRetryRequest(message: AttachmentArchiveRebuildMessage) {
+  await sendAttachmentArchiveQueueRequest(getAttachmentArchiveRetryQueueUrl(), message);
 }

--- a/lib/lambda/attachmentArchive-lib.test.ts
+++ b/lib/lambda/attachmentArchive-lib.test.ts
@@ -248,7 +248,8 @@ describe("attachmentArchive-lib", () => {
           manifestKey,
           attachmentCount: 1,
           pendingReason: "SOURCE_SCAN_PENDING",
-          pendingMessage: "Attachments are still being scanned. Please try again shortly.",
+          pendingMessage:
+            "Attachments are being scanned. Your download will start automatically when scanning is complete.",
           sourceScanPendingAt: "2026-06-15T10:00:00.000Z",
           sourceScanRetryCount: 2,
           sectionId: sectionDescriptor.sectionId,
@@ -267,11 +268,12 @@ describe("attachmentArchive-lib", () => {
     });
 
     expect(result).toEqual({
-      needsRebuild: false,
+      needsRebuild: true,
       response: {
         status: "PENDING",
         reason: "SOURCE_SCAN_PENDING",
-        message: "Attachments are still being scanned. Please try again shortly.",
+        message:
+          "Attachments are being scanned. Your download will start automatically when scanning is complete.",
         pollAfterSeconds: 5,
       },
     });
@@ -623,12 +625,74 @@ describe("attachmentArchive-lib", () => {
         body: expect.objectContaining({
           status: "PENDING",
           pendingReason: "SOURCE_SCAN_PENDING",
-          pendingMessage: "Attachments are still being scanned. Please try again shortly.",
+          pendingMessage:
+            "Attachments are being scanned. Your download will start automatically when scanning is complete.",
           sourceScanPendingAt: "2026-06-15T10:00:00.000Z",
           sourceScanRetryCount: 2,
         }),
       }),
     );
+  });
+
+  it("rechecks source attachments after a source-scan pending rebuild", async () => {
+    const sectionCurrent = buildAttachmentArchiveCurrent({
+      scope: "section",
+      hash: manifest.hash,
+      status: "PENDING",
+      artifactKey,
+      manifestKey,
+      attachmentCount: 1,
+      pendingReason: "SOURCE_SCAN_PENDING",
+      pendingMessage:
+        "Attachments are being scanned. Your download will start automatically when scanning is complete.",
+      sourceScanPendingAt: "2026-06-15T10:00:00.000Z",
+      sourceScanRetryCount: 1,
+      sectionId: sectionDescriptor.sectionId,
+      sectionNumber: sectionDescriptor.sectionNumber,
+      sectionLabel: sectionDescriptor.sectionLabel,
+      sectionFolderName: sectionDescriptor.sectionFolderName,
+    });
+    const packageCurrent = buildAttachmentArchiveCurrent({
+      scope: "all",
+      hash: packageManifest.hash,
+      status: "PENDING",
+      artifactKey: packageArtifactKey,
+      manifestKey: packageManifestKey,
+      attachmentCount: 1,
+      pendingReason: "SOURCE_SCAN_PENDING",
+      pendingMessage:
+        "Attachments are being scanned. Your download will start automatically when scanning is complete.",
+      sourceScanPendingAt: "2026-06-15T10:00:00.000Z",
+      sourceScanRetryCount: 1,
+    });
+    getObjectText.mockImplementation(async ({ key }) =>
+      JSON.stringify(key.includes("/all/") ? packageCurrent : sectionCurrent),
+    );
+    getObjectTags.mockResolvedValue({ virusScanStatus: "CLEAN" });
+    stepFunctionsSpy.mockResolvedValue({} as never);
+
+    const result = await rebuildPackageAttachmentArchives({
+      packageId: "MD-10-6772",
+      changelog: [],
+      sourceScanPendingAt: "2026-06-15T10:00:00.000Z",
+      sourceScanRetryCount: 2,
+    });
+
+    expect(result).toMatchObject({
+      packageId: "MD-10-6772",
+      packageStatus: "PENDING",
+      sourceScanPending: false,
+      startedArtifactCount: 2,
+      sectionResults: [
+        {
+          sectionId: "section-a",
+          started: true,
+          status: "PENDING",
+        },
+      ],
+    });
+    expect(getObjectTags).toHaveBeenCalled();
+    expect(stepFunctionsSpy).toHaveBeenCalledTimes(2);
   });
 
   it("marks rebuilds failed when source attachment scanning reaches a non-clean status", async () => {

--- a/lib/lambda/attachmentArchive-lib.test.ts
+++ b/lib/lambda/attachmentArchive-lib.test.ts
@@ -237,6 +237,51 @@ describe("attachmentArchive-lib", () => {
     });
   });
 
+  it("queues one recovery for legacy source-scan pending state without retry metadata", async () => {
+    getObjectText.mockResolvedValue(
+      JSON.stringify(
+        buildAttachmentArchiveCurrent({
+          scope: "section",
+          hash: manifest.hash,
+          status: "PENDING",
+          artifactKey,
+          manifestKey,
+          attachmentCount: 1,
+          pendingReason: "SOURCE_SCAN_PENDING",
+          pendingMessage:
+            "Attachments are being scanned. Your download will start automatically when scanning is complete.",
+          sourceScanPendingAt: "2026-06-15T10:00:00.000Z",
+          sectionId: sectionDescriptor.sectionId,
+          sectionNumber: sectionDescriptor.sectionNumber,
+          sectionLabel: sectionDescriptor.sectionLabel,
+          sectionFolderName: sectionDescriptor.sectionFolderName,
+        }),
+      ),
+    );
+
+    const result = await getRequestedAttachmentArchiveStatus({
+      packageId: "MD-10-6772",
+      scope: "section",
+      sectionId: sectionDescriptor.sectionId,
+      changelog: [],
+    });
+
+    expect(result).toEqual({
+      needsRebuild: true,
+      rebuildRequest: {
+        sourceScanPendingAt: "2026-06-15T10:00:00.000Z",
+        sourceScanRetryCount: 0,
+      },
+      response: {
+        status: "PENDING",
+        reason: "SOURCE_SCAN_PENDING",
+        message:
+          "Attachments are being scanned. Your download will start automatically when scanning is complete.",
+        pollAfterSeconds: 5,
+      },
+    });
+  });
+
   it("returns source-scan pending details from current archive state", async () => {
     getObjectText.mockResolvedValue(
       JSON.stringify(
@@ -268,7 +313,7 @@ describe("attachmentArchive-lib", () => {
     });
 
     expect(result).toEqual({
-      needsRebuild: true,
+      needsRebuild: false,
       response: {
         status: "PENDING",
         reason: "SOURCE_SCAN_PENDING",
@@ -693,6 +738,65 @@ describe("attachmentArchive-lib", () => {
     });
     expect(getObjectTags).toHaveBeenCalled();
     expect(stepFunctionsSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps source-scan pending rebuilds queued when source tags are still pending", async () => {
+    const sectionCurrent = buildAttachmentArchiveCurrent({
+      scope: "section",
+      hash: manifest.hash,
+      status: "PENDING",
+      artifactKey,
+      manifestKey,
+      attachmentCount: 1,
+      pendingReason: "SOURCE_SCAN_PENDING",
+      pendingMessage:
+        "Attachments are being scanned. Your download will start automatically when scanning is complete.",
+      sourceScanPendingAt: "2026-06-15T10:00:00.000Z",
+      sourceScanRetryCount: 1,
+      sectionId: sectionDescriptor.sectionId,
+      sectionNumber: sectionDescriptor.sectionNumber,
+      sectionLabel: sectionDescriptor.sectionLabel,
+      sectionFolderName: sectionDescriptor.sectionFolderName,
+    });
+    const packageCurrent = buildAttachmentArchiveCurrent({
+      scope: "all",
+      hash: packageManifest.hash,
+      status: "PENDING",
+      artifactKey: packageArtifactKey,
+      manifestKey: packageManifestKey,
+      attachmentCount: 1,
+      pendingReason: "SOURCE_SCAN_PENDING",
+      pendingMessage:
+        "Attachments are being scanned. Your download will start automatically when scanning is complete.",
+      sourceScanPendingAt: "2026-06-15T10:00:00.000Z",
+      sourceScanRetryCount: 1,
+    });
+    getObjectText.mockImplementation(async ({ key }) =>
+      JSON.stringify(key.includes("/all/") ? packageCurrent : sectionCurrent),
+    );
+    getObjectTags.mockResolvedValue({});
+
+    const result = await rebuildPackageAttachmentArchives({
+      packageId: "MD-10-6772",
+      changelog: [],
+      sourceScanPendingAt: "2026-06-15T10:00:00.000Z",
+      sourceScanRetryCount: 2,
+    });
+
+    expect(result).toMatchObject({
+      packageId: "MD-10-6772",
+      packageStatus: "PENDING",
+      sourceScanPending: true,
+      startedArtifactCount: 0,
+      sectionResults: [
+        {
+          sectionId: "section-a",
+          started: false,
+          status: "PENDING",
+        },
+      ],
+    });
+    expect(stepFunctionsSpy).not.toHaveBeenCalled();
   });
 
   it("marks rebuilds failed when source attachment scanning reaches a non-clean status", async () => {

--- a/lib/lambda/attachmentArchive-lib.ts
+++ b/lib/lambda/attachmentArchive-lib.ts
@@ -57,7 +57,7 @@ const DEFAULT_POLL_AFTER_SECONDS = 3;
 const DEFAULT_REBUILD_START_DELAY_MS = 1000;
 const SOURCE_SCAN_PENDING_POLL_AFTER_SECONDS = 5;
 const SOURCE_SCAN_PENDING_MESSAGE =
-  "Attachments are still being scanned. Please try again shortly.";
+  "Attachments are being scanned. Your download will start automatically when scanning is complete.";
 const awsRegion = process.env.region || process.env.AWS_REGION;
 
 const archiveBucketClient = new S3Client({ region: awsRegion });
@@ -811,7 +811,11 @@ async function ensureArchiveArtifact({
     };
   }
 
-  if (resolution.action === "in_progress") {
+  const shouldRecheckSourceScan =
+    resolution.action === "in_progress" &&
+    resolution.current?.pendingReason === "SOURCE_SCAN_PENDING";
+
+  if (resolution.action === "in_progress" && !shouldRecheckSourceScan) {
     return {
       artifact,
       artifactBucketName: writeBucketName,
@@ -1050,7 +1054,7 @@ export async function getRequestedAttachmentArchiveDownload({
             ? SOURCE_SCAN_PENDING_POLL_AFTER_SECONDS
             : DEFAULT_POLL_AFTER_SECONDS,
       },
-      needsRebuild: false,
+      needsRebuild: resolution.pendingReason === "SOURCE_SCAN_PENDING",
     };
   }
 

--- a/lib/lambda/attachmentArchive-lib.ts
+++ b/lib/lambda/attachmentArchive-lib.ts
@@ -46,6 +46,7 @@ import {
   AttachmentArchiveManifestAttachment,
   AttachmentArchiveNamespace,
   AttachmentArchivePackageManifest,
+  AttachmentArchiveRebuildMessage,
   AttachmentArchiveScope,
   AttachmentArchiveSectionManifest,
   AttachmentArchiveSourceAttachment,
@@ -812,8 +813,7 @@ async function ensureArchiveArtifact({
   }
 
   const shouldRecheckSourceScan =
-    resolution.action === "in_progress" &&
-    resolution.current?.pendingReason === "SOURCE_SCAN_PENDING";
+    resolution.action === "in_progress" && resolution.pendingReason === "SOURCE_SCAN_PENDING";
 
   if (resolution.action === "in_progress" && !shouldRecheckSourceScan) {
     return {
@@ -1018,6 +1018,10 @@ export async function getRequestedAttachmentArchiveDownload({
 }): Promise<{
   response: AttachmentArchiveDownloadResponse;
   needsRebuild: boolean;
+  rebuildRequest?: Pick<
+    AttachmentArchiveRebuildMessage,
+    "sourceScanPendingAt" | "sourceScanRetryCount"
+  >;
 }> {
   const artifact = getRequestedArtifact({
     packageId,
@@ -1044,6 +1048,10 @@ export async function getRequestedAttachmentArchiveDownload({
   }
 
   if (resolution.action === "in_progress") {
+    const needsSourceScanRecovery =
+      resolution.pendingReason === "SOURCE_SCAN_PENDING" &&
+      typeof resolution.current?.sourceScanRetryCount !== "number";
+
     return {
       response: {
         status: "PENDING",
@@ -1054,7 +1062,17 @@ export async function getRequestedAttachmentArchiveDownload({
             ? SOURCE_SCAN_PENDING_POLL_AFTER_SECONDS
             : DEFAULT_POLL_AFTER_SECONDS,
       },
-      needsRebuild: resolution.pendingReason === "SOURCE_SCAN_PENDING",
+      needsRebuild: needsSourceScanRecovery,
+      ...(needsSourceScanRecovery
+        ? {
+            rebuildRequest: {
+              ...(resolution.current?.sourceScanPendingAt
+                ? { sourceScanPendingAt: resolution.current.sourceScanPendingAt }
+                : {}),
+              sourceScanRetryCount: 0,
+            },
+          }
+        : {}),
     };
   }
 

--- a/lib/lambda/forwardAttachmentArchiveRetries.test.ts
+++ b/lib/lambda/forwardAttachmentArchiveRetries.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { sendAttachmentArchiveRebuildRequest } = vi.hoisted(() => ({
+  sendAttachmentArchiveRebuildRequest: vi.fn(),
+}));
+
+vi.mock("../attachment-archive/rebuild-queue", () => ({
+  sendAttachmentArchiveRebuildRequest,
+}));
+
+import { handler } from "./forwardAttachmentArchiveRetries";
+
+describe("forwardAttachmentArchiveRetries handler", () => {
+  afterEach(() => {
+    sendAttachmentArchiveRebuildRequest.mockReset();
+  });
+
+  it("forwards delayed retries to the primary rebuild queue", async () => {
+    const message = {
+      packageId: "MD-26-9999-P",
+      preferDraft: true,
+      source: "request",
+      sourceScanPendingAt: "2026-06-15T10:00:00.000Z",
+      sourceScanRetryCount: 3,
+    };
+
+    await handler(
+      {
+        Records: [{ body: JSON.stringify(message) }],
+      } as any,
+      {} as any,
+      {} as any,
+    );
+
+    expect(sendAttachmentArchiveRebuildRequest).toHaveBeenCalledWith(message);
+  });
+
+  it("rejects malformed retry messages", async () => {
+    await expect(
+      handler(
+        {
+          Records: [{ body: JSON.stringify({ packageId: "MD-26-9999-P" }) }],
+        } as any,
+        {} as any,
+        {} as any,
+      ),
+    ).rejects.toThrow("Attachment archive rebuild message must include packageId and source");
+
+    expect(sendAttachmentArchiveRebuildRequest).not.toHaveBeenCalled();
+  });
+});

--- a/lib/lambda/forwardAttachmentArchiveRetries.ts
+++ b/lib/lambda/forwardAttachmentArchiveRetries.ts
@@ -1,0 +1,29 @@
+import { SQSHandler } from "aws-lambda";
+
+import { sendAttachmentArchiveRebuildRequest } from "../attachment-archive/rebuild-queue";
+import { AttachmentArchiveRebuildMessage } from "../attachment-archive/types";
+
+function parseRecordBody(body: string): AttachmentArchiveRebuildMessage {
+  const parsed = JSON.parse(body) as Partial<AttachmentArchiveRebuildMessage>;
+  if (!parsed.packageId || !parsed.source) {
+    throw new Error("Attachment archive rebuild message must include packageId and source");
+  }
+
+  return parsed as AttachmentArchiveRebuildMessage;
+}
+
+export const handler: SQSHandler = async (event) => {
+  for (const record of event.Records) {
+    const message = parseRecordBody(record.body);
+    await sendAttachmentArchiveRebuildRequest(message);
+
+    console.info(
+      JSON.stringify({
+        event: "attachment_archive_retry_forwarded",
+        packageId: message.packageId,
+        preferDraft: message.preferDraft,
+        sourceScanRetryCount: message.sourceScanRetryCount,
+      }),
+    );
+  }
+};

--- a/lib/lambda/getAttachmentArchive.test.ts
+++ b/lib/lambda/getAttachmentArchive.test.ts
@@ -370,13 +370,14 @@ describe("getAttachmentArchive handler", () => {
     );
   });
 
-  it("returns source-scan pending details without queuing another rebuild", async () => {
+  it("returns source-scan pending details and queues a recovery rebuild", async () => {
     getRequestedAttachmentArchiveStatus.mockResolvedValue({
-      needsRebuild: false,
+      needsRebuild: true,
       response: {
         status: "PENDING",
         reason: "SOURCE_SCAN_PENDING",
-        message: "Attachments are still being scanned. Please try again shortly.",
+        message:
+          "Attachments are being scanned. Your download will start automatically when scanning is complete.",
         pollAfterSeconds: 5,
       },
     });
@@ -393,11 +394,17 @@ describe("getAttachmentArchive handler", () => {
       JSON.stringify({
         status: "PENDING",
         reason: "SOURCE_SCAN_PENDING",
-        message: "Attachments are still being scanned. Please try again shortly.",
+        message:
+          "Attachments are being scanned. Your download will start automatically when scanning is complete.",
         pollAfterSeconds: 5,
       }),
     );
-    expect(sendAttachmentArchiveRebuildRequest).not.toHaveBeenCalled();
+    expect(sendAttachmentArchiveRebuildRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        packageId: WITHDRAWN_CHANGELOG_ITEM_ID,
+        source: "request",
+      }),
+    );
   });
 
   it("queues a draft rebuild when a draft archive is pending and stale", async () => {

--- a/lib/lambda/getAttachmentArchive.test.ts
+++ b/lib/lambda/getAttachmentArchive.test.ts
@@ -370,9 +370,13 @@ describe("getAttachmentArchive handler", () => {
     );
   });
 
-  it("returns source-scan pending details and queues a recovery rebuild", async () => {
+  it("queues one recovery rebuild for legacy source-scan pending state", async () => {
     getRequestedAttachmentArchiveStatus.mockResolvedValue({
       needsRebuild: true,
+      rebuildRequest: {
+        sourceScanPendingAt: "2026-06-15T10:00:00.000Z",
+        sourceScanRetryCount: 0,
+      },
       response: {
         status: "PENDING",
         reason: "SOURCE_SCAN_PENDING",
@@ -402,9 +406,34 @@ describe("getAttachmentArchive handler", () => {
     expect(sendAttachmentArchiveRebuildRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         packageId: WITHDRAWN_CHANGELOG_ITEM_ID,
+        sourceScanPendingAt: "2026-06-15T10:00:00.000Z",
+        sourceScanRetryCount: 0,
         source: "request",
       }),
     );
+  });
+
+  it("does not enqueue another primary rebuild while a source-scan retry is scheduled", async () => {
+    getRequestedAttachmentArchiveStatus.mockResolvedValue({
+      needsRebuild: false,
+      response: {
+        status: "PENDING",
+        reason: "SOURCE_SCAN_PENDING",
+        message:
+          "Attachments are being scanned. Your download will start automatically when scanning is complete.",
+        pollAfterSeconds: 5,
+      },
+    });
+
+    const event = {
+      body: JSON.stringify({ id: WITHDRAWN_CHANGELOG_ITEM_ID, scope: "all" }),
+      requestContext: getRequestContext(),
+    } as APIGatewayEvent;
+
+    const response = await handler(event, {} as Context);
+
+    expect(response.statusCode).toBe(200);
+    expect(sendAttachmentArchiveRebuildRequest).not.toHaveBeenCalled();
   });
 
   it("queues a draft rebuild when a draft archive is pending and stale", async () => {

--- a/lib/lambda/getAttachmentArchive.ts
+++ b/lib/lambda/getAttachmentArchive.ts
@@ -149,6 +149,7 @@ export const handler = authenticatedMiddy({
       packageId,
       latestTimestamp,
       preferDraft: isDraftPackage || undefined,
+      ...("rebuildRequest" in result ? result.rebuildRequest : undefined),
       source: "request",
     });
   }

--- a/lib/lambda/getExternalAttachmentUrl.test.ts
+++ b/lib/lambda/getExternalAttachmentUrl.test.ts
@@ -291,6 +291,10 @@ describe("getExternalAttachmentUrl handler", () => {
   it("returns PENDING archive responses and queues a rebuild when needed", async () => {
     getRequestedAttachmentArchiveDownload.mockResolvedValueOnce({
       needsRebuild: true,
+      rebuildRequest: {
+        sourceScanPendingAt: "2026-06-15T10:00:00.000Z",
+        sourceScanRetryCount: 0,
+      },
       response: {
         status: "PENDING",
         pollAfterSeconds: 3,
@@ -316,6 +320,8 @@ describe("getExternalAttachmentUrl handler", () => {
     expect(sendAttachmentArchiveRebuildRequest).toHaveBeenCalledWith({
       packageId: "MD-10-6772",
       latestTimestamp: 25,
+      sourceScanPendingAt: "2026-06-15T10:00:00.000Z",
+      sourceScanRetryCount: 0,
       source: "request",
     });
     expect(generatePresignedDownloadUrl).not.toHaveBeenCalled();

--- a/lib/lambda/getExternalAttachmentUrl.ts
+++ b/lib/lambda/getExternalAttachmentUrl.ts
@@ -300,6 +300,7 @@ async function handleArchiveRequest({
       await sendAttachmentArchiveRebuildRequest({
         packageId: request.packageId,
         latestTimestamp: getLatestChangelogTimestamp(changelog),
+        ...archiveResult.rebuildRequest,
         source: "request",
       });
     }

--- a/lib/lambda/index.ts
+++ b/lib/lambda/index.ts
@@ -6,6 +6,7 @@ export * as deleteIndex from "./deleteIndex";
 export * as deleteDraft from "./deleteDraft";
 export * as externalAttachmentAuthorizer from "./externalAttachmentAuthorizer";
 export * as externalToken from "./externalToken";
+export * as forwardAttachmentArchiveRetries from "./forwardAttachmentArchiveRetries";
 export * as getAttachmentUrl from "./getAttachmentUrl";
 export * as getAttachmentArchive from "./getAttachmentArchive";
 export * as getCpocs from "./getCpocs";

--- a/lib/lambda/rebuildAttachmentArchives.test.ts
+++ b/lib/lambda/rebuildAttachmentArchives.test.ts
@@ -160,7 +160,7 @@ describe("rebuildAttachmentArchives handler", () => {
     });
   });
 
-  it("requeues source-scan pending rebuilds with bounded backoff", async () => {
+  it("requeues source-scan pending rebuilds on the delayed retry queue", async () => {
     vi.spyOn(packageApi, "getPackageChangelog").mockResolvedValue({
       hits: {
         hits: [],

--- a/lib/lambda/rebuildAttachmentArchives.test.ts
+++ b/lib/lambda/rebuildAttachmentArchives.test.ts
@@ -3,11 +3,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const {
   buildDraftAttachmentChangelog,
   rebuildPackageAttachmentArchives,
-  sendAttachmentArchiveRebuildRequest,
+  sendAttachmentArchiveRetryRequest,
 } = vi.hoisted(() => ({
   buildDraftAttachmentChangelog: vi.fn(),
   rebuildPackageAttachmentArchives: vi.fn(),
-  sendAttachmentArchiveRebuildRequest: vi.fn(),
+  sendAttachmentArchiveRetryRequest: vi.fn(),
 }));
 
 vi.mock("../attachment-archive/draft-package", () => ({
@@ -15,7 +15,7 @@ vi.mock("../attachment-archive/draft-package", () => ({
 }));
 
 vi.mock("../attachment-archive/rebuild-queue", () => ({
-  sendAttachmentArchiveRebuildRequest,
+  sendAttachmentArchiveRetryRequest,
 }));
 
 vi.mock("./attachmentArchive-lib", () => ({
@@ -30,7 +30,7 @@ describe("rebuildAttachmentArchives handler", () => {
     vi.restoreAllMocks();
     buildDraftAttachmentChangelog.mockReset();
     rebuildPackageAttachmentArchives.mockReset();
-    sendAttachmentArchiveRebuildRequest.mockReset();
+    sendAttachmentArchiveRetryRequest.mockReset();
   });
 
   it("rebuilds draft archives from synthetic draft changelog when preferDraft is true", async () => {
@@ -190,7 +190,7 @@ describe("rebuildAttachmentArchives handler", () => {
       {} as any,
     );
 
-    expect(sendAttachmentArchiveRebuildRequest).toHaveBeenCalledWith({
+    expect(sendAttachmentArchiveRetryRequest).toHaveBeenCalledWith({
       packageId: "MD-26-9999-P",
       source: "sink-changelog",
       sourceScanPendingAt: "2026-06-15T10:00:00.000Z",
@@ -235,6 +235,6 @@ describe("rebuildAttachmentArchives handler", () => {
         sourceScanRetryCount: 20,
       }),
     );
-    expect(sendAttachmentArchiveRebuildRequest).not.toHaveBeenCalled();
+    expect(sendAttachmentArchiveRetryRequest).not.toHaveBeenCalled();
   });
 });

--- a/lib/lambda/rebuildAttachmentArchives.test.ts
+++ b/lib/lambda/rebuildAttachmentArchives.test.ts
@@ -190,15 +190,12 @@ describe("rebuildAttachmentArchives handler", () => {
       {} as any,
     );
 
-    expect(sendAttachmentArchiveRebuildRequest).toHaveBeenCalledWith(
-      {
-        packageId: "MD-26-9999-P",
-        source: "sink-changelog",
-        sourceScanPendingAt: "2026-06-15T10:00:00.000Z",
-        sourceScanRetryCount: 3,
-      },
-      { delaySeconds: 30 },
-    );
+    expect(sendAttachmentArchiveRebuildRequest).toHaveBeenCalledWith({
+      packageId: "MD-26-9999-P",
+      source: "sink-changelog",
+      sourceScanPendingAt: "2026-06-15T10:00:00.000Z",
+      sourceScanRetryCount: 3,
+    });
   });
 
   it("does not requeue source-scan pending rebuilds after the retry cap", async () => {

--- a/lib/lambda/rebuildAttachmentArchives.ts
+++ b/lib/lambda/rebuildAttachmentArchives.ts
@@ -3,7 +3,7 @@ import { opensearch, SEATOOL_STATUS } from "shared-types";
 
 import { buildDraftAttachmentChangelog } from "../attachment-archive/draft-package";
 import type { AttachmentArchiveChangelogItem } from "../attachment-archive/package-activity";
-import { sendAttachmentArchiveRebuildRequest } from "../attachment-archive/rebuild-queue";
+import { sendAttachmentArchiveRetryRequest } from "../attachment-archive/rebuild-queue";
 import { AttachmentArchiveRebuildMessage } from "../attachment-archive/types";
 import { getDraftPackage, getPackageChangelog } from "../libs/api/package";
 import { rebuildPackageAttachmentArchives } from "./attachmentArchive-lib";
@@ -60,7 +60,7 @@ export const handler: SQSHandler = async (event) => {
     });
 
     if (result.sourceScanPending && !sourceScanRetriesExceeded) {
-      await sendAttachmentArchiveRebuildRequest({
+      await sendAttachmentArchiveRetryRequest({
         ...message,
         sourceScanPendingAt: message.sourceScanPendingAt || new Date().toISOString(),
         sourceScanRetryCount: sourceScanRetryCount + 1,

--- a/lib/lambda/rebuildAttachmentArchives.ts
+++ b/lib/lambda/rebuildAttachmentArchives.ts
@@ -9,7 +9,6 @@ import { getDraftPackage, getPackageChangelog } from "../libs/api/package";
 import { rebuildPackageAttachmentArchives } from "./attachmentArchive-lib";
 
 const MAX_SOURCE_SCAN_RETRY_COUNT = 20;
-const SOURCE_SCAN_RETRY_DELAY_SECONDS = 30;
 
 function parseRecordBody(body: string): AttachmentArchiveRebuildMessage {
   const parsed = JSON.parse(body) as Partial<AttachmentArchiveRebuildMessage>;
@@ -61,14 +60,11 @@ export const handler: SQSHandler = async (event) => {
     });
 
     if (result.sourceScanPending && !sourceScanRetriesExceeded) {
-      await sendAttachmentArchiveRebuildRequest(
-        {
-          ...message,
-          sourceScanPendingAt: message.sourceScanPendingAt || new Date().toISOString(),
-          sourceScanRetryCount: sourceScanRetryCount + 1,
-        },
-        { delaySeconds: SOURCE_SCAN_RETRY_DELAY_SECONDS },
-      );
+      await sendAttachmentArchiveRebuildRequest({
+        ...message,
+        sourceScanPendingAt: message.sourceScanPendingAt || new Date().toISOString(),
+        sourceScanRetryCount: sourceScanRetryCount + 1,
+      });
     }
 
     console.info(

--- a/lib/stacks/api.ts
+++ b/lib/stacks/api.ts
@@ -1085,6 +1085,15 @@ export class Api extends cdk.NestedStack {
         timeoutSeconds: 300,
       },
       {
+        id: "forwardAttachmentArchiveRetries",
+        entry: join(__dirname, "../lambda/forwardAttachmentArchiveRetries.ts"),
+        environment: {
+          ATTACHMENT_ARCHIVE_REBUILD_QUEUE_URL: attachmentArchiveRebuildQueue.queueUrl,
+        },
+        role: attachmentArchiveRequestRole,
+        timeoutSeconds: 60,
+      },
+      {
         id: "backfillAttachmentArchives",
         entry: join(__dirname, "../lambda/backfillAttachmentArchives.ts"),
         environment: {
@@ -1236,7 +1245,7 @@ export class Api extends cdk.NestedStack {
         maxConcurrency: 2,
       }),
     );
-    lambdas.rebuildAttachmentArchives.addEventSource(
+    lambdas.forwardAttachmentArchiveRetries.addEventSource(
       new SqsEventSource(attachmentArchiveRetryQueue, {
         batchSize: 1,
         maxConcurrency: 2,

--- a/lib/stacks/api.ts
+++ b/lib/stacks/api.ts
@@ -38,6 +38,7 @@ interface ApiStackProps extends cdk.NestedStackProps {
   stack: string;
   isDev: boolean;
   attachmentArchiveRebuildQueue: cdk.aws_sqs.IQueue;
+  attachmentArchiveRetryQueue: cdk.aws_sqs.IQueue;
   vpc: cdk.aws_ec2.IVpc;
   privateSubnets: cdk.aws_ec2.ISubnet[];
   lambdaSecurityGroup: cdk.aws_ec2.ISecurityGroup;
@@ -71,7 +72,14 @@ export class Api extends cdk.NestedStack {
     apiGateway: cdk.aws_apigateway.RestApi;
   } {
     const ATTACHMENT_ARCHIVE_HISTORICAL_BACKFILL_PAGES_PER_EXECUTION = 10;
-    const { project, stage, isDev, stack, attachmentArchiveRebuildQueue } = props;
+    const {
+      project,
+      stage,
+      isDev,
+      stack,
+      attachmentArchiveRebuildQueue,
+      attachmentArchiveRetryQueue,
+    } = props;
     const {
       vpc,
       privateSubnets,
@@ -1071,6 +1079,7 @@ export class Api extends cdk.NestedStack {
           ATTACHMENT_ARCHIVE_BASE_BUCKET_NAME: archiveBaseReadBucketName,
           ATTACHMENT_ARCHIVE_KEY_PREFIX: archiveOverlayPrefix,
           ATTACHMENT_ARCHIVE_REBUILD_START_DELAY_MS: "1000",
+          ATTACHMENT_ARCHIVE_RETRY_QUEUE_URL: attachmentArchiveRetryQueue.queueUrl,
         },
         role: attachmentArchiveRequestRole,
         timeoutSeconds: 300,
@@ -1220,8 +1229,15 @@ export class Api extends cdk.NestedStack {
       archiveStateMachine.stateMachineArn,
     );
     attachmentArchiveRebuildQueue.grantSendMessages(attachmentArchiveRequestRole);
+    attachmentArchiveRetryQueue.grantSendMessages(attachmentArchiveRequestRole);
     lambdas.rebuildAttachmentArchives.addEventSource(
       new SqsEventSource(attachmentArchiveRebuildQueue, {
+        batchSize: 1,
+        maxConcurrency: 2,
+      }),
+    );
+    lambdas.rebuildAttachmentArchives.addEventSource(
+      new SqsEventSource(attachmentArchiveRetryQueue, {
         batchSize: 1,
         maxConcurrency: 2,
       }),

--- a/lib/stacks/parent.ts
+++ b/lib/stacks/parent.ts
@@ -39,6 +39,7 @@ export class ParentStack extends cdk.Stack {
         encryption: cdk.aws_sqs.QueueEncryption.KMS_MANAGED,
         fifo: true,
         contentBasedDeduplication: true,
+        deliveryDelay: cdk.Duration.seconds(30),
         visibilityTimeout: cdk.Duration.minutes(5),
         deadLetterQueue: {
           maxReceiveCount: 3,

--- a/lib/stacks/parent.ts
+++ b/lib/stacks/parent.ts
@@ -39,7 +39,6 @@ export class ParentStack extends cdk.Stack {
         encryption: cdk.aws_sqs.QueueEncryption.KMS_MANAGED,
         fifo: true,
         contentBasedDeduplication: true,
-        deliveryDelay: cdk.Duration.seconds(30),
         visibilityTimeout: cdk.Duration.minutes(5),
         deadLetterQueue: {
           maxReceiveCount: 3,
@@ -47,6 +46,18 @@ export class ParentStack extends cdk.Stack {
         },
       },
     );
+    const attachmentArchiveRetryQueue = new cdk.aws_sqs.Queue(this, "AttachmentArchiveRetryQueue", {
+      queueName: `${props.project}-${props.stage}-attachment-archive-retry.fifo`,
+      encryption: cdk.aws_sqs.QueueEncryption.KMS_MANAGED,
+      fifo: true,
+      contentBasedDeduplication: true,
+      deliveryDelay: cdk.Duration.seconds(30),
+      visibilityTimeout: cdk.Duration.minutes(5),
+      deadLetterQueue: {
+        maxReceiveCount: 3,
+        queue: attachmentArchiveRebuildDeadLetterQueue,
+      },
+    });
 
     if (!props.isDev) {
       new CloudWatchLogsResourcePolicy(this, "logPolicy", {
@@ -97,6 +108,7 @@ export class ParentStack extends cdk.Stack {
       ...commonProps,
       stack: "api",
       attachmentArchiveRebuildQueue,
+      attachmentArchiveRetryQueue,
       vpc,
       privateSubnets,
       brokerString: props.brokerString,

--- a/react-app/src/features/package/package-activity/hook.test.tsx
+++ b/react-app/src/features/package/package-activity/hook.test.tsx
@@ -129,6 +129,39 @@ describe("useAttachmentService", () => {
     }
   });
 
+  it("ignores a second archive request while polling is already in progress", async () => {
+    vi.useFakeTimers();
+    try {
+      const getAttachmentArchiveSpy = vi
+        .spyOn(api, "getAttachmentArchive")
+        .mockResolvedValueOnce({
+          status: "PENDING",
+          pollAfterSeconds: 1,
+        })
+        .mockResolvedValueOnce({
+          status: "READY",
+          filename: "testPackage - Mon Mar 23 2026.zip",
+          url: "http://example.com/archive.zip",
+        });
+
+      const { result } = renderHook(() => useAttachmentService({ packageId: "testPackage" }), {
+        wrapper,
+      });
+
+      const firstRequest = result.current.onArchive({ scope: "all" });
+      const secondRequest = result.current.onArchive({ scope: "all" });
+
+      await expect(secondRequest).resolves.toBeUndefined();
+      expect(getAttachmentArchiveSpy).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await expect(firstRequest).resolves.toBe("http://example.com/archive.zip");
+      expect(getAttachmentArchiveSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("continues polling source-scan pending archives longer than archive-build pending archives", async () => {
     vi.useFakeTimers();
     try {
@@ -244,6 +277,38 @@ describe("useAttachmentService", () => {
       });
       expect(getAttachmentArchiveSpy).toHaveBeenCalledTimes(20);
       expect(consoleErrorSpy).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses the timeout message after source-scan polling stops", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+      const getAttachmentArchiveSpy = vi.spyOn(api, "getAttachmentArchive").mockResolvedValue({
+        status: "PENDING",
+        reason: "SOURCE_SCAN_PENDING",
+        message:
+          "Attachments are being scanned. Your download will start automatically when scanning is complete.",
+        pollAfterSeconds: 1,
+      });
+
+      const { result } = renderHook(() => useAttachmentService({ packageId: "testPackage" }), {
+        wrapper,
+      });
+
+      const archivePromise = result.current.onArchive({ scope: "all" });
+      await vi.runAllTimersAsync();
+      await expect(archivePromise).resolves.toBeUndefined();
+
+      vi.useRealTimers();
+      await waitFor(() => {
+        expect(result.current.archiveErrorMessage).toBe(
+          "Attachment archive is taking longer than expected. Please try again in a few moments.",
+        );
+      });
+      expect(getAttachmentArchiveSpy).toHaveBeenCalledTimes(60);
     } finally {
       vi.useRealTimers();
     }

--- a/react-app/src/features/package/package-activity/hook.test.tsx
+++ b/react-app/src/features/package/package-activity/hook.test.tsx
@@ -135,7 +135,8 @@ describe("useAttachmentService", () => {
       const pendingResponses = Array.from({ length: 21 }, () => ({
         status: "PENDING" as const,
         reason: "SOURCE_SCAN_PENDING" as const,
-        message: "Attachments are still being scanned. Please try again shortly.",
+        message:
+          "Attachments are being scanned. Your download will start automatically when scanning is complete.",
         pollAfterSeconds: 1,
       }));
       const getAttachmentArchiveSpy = vi.spyOn(api, "getAttachmentArchive");
@@ -156,7 +157,7 @@ describe("useAttachmentService", () => {
 
       await vi.advanceTimersByTimeAsync(0);
       expect(result.current.archiveWarningMessage).toBe(
-        "Attachments are still being scanned. Please try again shortly.",
+        "Attachments are being scanned. Your download will start automatically when scanning is complete.",
       );
 
       for (let i = 0; i < pendingResponses.length; i += 1) {

--- a/react-app/src/features/package/package-activity/hook.ts
+++ b/react-app/src/features/package/package-activity/hook.ts
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { opensearch } from "shared-types";
 
 import { getAttachmentArchive, getAttachmentUrl } from "@/api";
@@ -66,6 +66,7 @@ export const useAttachmentService = ({
   const [archiveErrorMessage, setArchiveErrorMessage] = useState<string | undefined>();
   const [archiveWarningMessage, setArchiveWarningMessage] = useState<string | undefined>();
   const [attachmentErrorMessage, setAttachmentErrorMessage] = useState<string | undefined>();
+  const archiveInFlightRef = useRef(false);
 
   const onUrl = async (attachment: Attachments[number]) => {
     setAttachmentErrorMessage(undefined);
@@ -84,6 +85,11 @@ export const useAttachmentService = ({
     scope,
     sectionId,
   }: AttachmentArchiveRequest): Promise<string | undefined> => {
+    if (archiveInFlightRef.current) {
+      return undefined;
+    }
+
+    archiveInFlightRef.current = true;
     setArchiveErrorMessage(undefined);
     setArchiveWarningMessage(undefined);
     setArchiveLoading(true);
@@ -113,7 +119,7 @@ export const useAttachmentService = ({
           sourceScanAttempts += 1;
           setArchiveWarningMessage(response.message || DEFAULT_SOURCE_SCAN_PENDING_MESSAGE);
           if (sourceScanAttempts >= MAX_SOURCE_SCAN_POLL_ATTEMPTS) {
-            throw new Error(response.message || DEFAULT_SOURCE_SCAN_PENDING_MESSAGE);
+            throw new Error(DEFAULT_ARCHIVE_TIMEOUT_MESSAGE);
           }
         } else {
           archiveBuildAttempts += 1;
@@ -130,6 +136,7 @@ export const useAttachmentService = ({
       console.error(archiveError);
       return undefined;
     } finally {
+      archiveInFlightRef.current = false;
       setArchiveLoading(false);
     }
   };

--- a/react-app/src/features/package/package-activity/hook.ts
+++ b/react-app/src/features/package/package-activity/hook.ts
@@ -17,7 +17,7 @@ const DEFAULT_ARCHIVE_ERROR_MESSAGE = "Unable to prepare the attachment archive"
 const DEFAULT_ARCHIVE_TIMEOUT_MESSAGE =
   "Attachment archive is taking longer than expected. Please try again in a few moments.";
 const DEFAULT_SOURCE_SCAN_PENDING_MESSAGE =
-  "Attachments are still being scanned. Please try again shortly.";
+  "Attachments are being scanned. Your download will start automatically when scanning is complete.";
 const MAX_ARCHIVE_BUILD_POLL_ATTEMPTS = 20;
 const MAX_SOURCE_SCAN_POLL_ATTEMPTS = 60;
 

--- a/react-app/src/features/package/package-activity/index.test.tsx
+++ b/react-app/src/features/package/package-activity/index.test.tsx
@@ -825,6 +825,36 @@ describe("Package Activity", () => {
     ).toBeGreaterThan(0);
   });
 
+  it("renders active attachment scanning as a status instead of an error", async () => {
+    const pendingMessage =
+      "Attachments are being scanned. Your download will start automatically when scanning is complete.";
+    vi.spyOn(packageActivityHooks, "useAttachmentService").mockImplementation(() => ({
+      attachmentErrorMessage: undefined,
+      archiveErrorMessage: undefined,
+      archiveWarningMessage: pendingMessage,
+      loading: true,
+      onArchive: vi.fn(),
+      onUrl: vi.fn(),
+      error: null,
+    }));
+
+    await renderFormWithPackageSectionAsync(
+      <PackageActivities
+        id={WITHDRAWN_CHANGELOG_ITEM_ID}
+        changelog={WITHDRAW_APPK_ITEM._source.changelog}
+      />,
+      WITHDRAWN_CHANGELOG_ITEM_ID,
+    );
+
+    const pendingMessages = screen.getAllByText(pendingMessage);
+    expect(pendingMessages.length).toBeGreaterThan(0);
+    pendingMessages.forEach((message) => {
+      expect(message).toHaveAttribute("role", "status");
+      expect(message).toHaveClass("text-gray-700");
+      expect(message).not.toHaveClass("text-red-700");
+    });
+  });
+
   it("uses consistent typography for attachment and archive status messages", async () => {
     vi.spyOn(packageActivityHooks, "useAttachmentService").mockImplementation(() => ({
       attachmentErrorMessage: "This attachment is no longer available.",

--- a/react-app/src/features/package/package-activity/index.test.tsx
+++ b/react-app/src/features/package/package-activity/index.test.tsx
@@ -515,6 +515,37 @@ describe("Package Activity", () => {
     });
   });
 
+  it("keeps a visible archive link when the browser blocks the automatic download", async () => {
+    const onArchive = vi.fn(() => Promise.resolve("http://example.com/all.zip"));
+    vi.spyOn(window, "open").mockReturnValue(null);
+
+    vi.spyOn(packageActivityHooks, "useAttachmentService").mockImplementation(() => ({
+      attachmentErrorMessage: undefined,
+      archiveErrorMessage: undefined,
+      archiveWarningMessage: undefined,
+      loading: false,
+      onArchive,
+      onUrl: vi.fn(),
+      error: null,
+    }));
+
+    const user = userEvent.setup();
+    await renderFormWithPackageSectionAsync(
+      <PackageActivities
+        id={WITHDRAWN_CHANGELOG_ITEM_ID}
+        changelog={WITHDRAW_APPK_ITEM._source.changelog}
+      />,
+      WITHDRAWN_CHANGELOG_ITEM_ID,
+    );
+
+    await user.click(screen.getByText("Download all attachments"));
+
+    const downloadLink = await screen.findByRole("link", {
+      name: "Download the attachment archive",
+    });
+    expect(downloadLink).toHaveAttribute("href", "http://example.com/all.zip");
+  });
+
   it("requests the section archive and opens the returned url", async () => {
     const onArchive = vi.fn(() => Promise.resolve("http://example.com/section.zip"));
     const openSpy = vi.spyOn(window, "open").mockImplementation(vi.fn());
@@ -818,11 +849,15 @@ describe("Package Activity", () => {
       WITHDRAWN_CHANGELOG_ITEM_ID,
     );
 
-    expect(
-      screen.getAllByText(
-        "One or more files are unavailable and were not included as part of the .zip file download.",
-      ).length,
-    ).toBeGreaterThan(0);
+    const warningMessages = screen.getAllByText(
+      "One or more files are unavailable and were not included as part of the .zip file download.",
+    );
+    expect(warningMessages.length).toBeGreaterThan(0);
+    warningMessages.forEach((message) => {
+      expect(message).toHaveAttribute("role", "status");
+      expect(message).toHaveClass("text-gray-700");
+      expect(message).not.toHaveClass("text-red-700");
+    });
   });
 
   it("renders active attachment scanning as a status instead of an error", async () => {
@@ -841,7 +876,7 @@ describe("Package Activity", () => {
     await renderFormWithPackageSectionAsync(
       <PackageActivities
         id={WITHDRAWN_CHANGELOG_ITEM_ID}
-        changelog={WITHDRAW_APPK_ITEM._source.changelog}
+        changelog={TEST_ITEM_WITH_CHANGELOG._source.changelog}
       />,
       WITHDRAWN_CHANGELOG_ITEM_ID,
     );
@@ -853,6 +888,9 @@ describe("Package Activity", () => {
       expect(message).toHaveClass("text-gray-700");
       expect(message).not.toHaveClass("text-red-700");
     });
+
+    expect(screen.getByRole("button", { name: "Download all attachments" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Download section attachments" })).toBeDisabled();
   });
 
   it("uses consistent typography for attachment and archive status messages", async () => {

--- a/react-app/src/features/package/package-activity/index.tsx
+++ b/react-app/src/features/package/package-activity/index.tsx
@@ -93,6 +93,7 @@ const getDraftPackageActivities = (
 };
 
 const attachmentStatusMessageClassName = "text-sm font-normal text-red-700";
+const attachmentPendingMessageClassName = "text-sm font-normal text-gray-700";
 
 type AttachmentDetailsProps = {
   id: string;
@@ -154,6 +155,7 @@ const Submission = ({ packageActivity }: SubmissionProps) => {
     preferDraft: packageActivity.isSyntheticDraft,
   });
   const archiveMessage = archiveErrorMessage || archiveWarningMessage;
+  const archiveIsPending = loading && Boolean(archiveWarningMessage) && !archiveErrorMessage;
   const hasAdditionalInformation = Boolean(additionalInformation?.trim());
 
   if (detailMessage && attachments.length === 0 && !hasAdditionalInformation) {
@@ -211,7 +213,14 @@ const Submission = ({ packageActivity }: SubmissionProps) => {
             Download section attachments
           </Button>
           {archiveMessage && (
-            <p role="alert" className={attachmentStatusMessageClassName}>
+            <p
+              role={archiveIsPending ? "status" : "alert"}
+              className={
+                archiveIsPending
+                  ? attachmentPendingMessageClassName
+                  : attachmentStatusMessageClassName
+              }
+            >
               {archiveMessage}
             </p>
           )}
@@ -270,6 +279,7 @@ const DownloadAllButton = ({ packageId, packageActivities }: DownloadAllButtonPr
     preferDraft,
   });
   const archiveMessage = archiveErrorMessage || archiveWarningMessage;
+  const archiveIsPending = loading && Boolean(archiveWarningMessage) && !archiveErrorMessage;
 
   if (attachmentsAggregate.length === 0) {
     return null;
@@ -302,7 +312,12 @@ const DownloadAllButton = ({ packageId, packageActivities }: DownloadAllButtonPr
         Download all attachments
       </Button>
       {archiveMessage && (
-        <p role="alert" className={`justify-self-end ${attachmentStatusMessageClassName}`}>
+        <p
+          role={archiveIsPending ? "status" : "alert"}
+          className={`justify-self-end ${
+            archiveIsPending ? attachmentPendingMessageClassName : attachmentStatusMessageClassName
+          }`}
+        >
           {archiveMessage}
         </p>
       )}

--- a/react-app/src/features/package/package-activity/index.tsx
+++ b/react-app/src/features/package/package-activity/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { opensearch, SEATOOL_STATUS } from "shared-types";
 import { ItemResult } from "shared-types/opensearch/changelog";
 import { formatDateToET, getDraftAttachments, getPackageActivityLabel } from "shared-utils";
@@ -95,6 +95,17 @@ const getDraftPackageActivities = (
 const attachmentStatusMessageClassName = "text-sm font-normal text-red-700";
 const attachmentPendingMessageClassName = "text-sm font-normal text-gray-700";
 
+const ArchiveDownloadFallback = ({ url }: { url?: string }) =>
+  url ? (
+    <p role="status" className={attachmentPendingMessageClassName}>
+      Your archive is ready, but the browser did not open it automatically.{" "}
+      <a className="underline" href={url} target="_blank" rel="noreferrer">
+        Download the attachment archive
+      </a>
+      .
+    </p>
+  ) : null;
+
 type AttachmentDetailsProps = {
   id: string;
   packageId: string;
@@ -155,8 +166,26 @@ const Submission = ({ packageActivity }: SubmissionProps) => {
     preferDraft: packageActivity.isSyntheticDraft,
   });
   const archiveMessage = archiveErrorMessage || archiveWarningMessage;
-  const archiveIsPending = loading && Boolean(archiveWarningMessage) && !archiveErrorMessage;
+  const archiveIsWarning = !archiveErrorMessage && Boolean(archiveWarningMessage);
+  const [archiveDownloadUrl, setArchiveDownloadUrl] = useState<string | undefined>();
   const hasAdditionalInformation = Boolean(additionalInformation?.trim());
+
+  const onDownloadSection = () => {
+    if (loading) {
+      return;
+    }
+
+    setArchiveDownloadUrl(undefined);
+    onArchive({ scope: "section", sectionId: id }).then((url) => {
+      if (url && !window.open(url)) {
+        setArchiveDownloadUrl(url);
+      }
+    });
+    sendGAEvent("section_attachments_download", {
+      number_attachments: attachments.length,
+      package_id: packageId,
+    });
+  };
 
   if (detailMessage && attachments.length === 0 && !hasAdditionalInformation) {
     return <p className="text-gray-700">{detailMessage}</p>;
@@ -198,25 +227,16 @@ const Submission = ({ packageActivity }: SubmissionProps) => {
             variant="outline"
             className="w-max"
             loading={loading}
-            onClick={() => {
-              onArchive({ scope: "section", sectionId: id }).then((url) => {
-                if (url) {
-                  window.open(url);
-                }
-              });
-              sendGAEvent("section_attachments_download", {
-                number_attachments: attachments.length,
-                package_id: packageId,
-              });
-            }}
+            disabled={loading}
+            onClick={onDownloadSection}
           >
             Download section attachments
           </Button>
           {archiveMessage && (
             <p
-              role={archiveIsPending ? "status" : "alert"}
+              role={archiveIsWarning ? "status" : "alert"}
               className={
-                archiveIsPending
+                archiveIsWarning
                   ? attachmentPendingMessageClassName
                   : attachmentStatusMessageClassName
               }
@@ -224,6 +244,7 @@ const Submission = ({ packageActivity }: SubmissionProps) => {
               {archiveMessage}
             </p>
           )}
+          <ArchiveDownloadFallback url={archiveDownloadUrl} />
         </>
       )}
       <div>
@@ -279,20 +300,22 @@ const DownloadAllButton = ({ packageId, packageActivities }: DownloadAllButtonPr
     preferDraft,
   });
   const archiveMessage = archiveErrorMessage || archiveWarningMessage;
-  const archiveIsPending = loading && Boolean(archiveWarningMessage) && !archiveErrorMessage;
+  const archiveIsWarning = !archiveErrorMessage && Boolean(archiveWarningMessage);
+  const [archiveDownloadUrl, setArchiveDownloadUrl] = useState<string | undefined>();
 
   if (attachmentsAggregate.length === 0) {
     return null;
   }
 
   const onDownloadAll = () => {
-    if (attachmentsAggregate.length === 0) {
+    if (attachmentsAggregate.length === 0 || loading) {
       return;
     }
 
+    setArchiveDownloadUrl(undefined);
     onArchive({ scope: "all" }).then((url) => {
-      if (url) {
-        window.open(url);
+      if (url && !window.open(url)) {
+        setArchiveDownloadUrl(url);
       }
     });
     sendGAEvent("all_attachments_download", {
@@ -305,6 +328,7 @@ const DownloadAllButton = ({ packageId, packageActivities }: DownloadAllButtonPr
     <>
       <Button
         loading={loading}
+        disabled={loading}
         onClick={onDownloadAll}
         variant="outline"
         className="max-w-fit min-h-fit justify-self-end"
@@ -313,14 +337,15 @@ const DownloadAllButton = ({ packageId, packageActivities }: DownloadAllButtonPr
       </Button>
       {archiveMessage && (
         <p
-          role={archiveIsPending ? "status" : "alert"}
+          role={archiveIsWarning ? "status" : "alert"}
           className={`justify-self-end ${
-            archiveIsPending ? attachmentPendingMessageClassName : attachmentStatusMessageClassName
+            archiveIsWarning ? attachmentPendingMessageClassName : attachmentStatusMessageClassName
           }`}
         >
           {archiveMessage}
         </p>
       )}
+      <ArchiveDownloadFallback url={archiveDownloadUrl} />
     </>
   );
 };


### PR DESCRIPTION
## Ticket
https://jiraent.cms.gov/browse/OY2-40915

## Context

Attachment archive downloads can remain stuck after an uploaded file initially reports that scanning is still in progress. This affects draft and submitted packages through both **Download all attachments** and **Download section attachments**.

Two issues prevented recovery:

- The archive worker attempted to use a per-message `DelaySeconds` value when requeueing work on an SQS FIFO queue. FIFO queues do not support per-message delays.
- A persisted `SOURCE_SCAN_PENDING` archive state was treated as already in progress, so later rebuild attempts did not recheck the source attachment scan tags.

Users could continue seeing “Attachments are still being scanned” even after scanning completed.

## Solution

- Keep the primary archive rebuild FIFO queue immediate.
- Add a dedicated FIFO retry queue with a 30-second delivery delay for scan-pending retries only.
- Send bounded `SOURCE_SCAN_PENDING` retries to the delayed queue without using the unsupported per-message delay option.
- Recheck source attachment scan tags when a saved archive state is `SOURCE_SCAN_PENDING`.
- Allow polling to enqueue recovery work for previously stuck scan-pending archives.
- Present active scanning as a neutral status and explain that the download will start automatically when scanning completes.
- Preserve the existing draft/main archive namespaces and the existing Download All/Download Section behavior.

## User impact

- Clean attachments continue through the immediate queue without an added 30-second delay.
- Attachments still being scanned are rechecked approximately every 30 seconds.
- Once all requested attachments are clean, archive creation continues and the browser download starts automatically while the page is still polling.
- The retry behavior applies to both drafts and regular submissions.

## Infrastructure changes

- Adds `${project}-${stage}-attachment-archive-retry.fifo` with a 30-second queue-level delivery delay.
- Connects the retry queue to the existing `rebuildAttachmentArchives` Lambda and its existing dead-letter queue.

## Out of scope

- Individual attachment download behavior for remapped legacy objects returning 500 instead of 410.
- Changing the existing rule that a non-`CLEAN` scan result blocks archive creation.
- Repairing record-specific terminal archive failures or missing/corrupt source objects.

## Testing

- `./run test --run lib/attachment-archive/rebuild-queue.test.ts lib/lambda/rebuildAttachmentArchives.test.ts lib/lambda/attachmentArchive-lib.test.ts lib/lambda/getAttachmentArchive.test.ts react-app/src/features/package/package-activity/hook.test.tsx react-app/src/features/package/package-activity/index.test.tsx` — 78 tests passed
- `bun run lint` — passed
- `bun run build` — passed
- `git diff --check` — passed

## Deployment validation

After deployment to Dev, verify:

- Draft: Download All and Download Section
- Submitted package: Download All and Download Section
- A clean attachment starts archive preparation without a forced retry delay
- A scan-pending attachment transitions to archive creation and automatic download after its scan becomes `CLEAN`

CDK synth was attempted locally but could not complete because the available AWS security token was invalid.
